### PR TITLE
New CLI options, bug fixes

### DIFF
--- a/.changeset/serious-rockets-trade.md
+++ b/.changeset/serious-rockets-trade.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Added new CLI options `--port`/`-p`, `--hostname`/`-H`, `--debug`/`-v`, and `--trace`/`-vv`. Renamed options `--config-file` to `config` and `--root-dir` to `--root`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         run: cd packages/core/ && pnpm wagmi generate
 
       - name: Test
-        run: pnpm test:core
+        run: pnpm --filter core test:typecheck
         env:
           DATABASE_URL: ${{ matrix.database == 'Postgres' && steps.postgres.outputs.connection-uri || '' }}
 
@@ -96,6 +96,6 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Test
-        run: pnpm test:create-ponder
+        run: pnpm --filter create-ponder test
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}

--- a/docs/pages/docs/api-reference/_meta.ts
+++ b/docs/pages/docs/api-reference/_meta.ts
@@ -2,5 +2,6 @@ export default {
   config: "Config",
   schema: "Schema",
   "indexing-functions": "Indexing functions",
-  "create-ponder": "Create Ponder",
+  "ponder-cli": "Ponder CLI",
+  "create-ponder": "create-ponder",
 };

--- a/docs/pages/docs/api-reference/config.mdx
+++ b/docs/pages/docs/api-reference/config.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Config API"
-description: "API reference for the Ponder config file."
+title: "API Reference: ponder.config.ts"
+description: "Learn about the options available in ponder.config.ts, Ponder's config file."
 ---
 
 import { Callout, Tabs } from "nextra/components";

--- a/docs/pages/docs/api-reference/create-ponder.mdx
+++ b/docs/pages/docs/api-reference/create-ponder.mdx
@@ -1,13 +1,15 @@
 ---
-title: "CLI reference"
-description: "API reference for the create-ponder CLI tool."
+title: "API Reference: create-ponder CLI"
+description: "Learn about the options available in the create-ponder CLI tool."
 ---
 
 import { Tabs } from "nextra/components";
 
-# Create Ponder API
+# create-ponder
 
-This command line tool creates a new project directory with `package.json`, `ponder.config.ts`, `ponder.schema.ts`, and other configuration files.
+The easiest way to get started with Ponder is by using `create-ponder`. This CLI tool creates a new Ponder project with `package.json`, `ponder.config.ts`, `ponder.schema.ts`, ABIs, and other project files set up for you.
+
+You can create a new app using the default template or one of the example apps.
 
 {/* prettier-ignore */}
 <Tabs items={["pnpm", "yarn", "npm"]}>

--- a/docs/pages/docs/api-reference/indexing-functions.mdx
+++ b/docs/pages/docs/api-reference/indexing-functions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Indexing function API"
-description: "API reference for indexing function files."
+title: "API Reference: Indexing functions"
+description: "Learn about the options available in Ponder indexing functions."
 ---
 
 import { Callout } from "nextra/components";

