### PR TITLE
Fix: `maxHistoricalTaskConcurrency` ignored in config

### DIFF
--- a/.changeset/slow-adults-decide.md
+++ b/.changeset/slow-adults-decide.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fix issue with maxHistoricalTaskConcurrency config being ignored.

--- a/packages/core/src/build/config/config.ts
+++ b/packages/core/src/build/config/config.ts
@@ -49,7 +49,8 @@ export async function buildNetworksAndSources({ config }: { config: Config }) {
         pollingInterval: network.pollingInterval ?? 1_000,
         defaultMaxBlockRange: getDefaultMaxBlockRange({ chainId, rpcUrls }),
         finalityBlockCount: getFinalityBlockCount({ chainId }),
-        maxHistoricalTaskConcurrency: 20,
+        maxHistoricalTaskConcurrency:
+          network.maxHistoricalTaskConcurrency ?? 20,
       } satisfies Network;
     }),
   );


### PR DESCRIPTION
sad