### PR TITLE
Add retry range detection for blast api

### DIFF
--- a/.changeset/happy-suits-report.md
+++ b/.changeset/happy-suits-report.md
@@ -1,0 +1,5 @@
+---
+"@ponder/utils": patch
+---
+
+Added automatic eth_getLogs retry range detection for the paid version of blast API.

--- a/packages/utils/src/getLogsRetryHelper.ts
+++ b/packages/utils/src/getLogsRetryHelper.ts
@@ -241,6 +241,23 @@ export const getLogsRetryHelper = ({
     } as const;
   }
 
+  // blast (paid)
+  match = sError.match(
+    /exceeds the range allowed for your plan \(\d+ > (\d+)\)/,
+  );
+  if (match !== null) {
+    const ranges = chunk({ params, range: BigInt(match[1]!) });
+
+    if (isRangeUnchanged(params, ranges)) {
+      return { shouldRetry: false } as const;
+    }
+
+    return {
+      shouldRetry: true,
+      ranges,
+    } as const;
+  }
+
   // No match found
   return {
     shouldRetry: false,


### PR DESCRIPTION
Important to note this is for https://blastapi.io and not Blast, the L2 with native yield (backed but not endorsed by Paradigm).