--- a/docs/pages/docs/api-reference/ponder-cli.mdx
+++ b/docs/pages/docs/api-reference/ponder-cli.mdx
@@ -1,0 +1,104 @@
+---
+title: "API Reference: Ponder CLI"
+description: "Learn about the options available in the Ponder CLI."
+---
+
+import { Callout } from "nextra/components";
+
+# Ponder CLI
+
+The Ponder CLI (provided by the `@ponder/core` package) is the entrypoint for your Ponder project.
+
+```bash
+Usage:
+  $ ponder <command> [OPTIONS]
+
+Commands:
+  dev      Start the app in development mode
+  start    Start the app in production mode
+  serve    Start the web server (experimental)
+  codegen  Generate the schema.graphql file, then exit
+
+Options:
+  --root [PATH]    Path to the project root directory (default: working directory)
+  --config [PATH]  Path to the project config file (default: ponder.config.ts)
+  -h, --help       Display this message 
+```
+
+## dev
+
+Start the app in development mode.
+
+- The app automatically restarts when changes are detected in any project file.
+- An auto-updating terminal UI displays useful information.
+
+```bash
+Usage:
+  $ ponder dev
+
+Options:
+  -p, --port [PORT]          Port number for the the web server (default: 42069) 
+  -H, --hostname [HOSTNAME]  Hostname for the web server (default: 0.0.0.0) 
+  -v, --debug                Enable debug logging (realtime blocks, internal events) 
+  -vv, --trace               Enable trace logging (db query logs, indexing checkpoints) 
+```
+
+## start
+
+Start the app in production mode.
+
+- Project files are built once on startup, and file changes are ignored.
+- The terminal UI is disabled.
+
+```bash
+Usage:
+  $ ponder start
+
+Options:
+  -p, --port [PORT]          Port number for the the web server (default: 42069)
+  -H, --hostname [HOSTNAME]  Hostname for the web server (default: 0.0.0.0)
+  -v, --debug                Enable debug logging (realtime blocks, internal events) 
+  -vv, --trace               Enable trace logging (db query logs, indexing checkpoints) 
+```
+
+## serve
+
+<Callout type="warning">
+  The `ponder serve` command is still experimental and it's behavior may change without notice. Do not rely on it for production usage.
+</Callout>
+
+Start the app in server-only mode. This option can be used to horizontally scale the GraphQL API in production.
+
+- Project files are built once on startup, and file changes are ignored.
+- The sync and indexing engines is disabled.
+- The GraphQL API server runs as normal, serving data from the connected database.
+
+```bash
+Usage:
+  $ ponder serve
+
+Options:
+  -p, --port [PORT]          Port number for the the web server (default: 42069) 
+  -H, --hostname [HOSTNAME]  Hostname for the web server (default: 0.0.0.0) 
+  -v, --debug                Enable debug logging (realtime blocks, internal events) 
+  -vv, --trace               Enable trace logging (db query logs, indexing checkpoints) 
+```
+
+## codegen
+
+<Callout type="info">
+  During development (when using `ponder dev`), codegen runs automatically run when changes are detected in `ponder.schema.ts`.
+</Callout>
+
+Generate the `schema.graphql` file.
+
+```bash
+Usage:
+  $ ponder codegen
+
+Options:
+  -p, --port [PORT]          Port number for the the web server (default: 42069) 
+  -H, --hostname [HOSTNAME]  Hostname for the web server (default: 0.0.0.0) 
+  -v, --debug                Enable debug logging (realtime blocks, internal events) 
+  -vv, --trace               Enable trace logging (db query logs, indexing checkpoints) 
+```

--- a/docs/pages/docs/api-reference/schema.mdx
+++ b/docs/pages/docs/api-reference/schema.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Schema API"
-description: "API reference for the Ponder schema file."
+title: "API Reference: ponder.schema.ts"
+description: "Learn about the options available in ponder.schema.ts, Ponder's schema definition file."
 ---
 
 # Schema API 🚧

--- a/package.json
+++ b/package.json
@@ -6,15 +6,11 @@
     "build": "pnpm --filter \"./packages/**\" --parallel build",
     "changeset:release": "pnpm build && changeset publish",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
-    "install:packages": "pnpm --filter \"./packages/**\" install",
-    "install:examples": "pnpm --filter \"./examples/**\" install",
     "format": "biome format . --write",
     "lint": "biome check .",
     "lint:fix": "pnpm lint --apply",
     "prepare": "npx simple-git-hooks",
     "test": "pnpm --parallel --no-bail test",
