### PR TITLE
create-ponder subgraph ID support on parity with etherscan

### DIFF
--- a/.changeset/many-boats-boil.md
+++ b/.changeset/many-boats-boil.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Re-added subgraph ID support

--- a/packages/create-ponder/.gitignore
+++ b/packages/create-ponder/.gitignore
@@ -3,3 +3,4 @@ dist/
 templates/*
 !templates/empty
 !templates/etherscan
+!templates/subgraph

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -32,7 +32,8 @@
     "prompts": "^2.4.2",
     "update-check": "^1.5.4",
     "validate-npm-package-name": "^5.0.0",
-    "viem": "^2.0.10"
+    "viem": "^2.0.10",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/packages/create-ponder/src/_test/cli.test.ts
+++ b/packages/create-ponder/src/_test/cli.test.ts
@@ -35,6 +35,45 @@ test("create empty", async () => {
   expect(templateFiles).toStrictEqual(generatedFiles);
 });
 
+test("create subgraph id", async () => {
+  await run({
+    args: [join("src", "_test", projectName)],
+    options: {
+      template: "subgraph",
+      skipGit: true,
+      subgraphId: "QmeCy8bjyudQYwddetkgKDKQTsFxWomvbgsDifnbWFEMK9",
+    },
+  });
+
+  const templateFiles = (
+    fs.readdirSync(join(__dirname, "..", "..", "templates", "subgraph"), {
+      recursive: true,
+    }) as string[]
+  )
+    .concat("ponder.config.ts")
+    .concat("abis/ERC20Abi.ts")
+    .concat("abis/ERC721Abi.ts")
+    .concat("abis/EntryPointAbi.ts")
+    .concat("src/EntryPoint.ts")
+    .concat("src/EntryPointV0.6.0.ts")
+    .concat("abis")
+    .concat("src")
+    // _gitignore is renamed to .gitignore
+    .map((filePath) =>
+      filePath === "_dot_env.local"
+        ? ".env.local"
+        : filePath === "_dot_eslintrc.json"
+          ? ".eslintrc.json"
+          : filePath === "_dot_gitignore"
+            ? ".gitignore"
+            : filePath,
+    )
+    .sort();
+
+  const generatedFiles = fs.readdirSync(genPath, { recursive: true }).sort();
+  expect(generatedFiles).toStrictEqual(templateFiles);
+}, 20_000);
+
 test("create etherscan", async () => {
   await run({
     args: [join("src", "_test", projectName)],

--- a/packages/create-ponder/src/etherscan.ts
+++ b/packages/create-ponder/src/etherscan.ts
@@ -163,9 +163,7 @@ export const fromEtherscan = async ({
       abiAbsolutePath,
       await prettier.format(
         `export const ${contractName}Abi = ${JSON.stringify(abi)} as const`,
-        {
-          parser: "typescript",
-        },
+        { parser: "typescript" },
       ),
     );
 

--- a/packages/create-ponder/src/helpers/getGraphProtocolChainId.ts
+++ b/packages/create-ponder/src/helpers/getGraphProtocolChainId.ts
@@ -1,0 +1,41 @@
+// https://github.com/graphprotocol/graph-cli/blob/main/src/protocols/index.js#L40
+// https://chainlist.org/
+const chainIdByGraphNetwork: Record<string, number | undefined> = {
+  mainnet: 1,
+  kovan: 42,
+  rinkeby: 4,
+  ropsten: 3,
+  goerli: 5,
+  "poa-core": 99,
+  "poa-sokol": 77,
+  xdai: 100,
+  matic: 137,
+  mumbai: 80001,
+  fantom: 250,
+  "fantom-testnet": 4002,
+  bsc: 56,
+  chapel: -1,
+  clover: 0,
+  avalanche: 43114,
+  fuji: 43113,
+  celo: 42220,
+  "celo-alfajores": 44787,
+  fuse: 122,
+  moonbeam: 1284,
+  moonriver: 1285,
+  mbase: -1,
+  "arbitrum-one": 42161,
+  "arbitrum-rinkeby": 421611,
+  optimism: 10,
+  "optimism-kovan": 69,
+  aurora: 1313161554,
+  "aurora-testnet": 1313161555,
+};
+
+export const getGraphProtocolChainId = (networkName: string) => {
+  return chainIdByGraphNetwork[networkName];
+};
+
+export const subgraphYamlFileNames = ["subgraph.yaml"].concat(
+  Object.keys(chainIdByGraphNetwork).map((n) => `subgraph-${n}.yaml`),
+);

--- a/packages/create-ponder/src/helpers/validateGraphProtocolSource.ts
+++ b/packages/create-ponder/src/helpers/validateGraphProtocolSource.ts
@@ -1,0 +1,42 @@
+// https://github.com/graphprotocol/graph-node/blob/master/docs/subgraph-manifest.md
+export type GraphSource = {
+  kind: string; // Should be "ethereum"
+  name: string;
+  network: string;
+  source: {
+    address: string;
+    abi: string; // Keys into dataSource.mapping.abis
+    startBlock?: number;
+  };
+  mapping: {
+    kind: string; // Should be "ethereum/events"
+    apiVersion: string;
+    language: string; // Should be "wasm/assemblyscript"
+    entities: string[]; // Corresponds to entities by name defined in schema.graphql
+    abis: {
+      name: string;
+      file: any;
+    }[];
+    eventHandlers?: {
+      event: string;
+      handler: string;
+      topic0?: string;
+    }[];
+    // NOTE: Not planning to support callHandlers or blockHandlers.
+    // callHandlers?: {
+    //   function: string;
+    //   handler: string;
+    // }[];
+    // blockHandlers?: {
+    //   handler: string;
+    //   filter?: {
+    //     kind: string;
+    //   };
+    // }[];
+    file: string; // relative path to file that contains handlers for this source
+  };
+};
+
+export const validateGraphProtocolSource = (source: unknown): GraphSource => {
+  return source as GraphSource;
+};

--- a/packages/create-ponder/src/subgraph.ts
+++ b/packages/create-ponder/src/subgraph.ts
@@ -1,7 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { SerializableConfig } from "@/index.js";
-import pico from "picocolors";
 import prettier from "prettier";
 import { parse } from "yaml";
 
@@ -42,14 +41,6 @@ export const fromSubgraphId = async ({
 
   const dataSources = manifest.dataSources as GraphSource[];
 
-  if (manifest.templates?.length > 0) {
-    console.log(
-      pico.yellow(
-        "\r\nDetected a factory pattern, which cannot be imported from Subgraph. See https://ponder.sh/docs/guides/add-contracts#factory-contracts for how to add them manually.",
-      ),
-    );
-  }
-
   mkdirSync(path.join(rootDir, "abis"), { recursive: true });
   mkdirSync(path.join(rootDir, "src"), { recursive: true });
 
@@ -71,9 +62,7 @@ export const fromSubgraphId = async ({
         abiPath,
         await prettier.format(
           `export const ${abi.name}Abi = ${abiContent} as const`,
-          {
-            parser: "typescript",
-          },
+          { parser: "typescript" },
         ),
       );
       abis[abi.name] = JSON.parse(abiContent);
@@ -122,5 +111,12 @@ export const fromSubgraphId = async ({
     contracts: contractsObject,
   };
 
-  return config;
+  const warnings = [];
+  if (manifest.templates?.length > 0) {
+    warnings.push(
+      "Factory pattern detected. Please reference the documentation on factory contracts (https://ponder.sh/docs/guides/add-contracts#factory-contracts).",
+    );
+  }
+
+  return { config, warnings };
 };

--- a/packages/create-ponder/src/subgraph.ts
+++ b/packages/create-ponder/src/subgraph.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { SerializableConfig } from "@/index.js";
+import pico from "picocolors";
+import prettier from "prettier";
+import { parse } from "yaml";
+
+import { getGraphProtocolChainId } from "./helpers/getGraphProtocolChainId.js";
+import {
+  GraphSource,
+  validateGraphProtocolSource,
+} from "./helpers/validateGraphProtocolSource.js";
+
+const fetchIpfsFile = async (cid: string) => {
+  const url = `https://ipfs.network.thegraph.com/api/v0/cat?arg=${cid}`;
+  const response = await fetch(url);
+  const contentRaw = await response.text();
+  return contentRaw;
+};
+
+export const fromSubgraphId = async ({
+  rootDir,
+  subgraphId,
+}: {
+  rootDir: string;
+  subgraphId: string;
+}) => {
+  // Fetch the manifest file.
+  const manifestRaw = await fetchIpfsFile(subgraphId);
+
+  const manifest = parse(manifestRaw);
+
+  const contracts: any = {};
+
+  manifest.dataSources.forEach((d: any) => {
+    contracts[d.name] = {
+      network: d.network,
+      address: d.source.address,
+      startBlock: d.source.startBlock,
+    };
+  });
+
+  const dataSources = manifest.dataSources as GraphSource[];
+
+  if (manifest.templates?.length > 0) {
+    console.log(
+      pico.yellow(
+        "\r\nDetected a factory pattern, which cannot be imported from Subgraph. See https://ponder.sh/docs/guides/add-contracts#factory-contracts for how to add them manually.",
+      ),
+    );
+  }
+
+  mkdirSync(path.join(rootDir, "abis"), { recursive: true });
+  mkdirSync(path.join(rootDir, "src"), { recursive: true });
+
+  // Fetch and write all referenced ABIs.
+  const abiFiles = dataSources
+    .flatMap((source) => validateGraphProtocolSource(source).mapping.abis)
+    .filter(
+      (source, idx, arr) =>
+        arr.findIndex((s) => s.name === source.name) === idx,
+    );
+
+  const abis: any = {};
+
+  await Promise.all(
+    abiFiles.map(async (abi) => {
+      const abiContent = await fetchIpfsFile(abi.file["/"].slice(6));
+      const abiPath = path.join(rootDir, `./abis/${abi.name}Abi.ts`);
+      writeFileSync(
+        abiPath,
+        await prettier.format(
+          `export const ${abi.name}Abi = ${abiContent} as const`,
+          {
+            parser: "typescript",
+          },
+        ),
+      );
+      abis[abi.name] = JSON.parse(abiContent);
+    }),
+  );
+
+  // Build the ponder sources.
+  const ponderContracts = dataSources.map((sourceInvalid) => {
+    const source = validateGraphProtocolSource(sourceInvalid);
+    const network = source.network || "mainnet";
+    const chainId = getGraphProtocolChainId(network);
+    if (!chainId || chainId === -1) {
+      throw new Error(`Unhandled network name: ${network}`);
+    }
+    const abiRelativePath = `./abis/${source.source.abi}Abi.ts`;
+
+    return {
+      name: source.name,
+      network: network,
+      address: source.source.address,
+      abi: {
+        abi: abis[source.source.abi],
+        dir: abiRelativePath,
+        name: `${source.source.abi}Abi`,
+      },
+      startBlock: source.source.startBlock,
+    };
+  });
+
+  const contractsObject: any = {};
+  const networksObject: any = {};
+
+  ponderContracts.forEach((pc) => {
+    contractsObject[pc.name] = pc;
+    networksObject[pc.network] = {
+      chainId: getGraphProtocolChainId(pc.network),
+      transport: `http(process.env.PONDER_RPC_URL_${getGraphProtocolChainId(
+        pc.network,
+      )})`,
+    };
+    contractsObject[pc.name].name = undefined;
+  });
+
+  const config: SerializableConfig = {
+    networks: networksObject,
+    contracts: contractsObject,
+  };
+
+  return config;
+};

--- a/packages/create-ponder/templates/subgraph/_dot_env.local
+++ b/packages/create-ponder/templates/subgraph/_dot_env.local
@@ -1,0 +1,5 @@
+# Mainnet RPC URL used for fetching blockchain data. Alchemy is recommended.
+PONDER_RPC_URL_1=
+
+# (Optional) Postgres database URL. If not provided, SQLite will be used. 
+DATABASE_URL=

--- a/packages/create-ponder/templates/subgraph/_dot_eslintrc.json
+++ b/packages/create-ponder/templates/subgraph/_dot_eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "ponder"
+}

--- a/packages/create-ponder/templates/subgraph/_dot_gitignore
+++ b/packages/create-ponder/templates/subgraph/_dot_gitignore
@@ -1,0 +1,18 @@
+# Dependencies
+/node_modules
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Misc
+.DS_Store
+
+# Env files
+.env*.local
+
+# Ponder
+/generated/
+/.ponder/

--- a/packages/create-ponder/templates/subgraph/package.json
+++ b/packages/create-ponder/templates/subgraph/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ponder-etherscan",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ponder dev",
+    "start": "ponder start",
+    "codegen": "ponder codegen",
+    "lint": "eslint .",
+    "typecheck": "tsc"
+  },
+  "dependencies": {
+    "@ponder/core": "^0.0.95",
+    "viem": "^1.19.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.9.0",
+    "eslint": "^8.53.0",
+    "eslint-config-ponder": "^0.0.95",
+    "typescript": "^5.2.2"
+  },
+  "engines": {
+    "node": ">=18.14"
+  }
+}

--- a/packages/create-ponder/templates/subgraph/ponder-env.d.ts
+++ b/packages/create-ponder/templates/subgraph/ponder-env.d.ts
@@ -1,0 +1,32 @@
+// This file enables type checking and editor autocomplete for this Ponder project.
+// After upgrading, you may find that changes have been made to this file.
+// If this happens, please commit the changes. Do not manually edit this file.
+// See https://ponder.sh/docs/guides/typescript for more information.
+
+declare module "@/generated" {
+  import type {
+    PonderContext,
+    PonderEvent,
+    PonderEventNames,
+    PonderApp,
+  } from "@ponder/core";
+
+  type Config = typeof import("./ponder.config.ts").default;
+  type Schema = typeof import("./ponder.schema.ts").default;
+
+  export const ponder: PonderApp<Config, Schema>;
+  export type EventNames = PonderEventNames<Config>;
+  export type Event<name extends EventNames = EventNames> = PonderEvent<
+    Config,
+    name
+  >;
+  export type Context<name extends EventNames = EventNames> = PonderContext<
+    Config,
+    Schema,
+    name
+  >;
+  export type IndexingFunctionArgs<name extends EventNames = EventNames> = {
+    event: Event<name>;
+    context: Context<name>;
+  };
+}

--- a/packages/create-ponder/templates/subgraph/ponder.schema.ts
+++ b/packages/create-ponder/templates/subgraph/ponder.schema.ts
@@ -1,0 +1,8 @@
+import { createSchema } from "@ponder/core";
+
+export default createSchema((p) => ({
+  Example: p.createTable({
+    id: p.string(),
+    name: p.string().optional(),
+  }),
+}));

--- a/packages/create-ponder/templates/subgraph/tsconfig.json
+++ b/packages/create-ponder/templates/subgraph/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    // Type checking
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+
+    // Interop constraints
+    "verbatimModuleSyntax": false,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+
+    // Language and environment
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "target": "ES2022",
+
+    // Skip type checking for node modules
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,6 +623,9 @@ importers:
       viem:
         specifier: ^2.0.10
         version: 2.0.10(typescript@5.0.4)
+      yaml:
+        specifier: ^2.3.4
+        version: 2.3.4
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4


### PR DESCRIPTION
Pulls subgraph info from ipfs using subgraph ID and generates ponder config and populates ABIs. Doesn't generate schema based on events yet, and doesn't support subgraph factory templates because the factory's child creation logic is in assemblyscript, and not the subgraph configuration itself.