### PR TITLE
Fixes issue with parsing class methods as helper functions

### DIFF
--- a/.changeset/selfish-toys-arrive.md
+++ b/.changeset/selfish-toys-arrive.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed static analysis issue affecting indexing functions using class methods as helper functions.

--- a/packages/core/src/build/functions/parseAst.test.ts
+++ b/packages/core/src/build/functions/parseAst.test.ts
@@ -155,3 +155,33 @@ test("renamed variable", () => {
     access: "write",
   });
 });
+
+test("helper class", () => {
+  const tableAccess = parseAst({
+    tableNames,
+    indexingFunctionKeys,
+    filePaths: [
+      path.join(
+        url.fileURLToPath(import.meta.url),
+        "..",
+        "test",
+        "helperClass.ts",
+      ),
+      path.join(url.fileURLToPath(import.meta.url), "..", "test", "util.ts"),
+    ],
+  });
+
+  expect(tableAccess).toHaveLength(2);
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event1",
+    access: "read",
+  });
+
+  expect(tableAccess).toContainEqual({
+    table: "Table1",
+    indexingFunctionKey: "C:Event1",
+    access: "write",
+  });
+});

--- a/packages/core/src/build/functions/parseAst.ts
+++ b/packages/core/src/build/functions/parseAst.ts
@@ -70,7 +70,18 @@ const helperFunctionName = (node: SgNode) => {
       ?.text(),
   );
 
-  return [...arrowFuncName, ...funcDeclarName].filter(
+  const methodDeclarAncestor = node
+    .ancestors()
+    .filter((n) => n.kind() === "method_definition");
+
+  const methodDeclarName = methodDeclarAncestor.map((m) =>
+    m
+      .children()
+      .find((c) => c.kind() === "property_identifier")
+      ?.text(),
+  );
+
+  return [...arrowFuncName, ...funcDeclarName, ...methodDeclarName].filter(
     (name) => !!name,
   ) as string[];
 };

--- a/packages/core/src/build/functions/parseAst.ts
+++ b/packages/core/src/build/functions/parseAst.ts
@@ -190,7 +190,7 @@ export const parseAst = ({
       for (const [name, helperFunctionState] of Object.entries(
         helperFunctionAccess,
       )) {
-        if (funcNode.find(`${name}`) !== null) {
+        if (funcNode.find(`${name}`) !== null || funcNode.find(`$$$.${name}`)) {
           for (const state of helperFunctionState) {
             addToTableAccess(state.table, indexingFunctionKey, state.method);
           }

--- a/packages/core/src/build/functions/test/helperClass.ts
+++ b/packages/core/src/build/functions/test/helperClass.ts
@@ -1,0 +1,7 @@
+import { ponder } from "./ponder-env.js";
+import { HelperClass } from "./util.js";
+
+ponder.on("C:Event1", async ({ event, context }) => {
+  const helper = new HelperClass();
+  await helper.helper({ context, event });
+});

--- a/packages/core/src/build/functions/test/helperClass.ts
+++ b/packages/core/src/build/functions/test/helperClass.ts
@@ -2,6 +2,6 @@ import { ponder } from "./ponder-env.js";
 import { HelperClass } from "./util.js";
 
 ponder.on("C:Event1", async ({ event, context }) => {
-  const helper = new HelperClass();
-  await helper.helper({ context, event });
+  const h = new HelperClass();
+  await h.helper({ context, event });
 });

--- a/packages/core/src/build/functions/test/util.ts
+++ b/packages/core/src/build/functions/test/util.ts
@@ -22,3 +22,11 @@ export async function helper3({ context }: { event: Event; context: Context }) {
     id: "kyle",
   });
 }
+
+export class HelperClass {
+  async helper({ context }: { event: Event; context: Context }) {
+    await context.db.Table1.upsert({
+      id: "kyle",
+    });
+  }
+}


### PR DESCRIPTION
```ts
class HelperClass {
  async helper({ context }: { event: Event; context: Context }) {
    await context.db.Table.upsert({
      id: "kyle",
    });
  }
}

ponder.on("C:Event1", async ({ event, context }) => {
  const h = new HelperClass();
  await h.helper({ context, event });
});
```
is now handled by Ponder static analysis.