-    "test:core": "pnpm --filter \"@ponder/core\" test:typecheck",
-    "test:create-ponder": "pnpm --filter \"create-ponder\" test",
     "typecheck": "pnpm --filter \"./packages/**\" --parallel typecheck"
   },
   "devDependencies": {

--- a/packages/core/src/_test/e2e/erc20/erc20.test.ts
+++ b/packages/core/src/_test/e2e/erc20/erc20.test.ts
@@ -42,10 +42,7 @@ afterEach(() => {
 
 test("erc20", async (context) => {
   const options = buildOptions({
-    cliOptions: {
-      rootDir: "./src/_test/e2e/erc20",
-      configFile: "ponder.config.ts",
-    },
+    cliOptions: { root: "./src/_test/e2e/erc20", config: "ponder.config.ts" },
   });
   const testOptions = {
     ...options,

--- a/packages/core/src/_test/e2e/factory/factory.test.ts
+++ b/packages/core/src/_test/e2e/factory/factory.test.ts
@@ -40,10 +40,7 @@ afterEach(() => {
 
 test("factory", async (context) => {
   const options = buildOptions({
-    cliOptions: {
-      rootDir: "./src/_test/e2e/factory",
-      configFile: "ponder.config.ts",
-    },
+    cliOptions: { root: "./src/_test/e2e/factory", config: "ponder.config.ts" },
   });
   const testOptions = {
     ...options,

--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -45,9 +45,7 @@ declare module "vitest" {
 
 beforeEach((context) => {
   const options = {
-    ...buildOptions({
-      cliOptions: { configFile: "", rootDir: "" },
-    }),
+    ...buildOptions({ cliOptions: { config: "", root: "" } }),
     telemetryDisabled: true,
   };
   context.common = {

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -70,7 +70,7 @@ export const buildOptions = ({
   if (cliOptions.hostname !== undefined) {
     hostname = cliOptions.hostname;
   } else {
-    hostname = "0.0.0.0";
+    hostname = "::";
   }
 
   let maxHealthcheckDuration: number;

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -14,7 +14,7 @@ export type Options = {
   logDir: string;
 
   port: number;
-  hostname: string;
+  hostname?: string;
   maxHealthcheckDuration: number;
 
   telemetryUrl: string;
@@ -66,12 +66,7 @@ export const buildOptions = ({
     port = 42069;
   }
 
-  let hostname: string;
-  if (cliOptions.hostname !== undefined) {
-    hostname = cliOptions.hostname;
-  } else {
-    hostname = "::";
-  }
+  const hostname = cliOptions.hostname;
 
   let maxHealthcheckDuration: number;
   if (process.env.RAILWAY_HEALTHCHECK_TIMEOUT_SEC) {

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -93,6 +93,9 @@ export class ServerService extends Emittery<ServerEvents> {
           this.common.metrics.ponder_server_port.set(this.port);
           resolve(server);
         })
+        // Note that this.common.options.hostname can be undefined if the user did not specify one.
+        // In this case, Node.js uses `::` if IPv6 is available and `0.0.0.0` otherwise.
+        // https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback
         .listen(this.port, this.common.options.hostname);
     });
 

--- a/packages/core/src/ui/graphiql.html.ts
+++ b/packages/core/src/ui/graphiql.html.ts
@@ -1,7 +1,6 @@
 // https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html
-export function graphiQLHtml({ endpoint }: { endpoint: string }) {
-  return /* html */ `
-<!--
+
+export const graphiQLHtml = `<!--
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.
  *
@@ -45,11 +44,8 @@ export function graphiQLHtml({ endpoint }: { endpoint: string }) {
     <script src="https://unpkg.com/graphiql/graphiql.min.js" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js" crossorigin="anonymous"></script>
     <script>
-      const fetcher = GraphiQL.createFetcher({
-        url: "${endpoint}",
-      });
+      const fetcher = GraphiQL.createFetcher({ url: "/" });
       const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
-
       const root = ReactDOM.createRoot(document.getElementById("graphiql"));
       root.render(
         React.createElement(GraphiQL, {
@@ -61,4 +57,3 @@ export function graphiQLHtml({ endpoint }: { endpoint: string }) {
     </script>
   </body>
 </html>`;
-}


### PR DESCRIPTION
- Adds `--hostname, -H` CLI option to override the default hostname of `0.0.0.0`.
- Updates GraphiQL HTML to run queries against `/` rather than attempt to construct a URL (was leading to hostname and port issues).