### PR TITLE
Use inner join in the getLogEvents query

### DIFF
--- a/.changeset/hip-geckos-glow.md
+++ b/.changeset/hip-geckos-glow.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where reorg would occasionally cause the process to exit.

--- a/.changeset/hip-geckos-glow.md
+++ b/.changeset/hip-geckos-glow.md
@@ -2,4 +2,4 @@
 "@ponder/core": patch
 ---
 
-Fixed a bug where reorg would occasionally cause the process to exit.
+Fixed a bug where reorgs would occasionally cause the process to exit.

--- a/packages/core/src/sync-store/postgres/store.ts
+++ b/packages/core/src/sync-store/postgres/store.ts
@@ -832,8 +832,8 @@ export class PostgresSyncStore implements SyncStore {
                 )} )`,
             )
             .selectFrom("logs")
-            .leftJoin("blocks", "blocks.hash", "logs.blockHash")
-            .leftJoin(
+            .innerJoin("blocks", "blocks.hash", "logs.blockHash")
+            .innerJoin(
               "transactions",
               "transactions.hash",
               "logs.transactionHash",

--- a/packages/core/src/sync-store/sqlite/store.ts
+++ b/packages/core/src/sync-store/sqlite/store.ts
@@ -845,8 +845,8 @@ export class SqliteSyncStore implements SyncStore {
                 )} )`,
             )
             .selectFrom("logs")
-            .leftJoin("blocks", "blocks.hash", "logs.blockHash")
-            .leftJoin(
+            .innerJoin("blocks", "blocks.hash", "logs.blockHash")
+            .innerJoin(
               "transactions",
               "transactions.hash",
               "logs.transactionHash",


### PR DESCRIPTION
This ensures all retrieved logs will have a corresponding block and transaction. This sometimes would cause an error in apps when a reorg occurs because the realtime service is not handling all possible states properly. Eventually, the realtime service will be fixed and restore the invariant, but this is a faster fix. 