### PR TITLE
Schema metadata table for ponder indexing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
     "p-limit": "^5.0.0",
     "p-queue": "^7.4.1",
     "pg": "^8.11.3",
+    "pg-listen": "^1.7.0",
     "picocolors": "^1.0.0",
     "pino": "^8.16.2",
     "prom-client": "^15.0.0",

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -168,6 +168,7 @@ export class Ponder {
         : new PostgresIndexingStore({
             common: this.common,
             pool: database.indexing.pool,
+            subscriber: database.indexing.subscriber!,
           }));
 
     const networksToSync = this.networks.filter((network) => {
@@ -373,6 +374,7 @@ export class Ponder {
         : new PostgresIndexingStore({
             common: this.common,
             pool: database.indexing.pool,
+            subscriber: database.indexing.subscriber!,
           });
 
     this.serverService = new ServerService({

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -235,6 +235,7 @@ export class Ponder {
 
     // One-time setup for some services.
     await this.syncStore.migrateUp();
+    await this.indexingStore.setup();
     this.serverService.setup();
 
     this.codegenService.generateGraphqlSchemaFile({

--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "crypto";
+import pgListen from "pg-listen";
 import { beforeEach, type TestContext } from "vitest";
 
 import { buildOptions } from "@/config/options.js";
@@ -128,11 +129,13 @@ export async function setupIndexingStore(context: TestContext) {
     const connectionString = databaseUrl.toString();
 
     const pool = new pg.Pool({ connectionString });
+    const subscriber = pgListen.default({ connectionString });
     await testClient.query(`CREATE DATABASE "${databaseName}"`);
 
     context.indexingStore = new PostgresIndexingStore({
       common: context.common,
       pool,
+      subscriber,
     });
 
     return async () => {

--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -137,6 +137,7 @@ export async function setupIndexingStore(context: TestContext) {
       pool,
       subscriber,
     });
+    await context.indexingStore.setup();
 
     return async () => {
       try {

--- a/packages/core/src/config/database.ts
+++ b/packages/core/src/config/database.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 
+import pgListen from "pg-listen";
+
 import type { Config } from "@/config/config.js";
 import type { Common } from "@/Ponder.js";
 import pg from "@/utils/pg.js";
@@ -12,6 +14,7 @@ type StoreConfig =
   | {
       kind: "postgres";
       pool: pg.Pool;
+      subscriber?: pgListen.Subscriber;
     };
 
 type DatabaseConfig = {
@@ -52,9 +55,13 @@ export const buildDatabase = ({
   // Otherwise, check if the DATABASE_URL env var is set. If it is, use it, otherwise use SQLite.
   if (process.env.DATABASE_URL) {
     const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+    const subscriber = pgListen.default({
+      connectionString: process.env.DATABASE_URL,
+    });
+
     return {
       sync: { kind: "postgres", pool },
-      indexing: { kind: "postgres", pool },
+      indexing: { kind: "postgres", pool, subscriber },
     } satisfies DatabaseConfig;
   } else {
     return {

--- a/packages/core/src/indexing-store/postgres/migrations.ts
+++ b/packages/core/src/indexing-store/postgres/migrations.ts
@@ -1,0 +1,49 @@
+import type { Kysely } from "kysely";
+import { CompiledQuery, type Migration, type MigrationProvider } from "kysely";
+
+const migrations: Record<string, Migration> = {
+  ["2023_12_19_0_metadata"]: {
+    async up(db: Kysely<any>) {
+      await db.schema
+        .withSchema("public")
+        .createTable("ponder_metadata")
+        .ifNotExists()
+        .addColumn("namespace_version", "text", (col) => col.primaryKey())
+        .addColumn("schema", "jsonb")
+        .addColumn("is_published", "boolean", (col) => col.defaultTo(false))
+        .execute();
+
+      await db.withSchema("public").executeQuery(
+        CompiledQuery.raw(`
+              CREATE OR REPLACE FUNCTION notify_ponder_after_namespace_publish()
+              RETURNS TRIGGER AS
+              $BODY$
+                  BEGIN
+                      PERFORM pg_notify('namespace_published', row_to_json(NEW)::text);
+                      RETURN new;
+                  END;
+              $BODY$
+              LANGUAGE plpgsql
+        `),
+      );
+
+      await db.withSchema("public").executeQuery(
+        CompiledQuery.raw(`
+          CREATE OR REPLACE TRIGGER trigger_notify_ponder_after_namespace_publish
+          AFTER UPDATE OF is_published
+          ON "public"."ponder_metadata"
+          FOR EACH ROW
+          EXECUTE PROCEDURE notify_ponder_after_namespace_publish();
+         `),
+      );
+    },
+  },
+};
+
+class StaticMigrationProvider implements MigrationProvider {
+  async getMigrations() {
+    return migrations;
+  }
+}
+
+export const migrationProvider = new StaticMigrationProvider();

--- a/packages/core/src/indexing-store/sqlite/store.ts
+++ b/packages/core/src/indexing-store/sqlite/store.ts
@@ -51,6 +51,10 @@ export class SqliteIndexingStore implements IndexingStore {
     });
   }
 
+  // TODO: Some type of setup here.
+  // Fulfills the IndexingStore interface.
+  setup = async () => {};
+
   async kill() {
     return this.wrap({ method: "kill" }, async () => {
       const tableNames = Object.keys(this.schema?.tables ?? {});

--- a/packages/core/src/indexing-store/store.ts
+++ b/packages/core/src/indexing-store/store.ts
@@ -105,6 +105,21 @@ export interface IndexingStore {
     orderBy?: OrderByInput<any>;
   }): Promise<Row[]>;
 
+  findUniquePublic(options: {
+    tableName: string;
+    checkpoint?: Checkpoint;
+    id: string | number | bigint;
+  }): Promise<Row | null>;
+
+  findManyPublic(options: {
+    tableName: string;
+    checkpoint?: Checkpoint;
+    where?: WhereInput<any>;
+    skip?: number;
+    take?: number;
+    orderBy?: OrderByInput<any>;
+  }): Promise<Row[]>;
+
   create(options: {
     tableName: string;
     checkpoint: Checkpoint;

--- a/packages/core/src/indexing-store/store.ts
+++ b/packages/core/src/indexing-store/store.ts
@@ -86,6 +86,8 @@ export interface IndexingStore {
 
   kill(): Promise<void>;
 
+  setup(): Promise<void>;
+
   publish(): Promise<void>;
 
   revert(options: { checkpoint: Checkpoint }): Promise<void>;

--- a/packages/core/src/server/graphql/entity.ts
+++ b/packages/core/src/server/graphql/entity.ts
@@ -67,7 +67,7 @@ export const buildEntityTypes = ({ schema }: { schema: Schema }) => {
               // @ts-ignore
               const relatedRecordId = parent[column.referenceColumn];
 
-              return await store.findUnique({
+              return await store.findUniquePublic({
                 tableName: referencedTable,
                 id: relatedRecordId,
               });

--- a/packages/core/src/server/graphql/plural.ts
+++ b/packages/core/src/server/graphql/plural.ts
@@ -127,7 +127,7 @@ export const buildPluralField = ({
       ? { ...maxCheckpoint, blockTimestamp: timestamp }
       : undefined; // Latest.
 
-    return await store.findMany({
+    return await store.findManyPublic({
       tableName: tableName,
       checkpoint,
       where: where ? buildWhereObject({ where }) : undefined,

--- a/packages/core/src/server/graphql/singular.ts
+++ b/packages/core/src/server/graphql/singular.ts
@@ -37,7 +37,7 @@ const buildSingularField = ({
       ? { ...maxCheckpoint, blockTimestamp: timestamp }
       : undefined; // Latest.
 
-    const entityInstance = await store.findUnique({
+    const entityInstance = await store.findUniquePublic({
       tableName: tableName,
       id,
       checkpoint,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,9 @@ importers:
       pg:
         specifier: ^8.11.3
         version: 8.11.3
+      pg-listen:
+        specifier: ^1.7.0
+        version: 1.7.0(pg@8.11.3)
       picocolors:
         specifier: ^1.0.0
         version: 1.0.0
@@ -13215,9 +13218,27 @@ packages:
     resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
     dev: false
 
+  /pg-format@1.0.4:
+    resolution: {integrity: sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==}
+    engines: {node: '>=4.0'}
+    dev: false
+
   /pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
+
+  /pg-listen@1.7.0(pg@8.11.3):
+    resolution: {integrity: sha512-MKDwKLm4ryhy7iq1yw1K1MvUzBdTkaT16HZToddX9QaT8XSdt3Kins5mYH6DLECGFzFWG09VdXvWOIYogjXrsg==}
+    peerDependencies:
+      pg: 7.x || 8.x
+    dependencies:
+      debug: 4.3.4(supports-color@8.1.1)
+      pg: 8.11.3
+      pg-format: 1.0.4
+      typed-emitter: 0.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /pg-numeric@1.0.2:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
@@ -15725,6 +15746,10 @@ packages:
       for-each: 0.3.3
       is-typed-array: 1.1.12
     dev: true
+
+  /typed-emitter@0.1.0:
+    resolution: {integrity: sha512-Tfay0l6gJMP5rkil8CzGbLthukn+9BN/VXWcABVFPjOoelJ+koW8BuPZYk+h/L+lEeIp1fSzVRiWRPIjKVjPdg==}
+    dev: false
 
   /typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}


### PR DESCRIPTION
**Changes**
- Adds metadata table for ponder indexing (in Postgres) to enable zero downtime indexing reads
- Adds `findXPublic` methods that will consistently read from the `public` namespace
- Registers an event listener on `NOTIFY` events in postgres when a publish has happened

**N.B.**: Public index methods are implicitly tested in the integration tests for the server