### PR TITLE
Fix custom filters

### DIFF
--- a/.changeset/dirty-clocks-wonder.md
+++ b/.changeset/dirty-clocks-wonder.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where contracts that specify multiple addresses or use a custom filter with multiple events would not be cached properly during the sync.

--- a/.changeset/thick-monkeys-serve.md
+++ b/.changeset/thick-monkeys-serve.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where `NaN` was an allowed value for `startBlock` and `endBlock`. Now, `NaN` values are coerced to `0` and `undefined` respectively.

--- a/packages/core/src/build/config/config.test.ts
+++ b/packages/core/src/build/config/config.test.ts
@@ -22,10 +22,7 @@ const bytes2 =
 test("buildNetworksAndSources() builds topics for multiple events", async () => {
   const config = createConfig({
     networks: {
-      mainnet: {
-        chainId: 1,
-        transport: http("http://127.0.0.1:8545"),
-      },
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
     },
     contracts: {
       a: {
@@ -50,10 +47,7 @@ test("buildNetworksAndSources() builds topics for multiple events", async () => 
 test("buildNetworksAndSources() handles overloaded event signatures and combines topics", async () => {
   const config = createConfig({
     networks: {
-      mainnet: {
-        chainId: 1,
-        transport: http("http://127.0.0.1:8545"),
-      },
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
     },
     contracts: {
       BaseRegistrartImplementation: {
@@ -80,14 +74,8 @@ test("buildNetworksAndSources() handles overloaded event signatures and combines
 test("buildNetworksAndSources() creates a source for each network for multi-network contracts", async () => {
   const config = createConfig({
     networks: {
-      mainnet: {
-        chainId: 1,
-        transport: http("http://127.0.0.1:8545"),
-      },
-      optimism: {
-        chainId: 10,
-        transport: http("http://127.0.0.1:8545"),
-      },
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
+      optimism: { chainId: 10, transport: http("http://127.0.0.1:8545") },
     },
     contracts: {
       a: {
@@ -105,10 +93,7 @@ test("buildNetworksAndSources() creates a source for each network for multi-netw
 test("buildNetworksAndSources() builds topics for event with args", async () => {
   const config = createConfig({
     networks: {
-      mainnet: {
-        chainId: 1,
-        transport: http("http://127.0.0.1:8545"),
-      },
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
     },
     contracts: {
       a: {
@@ -139,10 +124,7 @@ test("buildNetworksAndSources() builds topics for event with args", async () => 
 test("buildNetworksAndSources() builds topics for event with unnamed parameters", async () => {
   const config = createConfig({
     networks: {
-      mainnet: {
-        chainId: 1,
-        transport: http("http://127.0.0.1:8545"),
-      },
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
     },
     contracts: {
       a: {
@@ -171,10 +153,7 @@ test("buildNetworksAndSources() builds topics for event with unnamed parameters"
 test("buildNetworksAndSources() overrides default values with network-specific values", async () => {
   const config = createConfig({
     networks: {
-      mainnet: {
-        chainId: 1,
-        transport: http("http://127.0.0.1:8545"),
-      },
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
     },
     contracts: {
       a: {
@@ -201,10 +180,7 @@ test("buildNetworksAndSources() overrides default values with network-specific v
 test("buildNetworksAndSources() handles network name shortcut", async () => {
   const config = createConfig({
     networks: {
-      mainnet: {
-        chainId: 1,
-        transport: http("http://127.0.0.1:8545"),
-      },
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
     },
     contracts: {
       a: {
@@ -391,4 +367,42 @@ test("buildNetworksAndSources() validates address length", async () => {
   expect(result.error?.message).toBe(
     "Validation failed: Invalid length for address '0x000000000001'. Got 14, expected 42 characters.",
   );
+});
+
+test("buildNetworksAndSources() coerces NaN startBlock to 0", async () => {
+  const config = createConfig({
+    networks: {
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
+    },
+    contracts: {
+      a: {
+        network: { mainnet: {} },
+        abi: [event0, event1],
+        startBlock: NaN,
+      },
+    },
+  });
+
+  const { sources } = await buildNetworksAndSources({ config });
+
+  expect(sources[0].startBlock).toBe(0);
+});
+
+test("buildNetworksAndSources() coerces NaN endBlock to undefined", async () => {
+  const config = createConfig({
+    networks: {
+      mainnet: { chainId: 1, transport: http("http://127.0.0.1:8545") },
+    },
+    contracts: {
+      a: {
+        network: { mainnet: {} },
+        abi: [event0, event1],
+        endBlock: NaN,
+      },
+    },
+  });
+
+  const { sources } = await buildNetworksAndSources({ config });
+
+  expect(sources[0].endBlock).toBe(undefined);
 });

--- a/packages/core/src/build/config/config.ts
+++ b/packages/core/src/build/config/config.ts
@@ -66,6 +66,15 @@ export async function buildNetworksAndSources({ config }: { config: Config }) {
         );
       }
 
+      const startBlockMaybeNan = contract.startBlock ?? 0;
+      const startBlock = Number.isNaN(startBlockMaybeNan)
+        ? 0
+        : startBlockMaybeNan;
+      const endBlockMaybeNan = contract.endBlock;
+      const endBlock = Number.isNaN(endBlockMaybeNan)
+        ? undefined
+        : endBlockMaybeNan;
+
       // Single network case.
       if (typeof contract.network === "string") {
         return {
@@ -78,8 +87,8 @@ export async function buildNetworksAndSources({ config }: { config: Config }) {
           factory: "factory" in contract ? contract.factory : undefined,
           filter: contract.filter,
 
-          startBlock: contract.startBlock ?? 0,
-          endBlock: contract.endBlock,
+          startBlock,
+          endBlock,
           maxBlockRange: contract.maxBlockRange,
         };
       }
@@ -91,24 +100,36 @@ export async function buildNetworksAndSources({ config }: { config: Config }) {
       // Multiple networks case.
       return Object.entries(contract.network)
         .filter((n): n is [string, DefinedNetworkOverride] => !!n[1])
-        .map(([networkName, overrides]) => ({
-          id: `${contractName}_${networkName}`,
-          contractName,
-          networkName,
-          abi: contract.abi,
+        .map(([networkName, overrides]) => {
+          const startBlockMaybeNan =
+            overrides.startBlock ?? contract.startBlock ?? 0;
+          const startBlock = Number.isNaN(startBlockMaybeNan)
+            ? 0
+            : startBlockMaybeNan;
+          const endBlockMaybeNan = overrides.endBlock ?? contract.endBlock;
+          const endBlock = Number.isNaN(endBlockMaybeNan)
+            ? undefined
+            : endBlockMaybeNan;
 
-          address:
-            ("address" in overrides ? overrides?.address : undefined) ??
-            ("address" in contract ? contract.address : undefined),
-          factory:
-            ("factory" in overrides ? overrides.factory : undefined) ??
-            ("factory" in contract ? contract.factory : undefined),
-          filter: overrides.filter ?? contract.filter,
+          return {
+            id: `${contractName}_${networkName}`,
+            contractName,
+            networkName,
+            abi: contract.abi,
 
-          startBlock: overrides.startBlock ?? contract.startBlock ?? 0,
-          endBlock: overrides.endBlock ?? contract.endBlock,
-          maxBlockRange: overrides.maxBlockRange ?? contract.maxBlockRange,
-        }));
+            address:
+              ("address" in overrides ? overrides?.address : undefined) ??
+              ("address" in contract ? contract.address : undefined),
+            factory:
+              ("factory" in overrides ? overrides.factory : undefined) ??
+              ("factory" in contract ? contract.factory : undefined),
+            filter: overrides.filter ?? contract.filter,
+
+            startBlock,
+            endBlock,
+            maxBlockRange: overrides.maxBlockRange ?? contract.maxBlockRange,
+          };
+        });
     })
     // Second, build and validate the factory or log filter.
     .map((rawContract) => {

--- a/packages/core/src/sync-store/postgres/store.ts
+++ b/packages/core/src/sync-store/postgres/store.ts
@@ -232,28 +232,25 @@ export class PostgresSyncStore implements SyncStore {
       .where("chainId", "=", chainId)
       .execute();
 
-    const intervalsByFragment = intervals.reduce(
+    const intervalsByFragmentId = intervals.reduce(
       (acc, cur) => {
-        const { fragmentId, ...rest } = cur;
-        acc[fragmentId] ||= [];
-        acc[fragmentId].push(rest);
+        const { fragmentId, startBlock, endBlock } = cur;
+        (acc[fragmentId] ||= []).push([Number(startBlock), Number(endBlock)]);
         return acc;
       },
-      {} as Record<string, { startBlock: bigint; endBlock: bigint }[]>,
+      {} as Record<string, [number, number][]>,
     );
 
-    const fragmentIntervals = fragments.map((f) => {
-      return (intervalsByFragment[f.id] ?? []).map(
-        (r) =>
-          [Number(r.startBlock), Number(r.endBlock)] satisfies [number, number],
-      );
-    });
-
-    const intersectIntervals = intervalIntersectionMany(fragmentIntervals);
+    const intervalsForEachFragment = fragments.map((f) =>
+      intervalUnion(intervalsByFragmentId[f.id] ?? []),
+    );
+    const intervalsSharedByAllFragments = intervalIntersectionMany(
+      intervalsForEachFragment,
+    );
 
     this.record("getLogFilterIntervals", stopClock());
 
-    return intersectIntervals;
+    return intervalsSharedByAllFragments;
   };
 
   insertFactoryChildAddressLogs = async ({
@@ -505,7 +502,7 @@ export class PostgresSyncStore implements SyncStore {
       intervalsForEachFragment,
     );
 
-    this.record("getLogFilterIntervals", stopClock());
+    this.record("getFactoryLogFilterIntervals", stopClock());
 
     return intervalsSharedByAllFragments;
   };

--- a/packages/core/src/sync-store/postgres/store.ts
+++ b/packages/core/src/sync-store/postgres/store.ts
@@ -489,31 +489,25 @@ export class PostgresSyncStore implements SyncStore {
       .where("chainId", "=", chainId)
       .execute();
 
-    const intervalsByFragment = intervals.reduce(
+    const intervalsByFragmentId = intervals.reduce(
       (acc, cur) => {
-        const { fragmentId, ...rest } = cur;
-        acc[fragmentId] ||= [];
-        acc[fragmentId].push({
-          startBlock: rest.startBlock,
-          endBlock: rest.endBlock,
-        });
+        const { fragmentId, startBlock, endBlock } = cur;
+        (acc[fragmentId] ||= []).push([Number(startBlock), Number(endBlock)]);
         return acc;
       },
-      {} as Record<string, { startBlock: bigint; endBlock: bigint }[]>,
+      {} as Record<string, [number, number][]>,
     );
 
-    const fragmentIntervals = fragments.map((f) => {
-      return (intervalsByFragment[f.id] ?? []).map(
-        (r) =>
-          [Number(r.startBlock), Number(r.endBlock)] satisfies [number, number],
-      );
-    });
+    const intervalsForEachFragment = fragments.map((f) =>
+      intervalUnion(intervalsByFragmentId[f.id] ?? []),
+    );
+    const intervalsSharedByAllFragments = intervalIntersectionMany(
+      intervalsForEachFragment,
+    );
 
-    const intersectIntervals = intervalIntersectionMany(fragmentIntervals);
+    this.record("getLogFilterIntervals", stopClock());
 
-    this.record("getFactoryLogFilterIntervals", stopClock());
-
-    return intersectIntervals;
+    return intervalsSharedByAllFragments;
   };
 
   insertRealtimeBlock = async ({

--- a/packages/core/src/sync-store/sqlite/store.ts
+++ b/packages/core/src/sync-store/sqlite/store.ts
@@ -230,29 +230,28 @@ export class SqliteSyncStore implements SyncStore {
       .where("chainId", "=", chainId)
       .execute();
 
-    const intervalsByFragment = intervals.reduce(
+    const intervalsByFragmentId = intervals.reduce(
       (acc, cur) => {
-        const { fragmentId, ...rest } = cur;
-        acc[fragmentId] ||= [];
-        acc[fragmentId].push({
-          startBlock: decodeToBigInt(rest.startBlock),
-          endBlock: decodeToBigInt(rest.endBlock),
-        });
+        const { fragmentId, startBlock, endBlock } = cur;
+        (acc[fragmentId] ||= []).push([
+          Number(decodeToBigInt(startBlock)),
+          Number(decodeToBigInt(endBlock)),
+        ]);
         return acc;
       },
-      {} as Record<string, { startBlock: bigint; endBlock: bigint }[]>,
+      {} as Record<string, [number, number][]>,
     );
 
-    const fragmentIntervals = fragments.map((f) => {
-      return (intervalsByFragment[f.id] ?? []).map(
-        (r) =>
-          [Number(r.startBlock), Number(r.endBlock)] satisfies [number, number],
-      );
-    });
+    const intervalsForEachFragment = fragments.map((f) =>
+      intervalUnion(intervalsByFragmentId[f.id] ?? []),
+    );
+    const intervalsSharedByAllFragments = intervalIntersectionMany(
+      intervalsForEachFragment,
+    );
 
-    const intersectionIntervals = intervalIntersectionMany(fragmentIntervals);
     this.record("getLogFilterIntervals", stopClock());
-    return intersectionIntervals;
+
+    return intervalsSharedByAllFragments;
   };
 
   insertFactoryChildAddressLogs = async ({

--- a/packages/core/src/sync-store/sqlite/store.ts
+++ b/packages/core/src/sync-store/sqlite/store.ts
@@ -486,31 +486,25 @@ export class SqliteSyncStore implements SyncStore {
       .where("chainId", "=", chainId)
       .execute();
 
-    const intervalsByFragment = intervals.reduce(
+    const intervalsByFragmentId = intervals.reduce(
       (acc, cur) => {
-        const { fragmentId, ...rest } = cur;
-        acc[fragmentId] ||= [];
-        acc[fragmentId].push({
-          startBlock: decodeToBigInt(rest.startBlock),
-          endBlock: decodeToBigInt(rest.endBlock),
-        });
+        const { fragmentId, startBlock, endBlock } = cur;
+        (acc[fragmentId] ||= []).push([Number(startBlock), Number(endBlock)]);
         return acc;
       },
-      {} as Record<string, { startBlock: bigint; endBlock: bigint }[]>,
+      {} as Record<string, [number, number][]>,
     );
 
-    const fragmentIntervals = fragments.map((f) => {
-      return (intervalsByFragment[f.id] ?? []).map(
-        (r) =>
-          [Number(r.startBlock), Number(r.endBlock)] satisfies [number, number],
-      );
-    });
-
-    const intersectionIntervals = intervalIntersectionMany(fragmentIntervals);
+    const intervalsForEachFragment = fragments.map((f) =>
+      intervalUnion(intervalsByFragmentId[f.id] ?? []),
+    );
+    const intervalsSharedByAllFragments = intervalIntersectionMany(
+      intervalsForEachFragment,
+    );
 
     this.record("getFactoryLogFilterIntervals", stopClock());
 
-    return intersectionIntervals;
+    return intervalsSharedByAllFragments;
   };
 
   insertRealtimeBlock = async ({

--- a/packages/core/src/utils/interval.test.ts
+++ b/packages/core/src/utils/interval.test.ts
@@ -82,6 +82,20 @@ test("intervalUnion removes duplicate intervals", () => {
   expect(result).toEqual([[1, 6]]);
 });
 
+test("intervalUnion does not mutate inputs", () => {
+  const intervals = [
+    [3, 5],
+    [1, 2],
+    [4, 6],
+  ] satisfies [number, number][];
+  const originalIntervals = JSON.parse(JSON.stringify(intervals));
+
+  intervalUnion(intervals);
+
+  // Asserting that the original intervals array has not been modified
+  expect(intervals).toEqual(originalIntervals);
+});
+
 test("intervalIntersection handles empty input", () => {
   const result = intervalIntersection([], []);
   expect(result).toEqual([]);

--- a/packages/core/src/utils/interval.ts
+++ b/packages/core/src/utils/interval.ts
@@ -20,10 +20,14 @@ export function intervalSum(intervals: [number, number][]) {
  * @param intervals List of numeric intervals to find the union of.
  * @returns Union of the intervals, represented as a list of intervals.
  */
-export function intervalUnion(intervals: [number, number][]) {
-  if (intervals.length === 0) return [];
+export function intervalUnion(intervals_: [number, number][]) {
+  if (intervals_.length === 0) return [];
 
-  // Sort intervals based on the left end
+  // Create copies to avoid mutating the originals.
+  const intervals = intervals_.map(
+    (interval) => [...interval] as [number, number],
+  );
+  // Sort intervals based on the left end.
   intervals.sort((a, b) => a[0] - b[0]);
 
   const result: [number, number][] = [];
@@ -88,7 +92,7 @@ export function intervalIntersection(
  *
  * @param list1 First list of numeric intervals.
  * @param list2 Second list of numeric intervals.
- * @returns Difference of the intervals, represented as a list of intervals.
+ * @returns Intersection of the intervals, represented as a list of intervals.
  */
 export function intervalIntersectionMany(lists: [number, number][][]) {
   if (lists.length === 0) return [];


### PR DESCRIPTION
Fixed a rare bug where contracts that specify multiple addresses or use a custom filter with multiple events would not be cached properly during the sync.