### PR TITLE
fix(docs): Add details on RPC URL environment variable formatting

### DIFF
--- a/docs/pages/docs/getting-started/migrate-subgraph.mdx
+++ b/docs/pages/docs/getting-started/migrate-subgraph.mdx
@@ -71,7 +71,9 @@ npm run dev
 
 Ponder fetches data using the standard Ethereum RPC API. To get started, you'll need an RPC URL from a provider like Alchemy or Infura.
 
-Open up `.env.local` and paste in RPC URLs for any networks that your project uses:
+Open `.env.local` and paste in RPC URLs for any networks that your project uses.
+
+Each RPC URL environment variable is named `PONDER_RPC_URL` postfixed with the chain ID (e.g. `PONDER_RPC_URL_8453` for Base Mainnet):
 
 {/* prettier-ignore */}
 ```js filename=".env.local"

--- a/docs/pages/docs/getting-started/new-project.mdx
+++ b/docs/pages/docs/getting-started/new-project.mdx
@@ -66,7 +66,9 @@ npm run dev
 
 Ponder fetches data using the standard Ethereum RPC API. To get started, you'll need an RPC URL from a provider like Alchemy or Infura.
 
-Open `.env.local` and paste in RPC URLs for any networks that your project uses:
+Open `.env.local` and paste in RPC URLs for any networks that your project uses.
+
+Each RPC URL environment variable is named `PONDER_RPC_URL` postfixed with the chain ID (e.g. `PONDER_RPC_URL_8453` for Base Mainnet):
 
 {/* prettier-ignore */}
 ```js filename=".env.local"


### PR DESCRIPTION
# Summary
* Specify RPC URL environment variable formatting requirements in docs

# Description
This is a super minor nit that tripped me up when getting started.

It wasn't entirely clear to me that the `1` in `PONDER_RPC_URL_1` represented the chain ID. This PR just adds some clarity on appending the chain ID of non Ethereum Mainnet chains.

Feel free to disregard or completely reword!