### PR TITLE
Advanced Abstract Syntax Tree Parsing

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -25,7 +25,7 @@ import { type SyncStore } from "@/sync-store/store.js";
 import { TelemetryService } from "@/telemetry/service.js";
 import { UiService } from "@/ui/service.js";
 import type { GraphQLSchema } from "graphql";
-import type { TableAccess } from "./build/parseIndexingAst.js";
+import type { TableAccess } from "./build/functions/parseAst.js";
 import { type RequestQueue, createRequestQueue } from "./utils/requestQueue.js";
 
 export type Common = {

--- a/packages/core/src/build/functions/parseAst.test.ts
+++ b/packages/core/src/build/functions/parseAst.test.ts
@@ -73,6 +73,36 @@ test("helper function", () => {
   });
 });
 
+test.skip("helper rename", () => {
+  const tableAccess = parseAst({
+    tableNames,
+    indexingFunctionKeys,
+    filePaths: [
+      path.join(
+        url.fileURLToPath(import.meta.url),
+        "..",
+        "test",
+        "helperFuncRename.ts",
+      ),
+      path.join(url.fileURLToPath(import.meta.url), "..", "test", "util.ts"),
+    ],
+  });
+
+  expect(tableAccess).toHaveLength(4);
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event1",
+    access: "read",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event1",
+    access: "write",
+  });
+});
+
 test("renamed variable", () => {
   const tableAccess = parseAst({
     tableNames,

--- a/packages/core/src/build/functions/parseAst.test.ts
+++ b/packages/core/src/build/functions/parseAst.test.ts
@@ -16,7 +16,7 @@ test("basic", () => {
     ],
   });
 
-  expect(tableAccess).toHaveLength(6);
+  expect(tableAccess).toHaveLength(4);
 
   expect(tableAccess).toContainEqual({
     table: "Table1",
@@ -58,7 +58,7 @@ test("helper function", () => {
     ],
   });
 
-  expect(tableAccess).toHaveLength(4);
+  expect(tableAccess).toHaveLength(2);
 
   expect(tableAccess).toContainEqual({
     table: "Table1",

--- a/packages/core/src/build/functions/parseAst.test.ts
+++ b/packages/core/src/build/functions/parseAst.test.ts
@@ -16,7 +16,7 @@ test("basic", () => {
     ],
   });
 
-  expect(tableAccess).toHaveLength(4);
+  expect(tableAccess).toHaveLength(6);
 
   expect(tableAccess).toContainEqual({
     table: "Table1",
@@ -58,7 +58,7 @@ test("helper function", () => {
     ],
   });
 
-  expect(tableAccess).toHaveLength(2);
+  expect(tableAccess).toHaveLength(4);
 
   expect(tableAccess).toContainEqual({
     table: "Table1",
@@ -73,7 +73,7 @@ test("helper function", () => {
   });
 });
 
-test("basic", () => {
+test("renamed variable", () => {
   const tableAccess = parseAst({
     tableNames,
     indexingFunctionKeys,
@@ -87,7 +87,7 @@ test("basic", () => {
     ],
   });
 
-  expect(tableAccess).toHaveLength(2);
+  expect(tableAccess).toHaveLength(6);
 
   expect(tableAccess).toContainEqual({
     table: "Table1",

--- a/packages/core/src/build/functions/parseAst.test.ts
+++ b/packages/core/src/build/functions/parseAst.test.ts
@@ -43,7 +43,7 @@ test("basic", () => {
   });
 });
 
-test("basic", () => {
+test("helper function", () => {
   const tableAccess = parseAst({
     tableNames,
     indexingFunctionKeys,
@@ -54,6 +54,7 @@ test("basic", () => {
         "test",
         "helperFunc.ts",
       ),
+      path.join(url.fileURLToPath(import.meta.url), "..", "test", "util.ts"),
     ],
   });
 

--- a/packages/core/src/build/functions/parseAst.test.ts
+++ b/packages/core/src/build/functions/parseAst.test.ts
@@ -72,3 +72,32 @@ test("helper function", () => {
     access: "write",
   });
 });
+
+test("basic", () => {
+  const tableAccess = parseAst({
+    tableNames,
+    indexingFunctionKeys,
+    filePaths: [
+      path.join(
+        url.fileURLToPath(import.meta.url),
+        "..",
+        "test",
+        "renameVar.ts",
+      ),
+    ],
+  });
+
+  expect(tableAccess).toHaveLength(2);
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event2",
+    access: "read",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event2",
+    access: "write",
+  });
+});

--- a/packages/core/src/build/functions/parseAst.test.ts
+++ b/packages/core/src/build/functions/parseAst.test.ts
@@ -1,0 +1,73 @@
+import path from "path";
+import url from "url";
+import { expect, test } from "vitest";
+import { parseAst } from "./parseAst.js";
+import schema from "./test/ponder.schema.js";
+
+const tableNames = Object.keys(schema.tables);
+const indexingFunctionKeys = ["C:Event1", "C:Event2", "C:Event3"];
+
+test("basic", () => {
+  const tableAccess = parseAst({
+    tableNames,
+    indexingFunctionKeys,
+    filePaths: [
+      path.join(url.fileURLToPath(import.meta.url), "..", "test", "basic.ts"),
+    ],
+  });
+
+  expect(tableAccess).toHaveLength(4);
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event1",
+    access: "read",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event1",
+    access: "write",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event2",
+    access: "read",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event2",
+    access: "write",
+  });
+});
+
+test("basic", () => {
+  const tableAccess = parseAst({
+    tableNames,
+    indexingFunctionKeys,
+    filePaths: [
+      path.join(
+        url.fileURLToPath(import.meta.url),
+        "..",
+        "test",
+        "helperFunc.ts",
+      ),
+    ],
+  });
+
+  expect(tableAccess).toHaveLength(2);
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event1",
+    access: "read",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event1",
+    access: "write",
+  });
+});

--- a/packages/core/src/build/functions/parseAst.ts
+++ b/packages/core/src/build/functions/parseAst.ts
@@ -36,10 +36,7 @@ const parseTableReference = (
 const findAllORMCalls = (root: SgNode) => {
   return Object.keys(ormFunctions).map((ormf) => ({
     method: ormf as keyof typeof ormFunctions,
-    nodes: [
-      ...root.findAll(`$_.$TABLE.${ormf}($$$)`),
-      ...root.findAll(`$TABLE.${ormf}($$$)`),
-    ],
+    nodes: root.findAll(`$TABLE.${ormf}($$$)`),
   }));
 };
 

--- a/packages/core/src/build/functions/parseAst.ts
+++ b/packages/core/src/build/functions/parseAst.ts
@@ -46,7 +46,7 @@ export type TableAccess = {
   access: "read" | "write";
 }[];
 
-export const parseIndexingAst = ({
+export const parseAst = ({
   tableNames,
   indexingFunctionKeys,
   filePaths,

--- a/packages/core/src/build/functions/parseAst.ts
+++ b/packages/core/src/build/functions/parseAst.ts
@@ -153,6 +153,7 @@ export const parseAst = ({
     }
   }
 
+  // Build tableAccess
   for (const filePath of filePaths) {
     const file = fs.readFileSync(filePath).toString();
 

--- a/packages/core/src/build/functions/parseAst.ts
+++ b/packages/core/src/build/functions/parseAst.ts
@@ -36,7 +36,7 @@ const parseTableReference = (
 const findAllORMCalls = (root: SgNode) => {
   return Object.keys(ormFunctions).map((ormf) => ({
     method: ormf as keyof typeof ormFunctions,
-    nodes: root.findAll(`$TABLE.${ormf}($$$)`),
+    nodes: root.findAll(`$TABLE.${ormf}($_)`),
   }));
 };
 

--- a/packages/core/src/build/functions/parseAst.ts
+++ b/packages/core/src/build/functions/parseAst.ts
@@ -23,9 +23,11 @@ const parseTableReference = (
   node: SgNode,
   tableNames: string[],
 ): string | undefined => {
-  const table = node.getMatch("TABLE")?.text();
+  const table = node.getMatch("TABLE")?.text()!;
 
-  return table && tableNames.includes(table) ? table : undefined;
+  // Note: An invalid table name should probably throw some sort of warning
+  // Could also set a flag to say: "mark this function as fully dependent"
+  return tableNames.includes(table) ? table : undefined;
 };
 
 const findAllORMCalls = (root: SgNode) => {

--- a/packages/core/src/build/functions/test/abi.ts
+++ b/packages/core/src/build/functions/test/abi.ts
@@ -1,0 +1,7 @@
+import { parseAbi } from "viem";
+
+export const abi = parseAbi([
+  "event Event1(bytes32 arg)",
+  "event Event2(bytes32 arg)",
+  "event Event3(bytes32 arg)",
+]);

--- a/packages/core/src/build/functions/test/abi.ts
+++ b/packages/core/src/build/functions/test/abi.ts
@@ -1,7 +1,0 @@
-import { parseAbi } from "viem";
-
-export const abi = parseAbi([
-  "event Event1(bytes32 arg)",
-  "event Event2(bytes32 arg)",
-  "event Event3(bytes32 arg)",
-]);

--- a/packages/core/src/build/functions/test/basic.ts
+++ b/packages/core/src/build/functions/test/basic.ts
@@ -1,0 +1,13 @@
+import { ponder } from "./ponder-env.js";
+
+ponder.on("C:Event1", async ({ event, context }) => {
+  await context.db.Table1.upsert({
+    id: event.args.arg,
+  });
+});
+
+ponder.on("C:Event2", async ({ event, context }) => {
+  await context.db.Table1.upsert({
+    id: event.args.arg,
+  });
+});

--- a/packages/core/src/build/functions/test/basic.ts
+++ b/packages/core/src/build/functions/test/basic.ts
@@ -7,7 +7,9 @@ ponder.on("C:Event1", async ({ event, context }) => {
 });
 
 ponder.on("C:Event2", async ({ event, context }) => {
-  await context.db.Table1.upsert({
+  const { Table1 } = context.db;
+
+  await Table1.upsert({
     id: event.args.arg,
   });
 });

--- a/packages/core/src/build/functions/test/helperFunc.ts
+++ b/packages/core/src/build/functions/test/helperFunc.ts
@@ -1,0 +1,11 @@
+import { type Context, ponder } from "./ponder-env.js";
+
+const helper = async (context: Context) => {
+  await context.db.Table1.upsert({
+    id: "kyle",
+  });
+};
+
+ponder.on("C:Event1", async ({ context }) => {
+  helper(context);
+});

--- a/packages/core/src/build/functions/test/helperFunc.ts
+++ b/packages/core/src/build/functions/test/helperFunc.ts
@@ -1,11 +1,6 @@
-import { type Context, ponder } from "./ponder-env.js";
-
-const helper = async (context: Context) => {
-  await context.db.Table1.upsert({
-    id: "kyle",
-  });
-};
+import { ponder } from "./ponder-env.js";
+import { helper1 } from "./util.js";
 
 ponder.on("C:Event1", async ({ context }) => {
-  helper(context);
+  helper1(context);
 });

--- a/packages/core/src/build/functions/test/helperFuncRename.ts
+++ b/packages/core/src/build/functions/test/helperFuncRename.ts
@@ -1,0 +1,6 @@
+import { ponder } from "./ponder-env.js";
+import { helper1 as helper } from "./util.js";
+
+ponder.on("C:Event1", async ({ context }) => {
+  helper(context);
+});

--- a/packages/core/src/build/functions/test/ponder-env.d.ts
+++ b/packages/core/src/build/functions/test/ponder-env.d.ts
@@ -1,0 +1,30 @@
+// This file enables type checking and editor autocomplete for this Ponder project.
+// After upgrading, you may find that changes have been made to this file.
+// If this happens, please commit the changes. Do not manually edit this file.
+// See https://ponder.sh/docs/guides/typescript for more information.
+
+import type {
+  PonderApp,
+  PonderContext,
+  PonderEvent,
+  PonderEventNames,
+} from "@ponder/core";
+
+type Config = typeof import("./ponder.config.ts").default;
+type Schema = typeof import("./ponder.schema.ts").default;
+
+export const ponder: PonderApp<Config, Schema>;
+export type EventNames = PonderEventNames<Config>;
+export type Event<name extends EventNames = EventNames> = PonderEvent<
+  Config,
+  name
+>;
+export type Context<name extends EventNames = EventNames> = PonderContext<
+  Config,
+  Schema,
+  name
+>;
+export type IndexingFunctionArgs<name extends EventNames = EventNames> = {
+  event: Event<name>;
+  context: Context<name>;
+};

--- a/packages/core/src/build/functions/test/ponder.config.ts
+++ b/packages/core/src/build/functions/test/ponder.config.ts
@@ -1,6 +1,11 @@
-import { http, zeroAddress } from "viem";
+import { http, parseAbi, zeroAddress } from "viem";
 import { createConfig } from "../../../config/config.js";
-import { abi } from "./abi.js";
+
+const abi = parseAbi([
+  "event Event1(bytes32 arg)",
+  "event Event2(bytes32 arg)",
+  "event Event3(bytes32 arg)",
+]);
 
 export default createConfig({
   networks: {

--- a/packages/core/src/build/functions/test/ponder.config.ts
+++ b/packages/core/src/build/functions/test/ponder.config.ts
@@ -1,0 +1,19 @@
+import { http, zeroAddress } from "viem";
+import { createConfig } from "../../../config/config.js";
+import { abi } from "./abi.js";
+
+export default createConfig({
+  networks: {
+    mainnet: {
+      chainId: 1,
+      transport: http(),
+    },
+  },
+  contracts: {
+    C: {
+      network: "mainnet",
+      abi,
+      address: zeroAddress,
+    },
+  },
+});

--- a/packages/core/src/build/functions/test/ponder.schema.ts
+++ b/packages/core/src/build/functions/test/ponder.schema.ts
@@ -1,0 +1,13 @@
+import { createSchema } from "../../../schema/schema.js";
+
+export default createSchema((p) => ({
+  Table1: p.createTable({
+    id: p.string(),
+  }),
+  Table2: p.createTable({
+    id: p.string(),
+  }),
+  Table3: p.createTable({
+    id: p.string(),
+  }),
+}));

--- a/packages/core/src/build/functions/test/renameVar.ts
+++ b/packages/core/src/build/functions/test/renameVar.ts
@@ -1,0 +1,9 @@
+import { ponder } from "./ponder-env.js";
+
+ponder.on("C:Event2", async ({ event, context }) => {
+  const { Table1: Table } = context.db;
+
+  await Table.upsert({
+    id: event.args.arg,
+  });
+});

--- a/packages/core/src/build/functions/test/util.ts
+++ b/packages/core/src/build/functions/test/util.ts
@@ -1,0 +1,13 @@
+import { type Context } from "./ponder-env.js";
+
+export const helper1 = async (context: Context) => {
+  await context.db.Table1.upsert({
+    id: "kyle",
+  });
+};
+
+export async function helper2(context: Context) {
+  await context.db.Table1.upsert({
+    id: "kyle",
+  });
+}

--- a/packages/core/src/build/service.ts
+++ b/packages/core/src/build/service.ts
@@ -20,7 +20,7 @@ import {
   type RawIndexingFunctions,
   safeBuildIndexingFunctions,
 } from "./functions/functions.js";
-import { type TableAccess, parseIndexingAst } from "./parseIndexingAst.js";
+import { type TableAccess, parseAst } from "./functions/parseAst.js";
 import { vitePluginPonder } from "./plugin.js";
 import type { ViteNodeError } from "./stacktrace.js";
 import { parseViteNodeError } from "./stacktrace.js";
@@ -394,7 +394,7 @@ export class BuildService extends Emittery<BuildServiceEvents> {
       this.rawIndexingFunctions,
     ).flatMap((indexingFunctions) => indexingFunctions.map((x) => x.name));
 
-    const tableAccessMap = parseIndexingAst({
+    const tableAccessMap = parseAst({
       tableNames,
       filePaths,
       indexingFunctionKeys,

--- a/packages/core/src/indexing/service.test.ts
+++ b/packages/core/src/indexing/service.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/_test/setup.js";
 import { getEventsErc20 } from "@/_test/utils.js";
 import type { IndexingFunctions } from "@/build/functions/functions.js";
-import type { TableAccess } from "@/build/parseIndexingAst.js";
+import type { TableAccess } from "@/build/functions/parseAst.js";
 import { createSchema } from "@/schema/schema.js";
 import type { SyncGateway } from "@/sync-gateway/service.js";
 import { type Checkpoint, zeroCheckpoint } from "@/utils/checkpoint.js";

--- a/packages/core/src/indexing/service.ts
+++ b/packages/core/src/indexing/service.ts
@@ -1,6 +1,6 @@
 import type { Common } from "@/Ponder.js";
 import type { IndexingFunctions } from "@/build/functions/functions.js";
-import type { TableAccess } from "@/build/parseIndexingAst.js";
+import type { TableAccess } from "@/build/functions/parseAst.js";
 import type { Network } from "@/config/networks.js";
 import {
   type Source,


### PR DESCRIPTION
Handle helper functions, including in different files. 

When a ORM method (`upsert()`, `findMany()`) is called on variable that is not recognized, all tables in the schema are added to the table access matrix for that method. The most common occurrence of this is if a user were to rename a variable:

```ts
const { Account, TransferEvent: TE } = context.db;

await TE.update({
  ...
});
```

In this case, the table access would be the same as if `update()` was called on every table in the schema.