### PR TITLE
docs: Fix foundry link + import ABI the right way 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Ponder fetches event logs for the contracts added to `ponder.config.ts`, and pas
 // ponder.config.ts
 import { http } from "viem";
 
+import { BaseRegistrarAbi } from "./abis/BaseRegistrar";
+
 export const config = {
   networks: [
     {
@@ -76,7 +78,7 @@ export const config = {
     {
       name: "BaseRegistrar",
       network: "mainnet",
-      abi: "./abis/BaseRegistrar.json",
+      abi: BaseRegistrarAbi,
       address: "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
       startBlock: 9380410,
     },

--- a/README.md
+++ b/README.md
@@ -88,17 +88,21 @@ export const config = {
 
 ### 4. Define your schema
 
-The `schema.graphql` file contains a model of your application data. The entity types defined here correspond to database tables.
+The `ponder.schema.ts` file contains the database schema, and defines the shape data that the GraphQL API serves.
 
 ```ts
-// schema.graphql
+// ponder.schema.ts
 
-type EnsName @entity {
-  id: String!
-  name: String!
-  owner: String!
-  registeredAt: Int!
-}
+import { createSchema } from "@ponder/core";
+
+export default createSchema((p) => ({
+  EnsName: p.createTable({
+    id: p.string(),
+    name: p.string(),
+    owner: p.string(),
+    registeredAt: p.int(),
+  }),
+}));
 ```
 
 ### 5. Write indexing functions

--- a/docs/pages/docs/advanced.mdx
+++ b/docs/pages/docs/advanced.mdx
@@ -5,10 +5,10 @@ description: "A table of contents for advanced topics in Ponder documentation."
 
 # Advanced topics
 
-[Developing with Foundry →](/advanced/foundry-development)
-
 [Logging →](/advanced/logging)
 
 [Telemetry →](/advanced/telemetry)
 
 [Metrics →](/advanced/metrics)
+
+[Developing with Foundry →](/advanced/foundry)

--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -64,6 +64,8 @@ First, we add `BaseRegistrar` as a contract in our config file. Ponder's sync en
 import { createConfig } from "@ponder/core";
 import { http } from "viem";
 
+import { BaseRegistrarAbi } from "./abis/BaseRegistrar";
+
 export default createConfig({
   networks: {
     mainnet: {
@@ -74,7 +76,7 @@ export default createConfig({
   contracts: {
     BaseRegistrar: {
       network: "mainnet",
-      abi: "./abis/BaseRegistrar.json",
+      abi: BaseRegistrarAbi,
       address: "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
       startBlock: 9380410,
     },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -64,6 +64,8 @@ Ponder fetches event logs for the contracts added to `ponder.config.ts`, and pas
 // ponder.config.ts
 import { http } from "viem";
 
+import { BaseRegistrarAbi } from "./abis/BaseRegistrar";
+
 export const config = {
   networks: [
     {
@@ -76,7 +78,7 @@ export const config = {
     {
       name: "BaseRegistrar",
       network: "mainnet",
-      abi: "./abis/BaseRegistrar.json",
+      abi: BaseRegistrarAbi,
       address: "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
       startBlock: 9380410,
     },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -88,17 +88,21 @@ export const config = {
 
 ### 4. Define your schema
 
-The `schema.graphql` file contains a model of your application data. The entity types defined here correspond to database tables.
+The `ponder.schema.ts` file contains the database schema, and defines the shape data that the GraphQL API serves.
 
 ```ts
-// schema.graphql
+// ponder.schema.ts
 
-type EnsName @entity {
-  id: String!
-  name: String!
-  owner: String!
-  registeredAt: Int!
-}
+import { createSchema } from "@ponder/core";
+
+export default createSchema((p) => ({
+  EnsName: p.createTable({
+    id: p.string(),
+    name: p.string(),
+    owner: p.string(),
+    registeredAt: p.int(),
+  }),
+}));
 ```
 
 ### 5. Write indexing functions


### PR DESCRIPTION
Hey there!

I've been playing with ponder these last few days: love it, it's a great tool! Thanks for all the effort.

Creating this PR with a couple of _issues_ I found in the Docs:

1. On the `Advanced` page, the foundry link was broken. I also moved it to the bottom (as in the submenu)
2. The getting started guide `ponder.config.ts` example use a JSON path directly on the `abi` prop. Updated it to use the import as suggested in `Add Contracts` page.

Happy to tweak it further if needed.

Thanks!