### PR TITLE
Fix factory logs bug

### DIFF
--- a/.changeset/red-deers-care.md
+++ b/.changeset/red-deers-care.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where logs for factory contracts would sometimes be fetched twice. This caused an error for some projects using factory contracts.

--- a/packages/core/src/sync-historical/service.test.ts
+++ b/packages/core/src/sync-historical/service.test.ts
@@ -114,7 +114,8 @@ test("start() with factory contract inserts child contract addresses", async (co
   const iterator = syncStore.getFactoryChildAddresses({
     chainId: sources[1].chainId,
     factory: sources[1].criteria,
-    upToBlockNumber: BigInt(blockNumbers.finalizedBlockNumber),
+    fromBlock: BigInt(sources[1].startBlock),
+    toBlock: BigInt(blockNumbers.finalizedBlockNumber),
   });
 
   const childContractAddresses = [];

--- a/packages/core/src/sync-historical/service.ts
+++ b/packages/core/src/sync-historical/service.ts
@@ -659,7 +659,8 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     const iterator = this.syncStore.getFactoryChildAddresses({
       chainId: factory.chainId,
       factory: factory.criteria,
-      upToBlockNumber: BigInt(toBlock),
+      fromBlock: BigInt(factory.startBlock),
+      toBlock: BigInt(toBlock),
     });
 
     const logs: RpcLog[] = [];

--- a/packages/core/src/sync-realtime/service.test.ts
+++ b/packages/core/src/sync-realtime/service.test.ts
@@ -350,7 +350,8 @@ test("start() sync realtime data with factory sources", async (context) => {
   const iterator = syncStore.getFactoryChildAddresses({
     chainId: sources[1].chainId,
     factory: sources[1].criteria,
-    upToBlockNumber: BigInt(4),
+    fromBlock: BigInt(sources[1].startBlock),
+    toBlock: BigInt(4),
   });
 
   const childContractAddresses = [];

--- a/packages/core/src/sync-realtime/service.ts
+++ b/packages/core/src/sync-realtime/service.ts
@@ -847,7 +847,8 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
           const iterator = this.syncStore.getFactoryChildAddresses({
             chainId: this.network.chainId,
             factory: factory.criteria,
-            upToBlockNumber: toBlockNumber,
+            fromBlock: BigInt(factory.startBlock),
+            toBlock: toBlockNumber,
           });
           const childContractAddresses: Address[] = [];
           for await (const batch of iterator) {

--- a/packages/core/src/sync-store/postgres/store.ts
+++ b/packages/core/src/sync-store/postgres/store.ts
@@ -270,32 +270,28 @@ export class PostgresSyncStore implements SyncStore {
       .where("address", "=", address)
       .where("topic0", "=", eventSelector)
       .where("blockNumber", "<=", upToBlockNumber)
+      .orderBy("blockNumber", "asc")
       .limit(pageSize);
 
     let cursor: bigint | undefined = undefined;
 
     while (true) {
       let query = baseQuery;
-
-      if (cursor) {
-        query = query.where("blockNumber", ">", cursor);
-      }
+      if (cursor !== undefined) query = query.where("blockNumber", ">", cursor);
 
       const batch = await this.db.wrap(
         { method: "getFactoryChildAddresses" },
         () => query.execute(),
       );
 
-      const lastRow = batch[batch.length - 1];
-      if (lastRow) {
-        cursor = lastRow.blockNumber;
-      }
-
       if (batch.length > 0) {
         yield batch.map((a) => a.childAddress);
       }
 
+      // If the batch is less than the page size, there are no more pages.
       if (batch.length < pageSize) break;
+      // Otherwise, set the cursor to the last block number in the batch.
+      cursor = batch[batch.length - 1].blockNumber;
     }
   }
 
@@ -342,6 +338,10 @@ export class PostgresSyncStore implements SyncStore {
               chainId,
               checkpoint: this.createCheckpoint(rpcLog, rpcBlock, chainId),
             }));
+
+            // console.log(rpcLogs);
+            // console.log(logs.map((l) => l.id));
+
             await tx
               .insertInto("logs")
               .values(logs)

--- a/packages/core/src/sync-store/sqlite/store.ts
+++ b/packages/core/src/sync-store/sqlite/store.ts
@@ -36,7 +36,6 @@ import {
   checksumAddress,
 } from "viem";
 import type { SyncStore } from "../store.js";
-import type { BigIntText } from "./encoding.js";
 import {
   type SyncStoreTables,
   rpcToSqliteBlock,
@@ -254,12 +253,14 @@ export class SqliteSyncStore implements SyncStore {
 
   async *getFactoryChildAddresses({
     chainId,
-    upToBlockNumber,
+    fromBlock,
+    toBlock,
     factory,
     pageSize = 500,
   }: {
     chainId: number;
-    upToBlockNumber: bigint;
+    fromBlock: bigint;
+    toBlock: bigint;
     factory: FactoryCriteria;
     pageSize?: number;
   }) {
@@ -269,19 +270,20 @@ export class SqliteSyncStore implements SyncStore {
 
     const baseQuery = this.db
       .selectFrom("logs")
-      .select([selectChildAddressExpression.as("childAddress"), "blockNumber"])
+      .select(["id", selectChildAddressExpression.as("childAddress")])
       .where("chainId", "=", chainId)
       .where("address", "=", address)
       .where("topic0", "=", eventSelector)
-      .where("blockNumber", "<=", encodeAsText(upToBlockNumber))
-      .orderBy("blockNumber", "asc")
+      .where("blockNumber", ">=", encodeAsText(fromBlock))
+      .where("blockNumber", "<=", encodeAsText(toBlock))
+      .orderBy("id", "asc")
       .limit(pageSize);
 
-    let cursor: BigIntText | undefined = undefined;
+    let cursor: string | undefined = undefined;
 
     while (true) {
       let query = baseQuery;
-      if (cursor !== undefined) query = query.where("blockNumber", ">", cursor);
+      if (cursor !== undefined) query = query.where("id", ">", cursor);
 
       const batch = await this.db.wrap(
         { method: "getFactoryChildAddresses" },
@@ -295,7 +297,7 @@ export class SqliteSyncStore implements SyncStore {
       // If the batch is less than the page size, there are no more pages.
       if (batch.length < pageSize) break;
       // Otherwise, set the cursor to the last block number in the batch.
-      cursor = batch[batch.length - 1].blockNumber;
+      cursor = batch[batch.length - 1].id;
     }
   }
 

--- a/packages/core/src/sync-store/store.test.ts
+++ b/packages/core/src/sync-store/store.test.ts
@@ -460,7 +460,8 @@ test("getFactoryChildAddresses gets child addresses for topic location", async (
   let iterator = syncStore.getFactoryChildAddresses({
     chainId: 1,
     factory: factoryCriteria,
-    upToBlockNumber: 150n,
+    fromBlock: 0n,
+    toBlock: 150n,
   });
 
   let results = [];
@@ -474,7 +475,8 @@ test("getFactoryChildAddresses gets child addresses for topic location", async (
   iterator = syncStore.getFactoryChildAddresses({
     chainId: 1,
     factory: { ...factoryCriteria, childAddressLocation: "topic2" },
-    upToBlockNumber: 150n,
+    fromBlock: 0n,
+    toBlock: 150n,
   });
 
   results = [];
@@ -527,7 +529,8 @@ test("getFactoryChildAddresses gets child addresses for offset location", async 
   const iterator = syncStore.getFactoryChildAddresses({
     chainId: 1,
     factory: factoryCriteria,
-    upToBlockNumber: 150n,
+    fromBlock: 0n,
+    toBlock: 150n,
   });
 
   const results = [];
@@ -540,7 +543,7 @@ test("getFactoryChildAddresses gets child addresses for offset location", async 
   await cleanup();
 });
 
-test("getFactoryChildAddresses respects upToBlockNumber argument", async (context) => {
+test("getFactoryChildAddresses respects toBlock argument", async (context) => {
   const { sources } = context;
   const { syncStore, cleanup } = await setupDatabaseServices(context);
   const rpcData = await getRawRPCData(sources);
@@ -580,7 +583,8 @@ test("getFactoryChildAddresses respects upToBlockNumber argument", async (contex
   let iterator = syncStore.getFactoryChildAddresses({
     chainId: 1,
     factory: factoryCriteria,
-    upToBlockNumber: 150n,
+    fromBlock: 0n,
+    toBlock: 150n,
   });
 
   let results = [];
@@ -591,7 +595,8 @@ test("getFactoryChildAddresses respects upToBlockNumber argument", async (contex
   iterator = syncStore.getFactoryChildAddresses({
     chainId: 1,
     factory: factoryCriteria,
-    upToBlockNumber: 250n,
+    fromBlock: 0n,
+    toBlock: 250n,
   });
 
   results = [];
@@ -620,50 +625,79 @@ test("getFactoryChildAddresses paginates correctly", async (context) => {
   await syncStore.insertFactoryChildAddressLogs({
     chainId: 1,
     logs: [
+      // Include one log that doesn't match the factory criteria.
+      {
+        ...rpcData.block1.logs[0],
+        blockNumber: toHex(150),
+        blockHash:
+          "0x000000000000000000000000child80000000000000000000000000000000000",
+        logIndex: "0x8",
+        address: "0xfactory",
+        topics: [
+          "0x0000000000000000000000000000000000000000000factoryeventsignaturf",
+          "0x000000000000000000000000child80000000000000000000000000000000000",
+        ],
+      },
       {
         ...rpcData.block1.logs[1],
+        blockNumber: toHex(200),
+        blockHash:
+          "0x000000000000000000000000child20000000000000000000000000000000000",
+        logIndex: "0x2",
         address: "0xfactory",
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child20000000000000000000000000000000000",
         ],
-        blockNumber: toHex(200),
       },
+      // Include two logs in the same block.
       {
         ...rpcData.block1.logs[1],
+        blockNumber: toHex(201),
+        blockHash:
+          "0x000000000000000000000000child30000000000000000000000000000000000",
+        logIndex: "0x3",
         address: "0xfactory",
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child30000000000000000000000000000000000",
         ],
-        blockNumber: toHex(201),
-      },
-      {
-        ...rpcData.block1.logs[0],
-        address: "0xfactory",
-        topics: [
-          "0x0000000000000000000000000000000000000000000factoryeventsignature",
-          "0x000000000000000000000000child10000000000000000000000000000000000",
-        ],
-        blockNumber: toHex(100),
       },
       {
         ...rpcData.block1.logs[1],
+        blockNumber: toHex(201),
+        blockHash:
+          "0x000000000000000000000000child30000000000000000000000000000000000",
+        logIndex: "0x4",
         address: "0xfactory",
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child40000000000000000000000000000000000",
         ],
-        blockNumber: toHex(202),
+      },
+      {
+        ...rpcData.block1.logs[0],
+        blockNumber: toHex(100),
+        blockHash:
+          "0x000000000000000000000000child10000000000000000000000000000000000",
+        logIndex: "0x1",
+        address: "0xfactory",
+        topics: [
+          "0x0000000000000000000000000000000000000000000factoryeventsignature",
+          "0x000000000000000000000000child10000000000000000000000000000000000",
+        ],
       },
       {
         ...rpcData.block1.logs[1],
+        blockNumber: toHex(203),
+        blockHash:
+          "0x000000000000000000000000child50000000000000000000000000000000000",
+        logIndex: "0x5",
         address: "0xfactory",
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child50000000000000000000000000000000000",
         ],
-        blockNumber: toHex(203),
       },
     ],
   });
@@ -671,30 +705,23 @@ test("getFactoryChildAddresses paginates correctly", async (context) => {
   const iterator = syncStore.getFactoryChildAddresses({
     chainId: 1,
     factory: factoryCriteria,
-    upToBlockNumber: 1000n,
+    fromBlock: 0n,
+    toBlock: 1000n,
     pageSize: 2,
   });
 
-  let idx = 0;
-  for await (const page of iterator) {
-    if (idx === 0)
-      expect(page).toMatchObject([
-        "0xchild10000000000000000000000000000000000",
-        "0xchild20000000000000000000000000000000000",
-      ]);
-    if (idx === 1)
-      expect(page).toMatchObject([
-        "0xchild30000000000000000000000000000000000",
-        "0xchild40000000000000000000000000000000000",
-      ]);
-    if (idx === 2) {
-      expect(page).toMatchObject([
-        "0xchild50000000000000000000000000000000000",
-      ]);
-      expect((await iterator.next()).done).toBe(true);
-    }
-    idx++;
-  }
+  const results = [];
+  for await (const page of iterator) results.push(...page);
+  expect(results.sort()).toMatchObject(
+    [
+      "0xchild10000000000000000000000000000000000",
+      "0xchild20000000000000000000000000000000000",
+      "0xchild30000000000000000000000000000000000",
+      "0xchild40000000000000000000000000000000000",
+      "0xchild50000000000000000000000000000000000",
+    ].sort(),
+  );
+
   await cleanup();
 });
 
@@ -712,7 +739,8 @@ test("getFactoryChildAddresses does not yield empty list", async (context) => {
   const iterator = syncStore.getFactoryChildAddresses({
     chainId: 1,
     factory: factoryCriteria,
-    upToBlockNumber: 1000n,
+    fromBlock: 0n,
+    toBlock: 1000n,
   });
 
   let didYield = false;

--- a/packages/core/src/sync-store/store.test.ts
+++ b/packages/core/src/sync-store/store.test.ts
@@ -621,15 +621,6 @@ test("getFactoryChildAddresses paginates correctly", async (context) => {
     chainId: 1,
     logs: [
       {
-        ...rpcData.block1.logs[0],
-        address: "0xfactory",
-        topics: [
-          "0x0000000000000000000000000000000000000000000factoryeventsignature",
-          "0x000000000000000000000000child10000000000000000000000000000000000",
-        ],
-        blockNumber: toHex(100),
-      },
-      {
         ...rpcData.block1.logs[1],
         address: "0xfactory",
         topics: [
@@ -647,6 +638,33 @@ test("getFactoryChildAddresses paginates correctly", async (context) => {
         ],
         blockNumber: toHex(201),
       },
+      {
+        ...rpcData.block1.logs[0],
+        address: "0xfactory",
+        topics: [
+          "0x0000000000000000000000000000000000000000000factoryeventsignature",
+          "0x000000000000000000000000child10000000000000000000000000000000000",
+        ],
+        blockNumber: toHex(100),
+      },
+      {
+        ...rpcData.block1.logs[1],
+        address: "0xfactory",
+        topics: [
+          "0x0000000000000000000000000000000000000000000factoryeventsignature",
+          "0x000000000000000000000000child40000000000000000000000000000000000",
+        ],
+        blockNumber: toHex(202),
+      },
+      {
+        ...rpcData.block1.logs[1],
+        address: "0xfactory",
+        topics: [
+          "0x0000000000000000000000000000000000000000000factoryeventsignature",
+          "0x000000000000000000000000child50000000000000000000000000000000000",
+        ],
+        blockNumber: toHex(203),
+      },
     ],
   });
 
@@ -654,7 +672,7 @@ test("getFactoryChildAddresses paginates correctly", async (context) => {
     chainId: 1,
     factory: factoryCriteria,
     upToBlockNumber: 1000n,
-    pageSize: 1,
+    pageSize: 2,
   });
 
   let idx = 0;
@@ -662,14 +680,16 @@ test("getFactoryChildAddresses paginates correctly", async (context) => {
     if (idx === 0)
       expect(page).toMatchObject([
         "0xchild10000000000000000000000000000000000",
+        "0xchild20000000000000000000000000000000000",
       ]);
     if (idx === 1)
       expect(page).toMatchObject([
-        "0xchild20000000000000000000000000000000000",
+        "0xchild30000000000000000000000000000000000",
+        "0xchild40000000000000000000000000000000000",
       ]);
     if (idx === 2) {
       expect(page).toMatchObject([
-        "0xchild30000000000000000000000000000000000",
+        "0xchild50000000000000000000000000000000000",
       ]);
       expect((await iterator.next()).done).toBe(true);
     }

--- a/packages/core/src/sync-store/store.ts
+++ b/packages/core/src/sync-store/store.ts
@@ -68,7 +68,8 @@ export interface SyncStore {
   getFactoryChildAddresses(options: {
     chainId: number;
     factory: FactoryCriteria;
-    upToBlockNumber: bigint;
+    fromBlock: bigint;
+    toBlock: bigint;
     pageSize?: number;
   }): AsyncGenerator<Address[]>;
 


### PR DESCRIPTION
This PR fixes a bug in the internal `getFactoryChildAddresses` method. Previously, the method attempted to paginate on `blockNumber` without setting an `ORDER BY` on that field, leading to duplicate results. This bug went undetected for quite some time, and only caused an actual error in `0.4` when we began inserting logs in bulk during the historical sync, because the bulk upsert query we are now using throws an error if you attempt to insert two logs with the same ID in the same batch.