### PR TITLE
fix: explicitly set minThreads

### DIFF
--- a/.changeset/light-vans-double.md
+++ b/.changeset/light-vans-double.md
@@ -1,5 +1,0 @@
----
-"@ponder/core": patch
----
-
-Set minThreads explicitly in vite configuration

--- a/.changeset/light-vans-double.md
+++ b/.changeset/light-vans-double.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Set minThreads explicitly in vite configuration

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     poolOptions: {
       threads: {
         maxThreads: 4,
+        minThreads: 1,
       },
     },
     sequence: { hooks: "stack" },


### PR DESCRIPTION
On machines with alot of cores minThreads was defaulting to a value larger than maxThreads causing an issue with test setup