### PR TITLE
fix: metrics endpoint crashes when it 404s

### DIFF
--- a/.changeset/strong-oranges-change.md
+++ b/.changeset/strong-oranges-change.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where malformed requests to the `/metrics` path could cause the process to exit.

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -120,6 +120,7 @@ export class ServerService {
     return async (req, res) => {
       if (req.method !== "GET" && req.method !== "POST") {
         res.status(404).end();
+        return;
       }
 
       try {


### PR DESCRIPTION
the metrics endpoint will crash the process when it 404s because `end` is called multiple times.

<img width="741" alt="Screen Shot 2024-03-29 at 9 39 10 AM" src="https://github.com/ponder-sh/ponder/assets/3744812/741bd305-3915-447a-93d9-17a01991e099">
