### PR TITLE
Make `blocks.sha3uncles` column nullable

### DIFF
--- a/.changeset/dull-laws-eat.md
+++ b/.changeset/dull-laws-eat.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Made block.sha3Uncles column nullable

--- a/packages/core/src/sync-store/postgres/encoding.ts
+++ b/packages/core/src/sync-store/postgres/encoding.ts
@@ -23,7 +23,7 @@ type BlocksTable = {
   number: bigint;
   parentHash: Hash;
   receiptsRoot: Hex;
-  sha3Uncles: Hash;
+  sha3Uncles: Hash | null;
   size: bigint;
   stateRoot: Hash;
   timestamp: bigint;
@@ -52,7 +52,7 @@ export function rpcToPostgresBlock(
     number: BigInt(block.number!),
     parentHash: block.parentHash,
     receiptsRoot: block.receiptsRoot,
-    sha3Uncles: block.sha3Uncles,
+    sha3Uncles: block.sha3Uncles ?? null,
     size: BigInt(block.size),
     stateRoot: block.stateRoot,
     timestamp: BigInt(block.timestamp),

--- a/packages/core/src/sync-store/postgres/migrations.ts
+++ b/packages/core/src/sync-store/postgres/migrations.ts
@@ -431,6 +431,14 @@ const migrations: Record<string, Migration> = {
         .execute();
     },
   },
+  "2024_03_13_0_nullable_block_columns_sha3uncles": {
+    async up(db: Kysely<any>) {
+      await db.schema
+        .alterTable("blocks")
+        .alterColumn("sha3Uncles", (col) => col.dropNotNull())
+        .execute();
+    },
+  },
 };
 
 class StaticMigrationProvider implements MigrationProvider {

--- a/packages/core/src/sync-store/sqlite/encoding.ts
+++ b/packages/core/src/sync-store/sqlite/encoding.ts
@@ -26,7 +26,7 @@ type BlocksTable = {
   number: BigIntText;
   parentHash: Hash;
   receiptsRoot: Hex;
-  sha3Uncles: Hash;
+  sha3Uncles: Hash | null;
   size: BigIntText;
   stateRoot: Hash;
   timestamp: BigIntText;
@@ -57,7 +57,7 @@ export function rpcToSqliteBlock(
     number: encodeAsText(block.number!),
     parentHash: block.parentHash,
     receiptsRoot: block.receiptsRoot,
-    sha3Uncles: block.sha3Uncles,
+    sha3Uncles: block.sha3Uncles ?? null,
     size: encodeAsText(block.size),
     stateRoot: block.stateRoot,
     timestamp: encodeAsText(block.timestamp),

--- a/packages/core/src/sync-store/sqlite/migrations.ts
+++ b/packages/core/src/sync-store/sqlite/migrations.ts
@@ -428,6 +428,25 @@ const migrations: Record<string, Migration> = {
         .execute();
     },
   },
+  "2024_03_13_0_nullable_block_columns_sha3uncles": {
+    async up(db: Kysely<any>) {
+      await db.schema
+        .alterTable("blocks")
+        .addColumn("sha3Uncles_temp_null", "varchar(66)")
+        .execute();
+      await db
+        .updateTable("blocks")
+        .set((eb: any) => ({
+          sha3Uncles_temp_null: eb.selectFrom("blocks").select("sha3Uncles"),
+        }))
+        .execute();
+      await db.schema.alterTable("blocks").dropColumn("sha3Uncles").execute();
+      await db.schema
+        .alterTable("blocks")
+        .renameColumn("sha3Uncles_temp_null", "sha3Uncles")
+        .execute();
+    },
+  },
 };
 
 class StaticMigrationProvider implements MigrationProvider {

--- a/packages/core/src/types/eth.ts
+++ b/packages/core/src/types/eth.ts
@@ -34,7 +34,7 @@ export type Block = {
   /** Root of the this block’s receipts trie */
   receiptsRoot: Hex;
   /** SHA3 of the uncles data in this block */
-  sha3Uncles: Hash;
+  sha3Uncles: Hash | null;
   /** Size of this block in bytes */
   size: bigint;
   /** Root of this block’s final state trie */


### PR DESCRIPTION
Makes sha3uncles column nullable, enabling support for Celo.
