### PR TITLE
Fix bug when passing callback to ponder.on

### DIFF
--- a/packages/core/src/build/functions/parseAst.test.ts
+++ b/packages/core/src/build/functions/parseAst.test.ts
@@ -58,7 +58,7 @@ test("helper function", () => {
     ],
   });
 
-  expect(tableAccess).toHaveLength(2);
+  expect(tableAccess).toHaveLength(6);
 
   expect(tableAccess).toContainEqual({
     table: "Table1",
@@ -69,6 +69,30 @@ test("helper function", () => {
   expect(tableAccess).toContainEqual({
     table: "Table1",
     indexingFunctionKey: "C:Event1",
+    access: "write",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event2",
+    access: "read",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event2",
+    access: "write",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event3",
+    access: "read",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event3",
     access: "write",
   });
 });

--- a/packages/core/src/build/functions/parseAst.ts
+++ b/packages/core/src/build/functions/parseAst.ts
@@ -176,7 +176,7 @@ export const parseAst = ({
       for (const [name, helperFunctionState] of Object.entries(
         helperFunctionAccess,
       )) {
-        if (funcNode.find(`${name}($$$)`) !== null) {
+        if (funcNode.find(`${name}`) !== null) {
           for (const state of helperFunctionState) {
             addToTableAccess(state.table, indexingFunctionKey, state.method);
           }

--- a/packages/core/src/build/functions/test/helperFunc.ts
+++ b/packages/core/src/build/functions/test/helperFunc.ts
@@ -1,6 +1,12 @@
 import { ponder } from "./ponder-env.js";
-import { helper1 } from "./util.js";
+import { helper1, helper2, helper3 } from "./util.js";
 
 ponder.on("C:Event1", async ({ context }) => {
-  helper1({ context });
+  await helper1({ context });
 });
+
+ponder.on("C:Event2", async ({ context }) => {
+  await helper2(context);
+});
+
+ponder.on("C:Event3", helper3);

--- a/packages/core/src/build/functions/test/util.ts
+++ b/packages/core/src/build/functions/test/util.ts
@@ -1,4 +1,4 @@
-import { type Context } from "./ponder-env.js";
+import { type Context, type Event } from "./ponder-env.js";
 
 export const helper1 = async ({
   context,
@@ -12,6 +12,12 @@ export const helper1 = async ({
 };
 
 export async function helper2(context: Context) {
+  await context.db.Table1.upsert({
+    id: "kyle",
+  });
+}
+
+export async function helper3({ context }: { event: Event; context: Context }) {
   await context.db.Table1.upsert({
     id: "kyle",
   });


### PR DESCRIPTION
Fixes
```ts
const helper = async ({ event, context} : {event: Event, context: Context}) => {
  ...
}

ponder.on("Contract:Event", helper);
```

as seen in `main-characters`