### PR TITLE
feat: enable allowImportingTsExtensions in tsconfig

### DIFF
--- a/examples/reference-erc20/tsconfig.json
+++ b/examples/reference-erc20/tsconfig.json
@@ -17,6 +17,7 @@
     "noEmit": true,
     "lib": ["ES2022"],
     "target": "ES2022",
+    "allowImportingTsExtensions": true,
 
     // Skip type checking for node modules
     "skipLibCheck": true


### PR DESCRIPTION
> `--allowImportingTsExtensions` allows TypeScript files to import each other with a TypeScript-specific extension like `.ts`, `.mts`, or `.tsx`

[sauce](https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions)

is enabling here sufficient or should I also add the config to each template?