### PR TITLE
Optimized Historical Indexing

### DIFF
--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -15,7 +15,9 @@ import { PostgresDatabaseService } from "@/database/postgres/service.js";
 import type { DatabaseService, NamespaceInfo } from "@/database/service.js";
 import { SqliteDatabaseService } from "@/database/sqlite/service.js";
 import { createSchema } from "@/index.js";
-import { RealtimeIndexingStore } from "@/indexing-store/realtimeStore.js";
+import { getHistoricalIndexingStore } from "@/indexing-store/historicalStore.js";
+import { getReadIndexingStore } from "@/indexing-store/readStore.js";
+import { getRealtimeIndexingStore } from "@/indexing-store/realtimeStore.js";
 import type { IndexingStore } from "@/indexing-store/store.js";
 import { PostgresSyncStore } from "@/sync-store/postgres/store.js";
 import { SqliteSyncStore } from "@/sync-store/sqlite/store.js";
@@ -136,12 +138,27 @@ export async function setupDatabaseServices(
 
     await database.migrateSyncStore();
 
-    const indexingStore = new RealtimeIndexingStore({
-      kind: "sqlite",
-      schema: config.schema,
-      namespaceInfo: result.namespaceInfo,
-      db: database.indexingDb,
-    });
+    const indexingStore = {
+      ...getReadIndexingStore({
+        kind: "sqlite",
+        schema: config.schema,
+        namespaceInfo: result.namespaceInfo,
+        db: database.indexingDb,
+      }),
+      ...(config.indexing === "historical"
+        ? getHistoricalIndexingStore({
+            kind: "sqlite",
+            schema: config.schema,
+            namespaceInfo: result.namespaceInfo,
+            db: database.indexingDb,
+          })
+        : getRealtimeIndexingStore({
+            kind: "sqlite",
+            schema: config.schema,
+            namespaceInfo: result.namespaceInfo,
+            db: database.indexingDb,
+          })),
+    };
 
     const syncStore = new SqliteSyncStore({ db: database.syncDb });
 
@@ -165,12 +182,27 @@ export async function setupDatabaseServices(
 
     await database.migrateSyncStore();
 
-    const indexingStore = new RealtimeIndexingStore({
-      kind: "postgres",
-      schema: config.schema,
-      namespaceInfo: result.namespaceInfo,
-      db: database.indexingDb,
-    });
+    const indexingStore = {
+      ...getReadIndexingStore({
+        kind: "postgres",
+        schema: config.schema,
+        namespaceInfo: result.namespaceInfo,
+        db: database.indexingDb,
+      }),
+      ...(config.indexing === "historical"
+        ? getHistoricalIndexingStore({
+            kind: "postgres",
+            schema: config.schema,
+            namespaceInfo: result.namespaceInfo,
+            db: database.indexingDb,
+          })
+        : getRealtimeIndexingStore({
+            kind: "postgres",
+            schema: config.schema,
+            namespaceInfo: result.namespaceInfo,
+            db: database.indexingDb,
+          })),
+    };
 
     const syncStore = new PostgresSyncStore({ db: database.syncDb });
 

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -134,7 +134,7 @@ export const getNetworkAndSources = async (
 
   const requestQueue = createRequestQueue({
     network: networks[0],
-    metrics: common.metrics,
+    common,
   });
 
   return { networks: [mainnet], sources, requestQueues: [requestQueue] };

--- a/packages/core/src/bin/commands/serve.ts
+++ b/packages/core/src/bin/commands/serve.ts
@@ -6,7 +6,7 @@ import { buildOptions } from "@/common/options.js";
 import { buildPayload, createTelemetry } from "@/common/telemetry.js";
 import { PostgresDatabaseService } from "@/database/postgres/service.js";
 import type { NamespaceInfo } from "@/database/service.js";
-import { RealtimeIndexingStore } from "@/indexing-store/realtimeStore.js";
+import { getReadIndexingStore } from "@/indexing-store/readStore.js";
 import { createServer } from "@/server/service.js";
 import type { CliOptions } from "../ponder.js";
 import { setupShutdown } from "../utils/shutdown.js";
@@ -89,7 +89,7 @@ export async function serve({ cliOptions }: { cliOptions: CliOptions }) {
     userNamespace,
   });
 
-  const indexingStore = new RealtimeIndexingStore({
+  const indexingStore = getReadIndexingStore({
     kind: "postgres",
     schema,
     // Note: `ponder serve` serves data from the `publishSchema`. Also, it does

--- a/packages/core/src/bin/utils/run.test.ts
+++ b/packages/core/src/bin/utils/run.test.ts
@@ -109,7 +109,7 @@ test("run() setup error", async (context) => {
 
   await onReloadableErrorPromiseResolver.promise;
 
-  expect(indexingFunctions["Erc20:setup"]).toHaveBeenCalledTimes(4);
+  expect(indexingFunctions["Erc20:setup"]).toHaveBeenCalledTimes(1);
 
   await kill();
 });

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -4,7 +4,10 @@ import type { Common } from "@/common/common.js";
 import { PostgresDatabaseService } from "@/database/postgres/service.js";
 import type { DatabaseService, NamespaceInfo } from "@/database/service.js";
 import { SqliteDatabaseService } from "@/database/sqlite/service.js";
-import { RealtimeIndexingStore } from "@/indexing-store/realtimeStore.js";
+import { getHistoricalIndexingStore } from "@/indexing-store/historicalStore.js";
+import { getReadIndexingStore } from "@/indexing-store/readStore.js";
+import { getRealtimeIndexingStore } from "@/indexing-store/realtimeStore.js";
+import type { IndexingStore } from "@/indexing-store/store.js";
 import { createIndexingService } from "@/indexing/index.js";
 import { createServer } from "@/server/service.js";
 import { PostgresSyncStore } from "@/sync-store/postgres/store.js";
@@ -78,12 +81,20 @@ export async function run({
     syncStore = new PostgresSyncStore({ db: database.syncDb });
   }
 
-  const indexingStore = new RealtimeIndexingStore({
-    kind: database.kind,
-    schema,
-    namespaceInfo,
-    db: database.indexingDb,
-  });
+  let indexingStore: IndexingStore = {
+    ...getReadIndexingStore({
+      kind: database.kind,
+      schema,
+      namespaceInfo,
+      db: database.indexingDb,
+    }),
+    ...getHistoricalIndexingStore({
+      kind: database.kind,
+      schema,
+      namespaceInfo,
+      db: database.indexingDb,
+    }),
+  };
 
   const server = await createServer({ common, graphqlSchema, indexingStore });
 
@@ -119,9 +130,9 @@ export async function run({
   };
 
   const handleReorg = async (safeCheckpoint: Checkpoint) => {
-    await indexingStore.revert({
+    await database.revert({
       checkpoint: safeCheckpoint,
-      isCheckpointSafe: true,
+      namespaceInfo,
     });
   };
 
@@ -149,7 +160,7 @@ export async function run({
     },
   });
 
-  const indexingService = createIndexingService({
+  let indexingService = createIndexingService({
     indexingFunctions,
     common,
     indexingStore,
@@ -203,6 +214,31 @@ export async function run({
     common.logger.info({
       service: "server",
       msg: "Started responding as healthy",
+    });
+
+    indexingStore = {
+      ...getReadIndexingStore({
+        kind: database.kind,
+        schema,
+        namespaceInfo,
+        db: database.indexingDb,
+      }),
+      ...getRealtimeIndexingStore({
+        kind: database.kind,
+        schema,
+        namespaceInfo,
+        db: database.indexingDb,
+      }),
+    };
+
+    indexingService = createIndexingService({
+      indexingFunctions,
+      common,
+      indexingStore,
+      sources,
+      networks,
+      syncService,
+      schema,
     });
 
     syncService.startRealtime();

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -120,6 +120,7 @@ export async function getRpcUrlsForClient(parameters: {
   const { config, value } = parameters.transport({
     chain: parameters.chain,
     pollingInterval: 4_000, // default viem value
+    retryCount: 0,
   });
   const transport = { ...config, ...value } as Client["transport"];
 

--- a/packages/core/src/database/postgres/service.ts
+++ b/packages/core/src/database/postgres/service.ts
@@ -7,7 +7,11 @@ import {
   migrationProvider as syncMigrationProvider,
   moveLegacyTables,
 } from "@/sync-store/postgres/migrations.js";
-import { encodeCheckpoint, zeroCheckpoint } from "@/utils/checkpoint.js";
+import {
+  type Checkpoint,
+  encodeCheckpoint,
+  zeroCheckpoint,
+} from "@/utils/checkpoint.js";
 import { formatEta } from "@/utils/format.js";
 import { hash } from "@/utils/hash.js";
 import { createPool } from "@/utils/pg.js";
@@ -23,6 +27,7 @@ import {
 import type { Pool, PoolConfig } from "pg";
 import prometheus from "prom-client";
 import { HeadlessKysely } from "../kysely.js";
+import { revertIndexingTables } from "../revert.js";
 import type { BaseDatabaseService, NamespaceInfo } from "../service.js";
 import { type InternalTables, migrationProvider } from "./migrations.js";
 
@@ -40,7 +45,7 @@ export class PostgresDatabaseService implements BaseDatabaseService {
   private publishSchema?: string | undefined;
 
   db: HeadlessKysely<InternalTables>;
-  indexingDb: HeadlessKysely<InternalTables>;
+  indexingDb: HeadlessKysely<any>;
   syncDb: HeadlessKysely<SyncStoreTables>;
 
   private schema: Schema = null!;
@@ -336,6 +341,20 @@ export class PostgresDatabaseService implements BaseDatabaseService {
       }, HEARTBEAT_INTERVAL_MS);
 
       return { checkpoint, namespaceInfo };
+    });
+  }
+
+  async revert({
+    checkpoint,
+    namespaceInfo,
+  }: {
+    checkpoint: Checkpoint;
+    namespaceInfo: NamespaceInfo;
+  }) {
+    await revertIndexingTables({
+      db: this.indexingDb,
+      checkpoint,
+      namespaceInfo,
     });
   }
 

--- a/packages/core/src/database/revert.test.ts
+++ b/packages/core/src/database/revert.test.ts
@@ -1,4 +1,8 @@
-import { setupDatabaseServices, setupIsolatedDatabase } from "@/_test/setup.js";
+import {
+  setupCommon,
+  setupDatabaseServices,
+  setupIsolatedDatabase,
+} from "@/_test/setup.js";
 import { createSchema } from "@/schema/schema.js";
 import {
   type Checkpoint,
@@ -8,6 +12,7 @@ import {
 import { hash } from "@/utils/hash.js";
 import { beforeEach, expect, test } from "vitest";
 
+beforeEach(setupCommon);
 beforeEach(setupIsolatedDatabase);
 
 const schema = createSchema((p) => ({

--- a/packages/core/src/database/revert.test.ts
+++ b/packages/core/src/database/revert.test.ts
@@ -1,0 +1,149 @@
+import { setupDatabaseServices, setupIsolatedDatabase } from "@/_test/setup.js";
+import { createSchema } from "@/schema/schema.js";
+import {
+  type Checkpoint,
+  encodeCheckpoint,
+  zeroCheckpoint,
+} from "@/utils/checkpoint.js";
+import { hash } from "@/utils/hash.js";
+import { beforeEach, expect, test } from "vitest";
+
+beforeEach(setupIsolatedDatabase);
+
+const schema = createSchema((p) => ({
+  PetKind: p.createEnum(["CAT", "DOG"]),
+  Pet: p.createTable({
+    id: p.string(),
+    name: p.string(),
+    age: p.int().optional(),
+    bigAge: p.bigint().optional(),
+    kind: p.enum("PetKind").optional(),
+    rating: p.float().optional(),
+  }),
+  Person: p.createTable({
+    id: p.string(),
+    name: p.string(),
+  }),
+}));
+
+function createCheckpoint(index: number): Checkpoint {
+  return { ...zeroCheckpoint, blockTimestamp: index };
+}
+
+function calculateLogTableName(tableName: string) {
+  return hash(["public", "test", tableName]);
+}
+
+test("revert() deletes versions newer than the safe timestamp", async (context) => {
+  const { indexingStore, database, namespaceInfo, cleanup } =
+    await setupDatabaseServices(context, { schema, indexing: "realtime" });
+
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id1",
+    data: { name: "Skip" },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(13)),
+    id: "id2",
+    data: { name: "Foo" },
+  });
+  await indexingStore.update({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(15)),
+    id: "id1",
+    data: { name: "SkipUpdated" },
+  });
+  await indexingStore.create({
+    tableName: "Person",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id1",
+    data: { name: "Bob" },
+  });
+  await indexingStore.update({
+    tableName: "Person",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(11)),
+    id: "id1",
+    data: { name: "Bobby" },
+  });
+  await indexingStore.create({
+    tableName: "Person",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(12)),
+    id: "id2",
+    data: { name: "Kevin" },
+  });
+
+  await database.revert({
+    checkpoint: createCheckpoint(12),
+    namespaceInfo,
+  });
+
+  const { items: pets } = await indexingStore.findMany({ tableName: "Pet" });
+
+  expect(pets.length).toBe(1);
+  expect(pets[0].name).toBe("Skip");
+
+  const { items: persons } = await indexingStore.findMany({
+    tableName: "Person",
+  });
+
+  expect(persons.length).toBe(2);
+  expect(persons[0].name).toBe("Bobby");
+  expect(persons[1].name).toBe("Kevin");
+
+  const PetLogs = await database.indexingDb
+    .withSchema(namespaceInfo.internalNamespace)
+    .selectFrom(calculateLogTableName("Pet"))
+    .selectAll()
+    .execute();
+
+  expect(PetLogs).toHaveLength(1);
+
+  const PersonLogs = await database.indexingDb
+    .withSchema(namespaceInfo.internalNamespace)
+    .selectFrom(calculateLogTableName("Person"))
+    .selectAll()
+    .execute();
+  expect(PersonLogs).toHaveLength(3);
+
+  await cleanup();
+});
+
+test("revert() updates versions with intermediate logs", async (context) => {
+  const { indexingStore, database, namespaceInfo, cleanup } =
+    await setupDatabaseServices(context, { schema, indexing: "realtime" });
+
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(9)),
+    id: "id1",
+    data: { name: "Skip" },
+  });
+  await indexingStore.delete({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id1",
+  });
+
+  await database.revert({
+    checkpoint: createCheckpoint(8),
+    namespaceInfo,
+  });
+
+  const instancePet = await indexingStore.findUnique({
+    tableName: "Pet",
+    id: "id1",
+  });
+  expect(instancePet).toBe(null);
+
+  const PetLogs = await database.indexingDb
+    .withSchema(namespaceInfo.internalNamespace)
+    .selectFrom(calculateLogTableName("Pet"))
+    .selectAll()
+    .execute();
+  expect(PetLogs).toHaveLength(0);
+
+  await cleanup();
+});

--- a/packages/core/src/database/revert.ts
+++ b/packages/core/src/database/revert.ts
@@ -1,0 +1,71 @@
+import { type Checkpoint, encodeCheckpoint } from "@/utils/checkpoint.js";
+import type { HeadlessKysely } from "./kysely.js";
+import type { NamespaceInfo } from "./service.js";
+
+export const revertIndexingTables = async ({
+  checkpoint,
+  namespaceInfo,
+  db,
+}: {
+  namespaceInfo: NamespaceInfo;
+  db: HeadlessKysely<any>;
+  checkpoint: Checkpoint;
+}) => {
+  await db.wrap({ method: "revert" }, async () => {
+    const encodedCheckpoint = encodeCheckpoint(checkpoint);
+
+    await Promise.all(
+      Object.entries(namespaceInfo.internalTableIds).map(
+        async ([tableName, tableId]) => {
+          await db.transaction().execute(async (tx) => {
+            const rows = await tx
+              .withSchema(namespaceInfo.internalNamespace)
+              .deleteFrom(tableId)
+              .returningAll()
+              .where("checkpoint", ">", encodedCheckpoint)
+              .execute();
+
+            const reversed = rows.sort(
+              (a, b) => b.operation_id - a.operation_id,
+            );
+
+            // undo operation
+            for (const log of reversed) {
+              if (log.operation === 0) {
+                // create
+                await tx
+                  .withSchema(namespaceInfo.userNamespace)
+                  .deleteFrom(tableName)
+                  .where("id", "=", log.id)
+                  .execute();
+              } else if (log.operation === 1) {
+                // update
+                log.operation_id = undefined;
+                log.checkpoint = undefined;
+                log.operation = undefined;
+
+                await tx
+                  .withSchema(namespaceInfo.userNamespace)
+                  .updateTable(tableName)
+                  .set(log)
+                  .where("id", "=", log.id)
+                  .execute();
+              } else {
+                // delete
+                log.operation_id = undefined;
+                log.checkpoint = undefined;
+                log.operation = undefined;
+
+                await tx
+                  .withSchema(namespaceInfo.userNamespace)
+                  .insertInto(tableName)
+                  .values(log)
+                  .execute();
+              }
+            }
+          });
+        },
+      ),
+    );
+  });
+};

--- a/packages/core/src/database/service.ts
+++ b/packages/core/src/database/service.ts
@@ -25,5 +25,13 @@ export interface BaseDatabaseService {
     namespaceInfo: NamespaceInfo;
   }>;
 
+  revert({
+    checkpoint,
+    namespaceInfo,
+  }: {
+    checkpoint: Checkpoint;
+    namespaceInfo: NamespaceInfo;
+  }): Promise<void>;
+
   kill(): Promise<void>;
 }

--- a/packages/core/src/indexing-store/historicalStore.test.ts
+++ b/packages/core/src/indexing-store/historicalStore.test.ts
@@ -9,7 +9,6 @@ import {
   encodeCheckpoint,
   zeroCheckpoint,
 } from "@/utils/checkpoint.js";
-import { hash } from "@/utils/hash.js";
 import { beforeEach, expect, test } from "vitest";
 
 beforeEach(setupCommon);
@@ -42,14 +41,9 @@ function createCheckpoint(index: number): Checkpoint {
   return { ...zeroCheckpoint, blockTimestamp: index };
 }
 
-function calculateLogTableName(tableName: string) {
-  return hash(["public", "test", tableName]);
-}
-
 test("create() inserts a record", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -71,7 +65,6 @@ test("create() inserts a record", async (context) => {
 test("create() throws on unique constraint violation", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -98,7 +91,6 @@ test("create() throws on unique constraint violation", async (context) => {
 test("create() respects optional fields", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -121,7 +113,6 @@ test("create() respects optional fields", async (context) => {
 test("create() accepts enums", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -144,7 +135,6 @@ test("create() accepts enums", async (context) => {
 test("create() throws on invalid enum value", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await expect(() =>
@@ -162,7 +152,6 @@ test("create() throws on invalid enum value", async (context) => {
 test("create() accepts BigInt fields as bigint and returns as bigint", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -185,7 +174,6 @@ test("create() accepts BigInt fields as bigint and returns as bigint", async (co
 test("create() accepts float fields as float and returns as float", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -205,38 +193,9 @@ test("create() accepts float fields as float and returns as float", async (conte
   await cleanup();
 });
 
-test("create() inserts into the log table", async (context) => {
-  const { indexingStore, database, namespaceInfo, cleanup } =
-    await setupDatabaseServices(context, { schema, indexing: "realtime" });
-
-  await indexingStore.create({
-    tableName: "Pet",
-    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
-    id: "id1",
-    data: { name: "Skip", age: 12 },
-  });
-
-  const logs = await database.indexingDb
-    .withSchema(namespaceInfo.internalNamespace)
-    .selectFrom(calculateLogTableName("Pet"))
-    .selectAll()
-    .execute();
-
-  expect(logs).toMatchObject([
-    {
-      id: "id1",
-      checkpoint: encodeCheckpoint(createCheckpoint(10)),
-      operation: 0,
-    },
-  ]);
-
-  await cleanup();
-});
-
 test("update() updates a record", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -271,7 +230,6 @@ test("update() updates a record", async (context) => {
 test("update() updates a record using an update function", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -308,50 +266,9 @@ test("update() updates a record using an update function", async (context) => {
   await cleanup();
 });
 
-test("update() inserts into the log table", async (context) => {
-  const { indexingStore, database, namespaceInfo, cleanup } =
-    await setupDatabaseServices(context, { schema, indexing: "realtime" });
-
-  await indexingStore.create({
-    tableName: "Pet",
-    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
-    id: "id1",
-    data: { name: "Skip", bigAge: 100n },
-  });
-
-  const instance = await indexingStore.findUnique({
-    tableName: "Pet",
-    id: "id1",
-  });
-  expect(instance).toMatchObject({ id: "id1", name: "Skip", bigAge: 100n });
-
-  await indexingStore.update({
-    tableName: "Pet",
-    encodedCheckpoint: encodeCheckpoint(createCheckpoint(11)),
-    id: "id1",
-    data: { name: "Peanut Butter" },
-  });
-
-  const logs = await database.indexingDb
-    .withSchema(namespaceInfo.internalNamespace)
-    .selectFrom(calculateLogTableName("Pet"))
-    .selectAll()
-    .execute();
-
-  expect(logs).toHaveLength(2);
-  expect(logs[1]).toMatchObject({
-    id: "id1",
-    checkpoint: encodeCheckpoint(createCheckpoint(11)),
-    operation: 1,
-  });
-
-  await cleanup();
-});
-
 test("upsert() inserts a new record", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.upsert({
@@ -373,7 +290,6 @@ test("upsert() inserts a new record", async (context) => {
 test("upsert() updates a record", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -408,7 +324,6 @@ test("upsert() updates a record", async (context) => {
 test("upsert() updates a record using an update function", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -442,50 +357,9 @@ test("upsert() updates a record using an update function", async (context) => {
   await cleanup();
 });
 
-test("upsert() inserts into the log table", async (context) => {
-  const { indexingStore, database, namespaceInfo, cleanup } =
-    await setupDatabaseServices(context, { schema, indexing: "realtime" });
-
-  await indexingStore.create({
-    tableName: "Pet",
-    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
-    id: "id1",
-    data: { name: "Skip", age: 12 },
-  });
-  const instance = await indexingStore.findUnique({
-    tableName: "Pet",
-    id: "id1",
-  });
-  expect(instance).toMatchObject({ id: "id1", name: "Skip", age: 12 });
-
-  await indexingStore.upsert({
-    tableName: "Pet",
-    encodedCheckpoint: encodeCheckpoint(createCheckpoint(12)),
-    id: "id1",
-    create: { name: "Skip", age: 24 },
-    update: { name: "Jelly" },
-  });
-
-  const logs = await database.indexingDb
-    .withSchema(namespaceInfo.internalNamespace)
-    .selectFrom(calculateLogTableName("Pet"))
-    .selectAll()
-    .execute();
-
-  expect(logs).toHaveLength(2);
-  expect(logs[1]).toMatchObject({
-    id: "id1",
-    checkpoint: encodeCheckpoint(createCheckpoint(12)),
-    operation: 1,
-  });
-
-  await cleanup();
-});
-
 test("delete() removes a record", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -515,48 +389,9 @@ test("delete() removes a record", async (context) => {
   await cleanup();
 });
 
-test("delete() inserts into the log table", async (context) => {
-  const { indexingStore, database, namespaceInfo, cleanup } =
-    await setupDatabaseServices(context, { schema, indexing: "realtime" });
-
-  await indexingStore.create({
-    tableName: "Pet",
-    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
-    id: "id1",
-    data: { name: "Skip", age: 12 },
-  });
-  const instance = await indexingStore.findUnique({
-    tableName: "Pet",
-    id: "id1",
-  });
-  expect(instance).toMatchObject({ id: "id1", name: "Skip", age: 12 });
-
-  await indexingStore.delete({
-    tableName: "Pet",
-    encodedCheckpoint: encodeCheckpoint(createCheckpoint(15)),
-    id: "id1",
-  });
-
-  const logs = await database.indexingDb
-    .withSchema(namespaceInfo.internalNamespace)
-    .selectFrom(calculateLogTableName("Pet"))
-    .selectAll()
-    .execute();
-
-  expect(logs).toHaveLength(2);
-  expect(logs[1]).toMatchObject({
-    id: "id1",
-    checkpoint: encodeCheckpoint(createCheckpoint(15)),
-    operation: 2,
-  });
-
-  await cleanup();
-});
-
 test("createMany() inserts multiple entities", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   const createdItems = await indexingStore.createMany({
@@ -579,7 +414,6 @@ test("createMany() inserts multiple entities", async (context) => {
 test("createMany() inserts a large number of entities", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   const RECORD_COUNT = 100_000;
@@ -609,52 +443,9 @@ test("createMany() inserts a large number of entities", async (context) => {
   await cleanup();
 });
 
-test("createMany() inserts into the log table", async (context) => {
-  const { indexingStore, database, namespaceInfo, cleanup } =
-    await setupDatabaseServices(context, { schema, indexing: "realtime" });
-
-  await indexingStore.createMany({
-    tableName: "Pet",
-    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
-    data: [
-      { id: "id1", name: "Skip", bigAge: 105n },
-      { id: "id2", name: "Foo", bigAge: 10n },
-      { id: "id3", name: "Bar", bigAge: 190n },
-    ],
-  });
-
-  const logs = await database.indexingDb
-    .withSchema(namespaceInfo.internalNamespace)
-    .selectFrom(calculateLogTableName("Pet"))
-    .selectAll()
-    .execute();
-
-  expect(logs).toHaveLength(3);
-  expect(logs).toMatchObject([
-    {
-      id: "id1",
-      checkpoint: encodeCheckpoint(createCheckpoint(10)),
-      operation: 0,
-    },
-    {
-      id: "id2",
-      checkpoint: encodeCheckpoint(createCheckpoint(10)),
-      operation: 0,
-    },
-    {
-      id: "id3",
-      checkpoint: encodeCheckpoint(createCheckpoint(10)),
-      operation: 0,
-    },
-  ]);
-
-  await cleanup();
-});
-
 test("updateMany() updates multiple entities", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema,
-    indexing: "realtime",
   });
 
   await indexingStore.createMany({
@@ -683,9 +474,10 @@ test("updateMany() updates multiple entities", async (context) => {
   await cleanup();
 });
 
-test("updateMany() inserts into the log table", async (context) => {
-  const { indexingStore, database, namespaceInfo, cleanup } =
-    await setupDatabaseServices(context, { schema, indexing: "realtime" });
+test("updateMany() updates using a function", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
 
   await indexingStore.createMany({
     tableName: "Pet",
@@ -697,30 +489,18 @@ test("updateMany() inserts into the log table", async (context) => {
     ],
   });
 
-  await indexingStore.updateMany({
+  const updateditems = await indexingStore.updateMany({
     tableName: "Pet",
     encodedCheckpoint: encodeCheckpoint(createCheckpoint(11)),
     where: { bigAge: { gt: 50n } },
-    data: { bigAge: 300n },
+    data: () => ({ bigAge: 300n }),
   });
 
-  const logs = await database.indexingDb
-    .withSchema(namespaceInfo.internalNamespace)
-    .selectFrom(calculateLogTableName("Pet"))
-    .selectAll()
-    .execute();
+  expect(updateditems.length).toBe(2);
 
-  expect(logs).toHaveLength(5);
-  expect(logs[3]).toMatchObject({
-    id: "id1",
-    checkpoint: encodeCheckpoint(createCheckpoint(11)),
-    operation: 1,
-  });
-  expect(logs[4]).toMatchObject({
-    id: "id3",
-    checkpoint: encodeCheckpoint(createCheckpoint(11)),
-    operation: 1,
-  });
+  const { items } = await indexingStore.findMany({ tableName: "Pet" });
+
+  expect(items.map((i) => i.bigAge)).toMatchObject([300n, 10n, 300n]);
 
   await cleanup();
 });
@@ -728,7 +508,6 @@ test("updateMany() inserts into the log table", async (context) => {
 test("update() works with hex case sensitivity", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema: hexSchema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -757,7 +536,6 @@ test("update() works with hex case sensitivity", async (context) => {
 test("updateMany() works with hex case sensitivity", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema: hexSchema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -786,7 +564,6 @@ test("updateMany() works with hex case sensitivity", async (context) => {
 test("upsert() works with hex case sensitivity", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema: hexSchema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({
@@ -800,6 +577,7 @@ test("upsert() works with hex case sensitivity", async (context) => {
     tableName: "table",
     encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
     id: "0xA",
+    create: { n: 0 },
     update: { n: 2 },
   });
 
@@ -815,7 +593,6 @@ test("upsert() works with hex case sensitivity", async (context) => {
 test("delete() works with hex case sensitivity", async (context) => {
   const { indexingStore, cleanup } = await setupDatabaseServices(context, {
     schema: hexSchema,
-    indexing: "realtime",
   });
 
   await indexingStore.create({

--- a/packages/core/src/indexing-store/historicalStore.ts
+++ b/packages/core/src/indexing-store/historicalStore.ts
@@ -1,0 +1,327 @@
+import { StoreError } from "@/common/errors.js";
+import { HeadlessKysely } from "@/database/kysely.js";
+import type { NamespaceInfo } from "@/database/service.js";
+import type { Schema } from "@/schema/types.js";
+import { sql } from "kysely";
+import type { Row, WhereInput, WriteIndexingStore } from "./store.js";
+import { decodeRow, encodeRow, encodeValue } from "./utils/encoding.js";
+import { buildWhereConditions } from "./utils/filter.js";
+
+const MAX_BATCH_SIZE = 1_000 as const;
+
+export const getHistoricalIndexingStore = ({
+  kind,
+  schema,
+  namespaceInfo,
+  db,
+}: {
+  kind: "sqlite" | "postgres";
+  schema: Schema;
+  namespaceInfo: NamespaceInfo;
+  db: HeadlessKysely<any>;
+}): WriteIndexingStore<"historical"> => ({
+  create: async ({
+    tableName,
+    id,
+    data = {},
+  }: {
+    tableName: string;
+    id: string | number | bigint;
+    data?: Omit<Row, "id">;
+  }) => {
+    const table = schema.tables[tableName];
+
+    return db.wrap({ method: `${tableName}.create` }, async () => {
+      const createRow = encodeRow({ id, ...data }, table, kind);
+
+      try {
+        const row = await db
+          .withSchema(namespaceInfo.userNamespace)
+          .insertInto(tableName)
+          .values(createRow)
+          .returningAll()
+          .executeTakeFirstOrThrow();
+
+        return decodeRow(row, table, kind);
+      } catch (err) {
+        const error = err as Error;
+        throw (kind === "sqlite" &&
+          error.message.includes("UNIQUE constraint failed")) ||
+          (kind === "postgres" &&
+            error.message.includes("violates unique constraint"))
+          ? new StoreError(
+              `Cannot create ${tableName} record with ID ${id} because a record already exists with that ID (UNIQUE constraint violation). Hint: Did you forget to await the promise returned by a store method? Or, consider using ${tableName}.upsert().`,
+            )
+          : error;
+      }
+    });
+  },
+  createMany: async ({
+    tableName,
+    data,
+  }: {
+    tableName: string;
+    data: Row[];
+  }) => {
+    const table = schema.tables[tableName];
+
+    const rows: Row[] = [];
+
+    for (let i = 0, len = data.length; i < len; i += MAX_BATCH_SIZE) {
+      await db.wrap({ method: `${tableName}.createMany` }, async () => {
+        try {
+          const createRows = data
+            .slice(i, i + MAX_BATCH_SIZE)
+            .map((d) => encodeRow(d, table, kind));
+
+          const _rows = await db
+            .withSchema(namespaceInfo.userNamespace)
+            .insertInto(tableName)
+            .values(createRows)
+            .returningAll()
+            .execute();
+
+          rows.push(...(_rows as Row[]));
+        } catch (err) {
+          const error = err as Error;
+          throw (kind === "sqlite" &&
+            error.message.includes("UNIQUE constraint failed")) ||
+            (kind === "postgres" &&
+              error.message.includes("violates unique constraint"))
+            ? new StoreError(
+                `Cannot createMany ${tableName} records because one or more records already exist (UNIQUE constraint violation). Hint: Did you forget to await the promise returned by a store method?`,
+              )
+            : error;
+        }
+      });
+    }
+
+    return rows;
+  },
+  update: async ({
+    tableName,
+    id,
+    data = {},
+  }: {
+    tableName: string;
+    id: string | number | bigint;
+    data?:
+      | Partial<Omit<Row, "id">>
+      | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
+  }) => {
+    const table = schema.tables[tableName];
+
+    return db.wrap({ method: `${tableName}.update` }, async () => {
+      const encodedId = encodeValue(id, table.id, kind);
+
+      let updateRow: ReturnType<typeof encodeRow>;
+
+      if (typeof data === "function") {
+        // Find the latest version of this instance.
+        const latestRow = await db
+          .withSchema(namespaceInfo.userNamespace)
+          .selectFrom(tableName)
+          .selectAll()
+          .where("id", "=", encodedId)
+          .executeTakeFirst();
+        if (!latestRow)
+          throw new StoreError(
+            `Cannot update ${tableName} record with ID ${id} because no existing record was found with that ID. Consider using ${tableName}.upsert(), or create the record before updating it. Hint: Did you forget to await the promise returned by a store method?`,
+          );
+
+        const current = decodeRow(latestRow, table, kind);
+        const updateObject = data({ current });
+        updateRow = encodeRow({ id, ...updateObject }, table, kind);
+      } else {
+        updateRow = encodeRow({ id, ...data }, table, kind);
+      }
+      const row = await db
+        .updateTable(tableName)
+        .set(updateRow)
+        .where("id", "=", encodedId)
+        .returningAll()
+        .executeTakeFirstOrThrow();
+
+      const result = decodeRow(row, table, kind);
+
+      return result;
+    });
+  },
+  updateMany: async ({
+    tableName,
+    where,
+    data = {},
+  }: {
+    tableName: string;
+    where: WhereInput<any>;
+    data?:
+      | Partial<Omit<Row, "id">>
+      | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
+  }) => {
+    const table = schema.tables[tableName];
+
+    return db.wrap({ method: `${tableName}.updateMany` }, async () => {
+      if (typeof data === "function") {
+        const rows = await db.transaction().execute(async (tx) => {
+          let query = tx
+            .withSchema(namespaceInfo.userNamespace)
+            .selectFrom(tableName)
+            .selectAll();
+
+          if (where) {
+            query = query.where((eb) =>
+              buildWhereConditions({
+                eb,
+                where,
+                table,
+                encoding: kind,
+              }),
+            );
+          }
+
+          const latestRows = await query.execute();
+          const rows: Row[] = [];
+          for (const latestRow of latestRows) {
+            const current = decodeRow(latestRow, table, kind);
+            const updateObject = data({ current });
+            const updateRow = encodeRow(updateObject, table, kind);
+
+            const row = await tx
+              .withSchema(namespaceInfo.userNamespace)
+              .updateTable(tableName)
+              .set(updateRow)
+              .where("id", "=", latestRow.id)
+              .returningAll()
+              .executeTakeFirstOrThrow();
+
+            rows.push(row as Row);
+          }
+
+          return rows;
+        });
+
+        return rows.map((row) => decodeRow(row, table, kind));
+      } else {
+        const updateRow = encodeRow(data, table, kind);
+
+        const rows = await db
+          .with("latestRows(id)", (db) => {
+            let query = db
+              .withSchema(namespaceInfo.userNamespace)
+              .selectFrom(tableName)
+              .select("id");
+
+            if (where) {
+              query = query.where((eb) =>
+                buildWhereConditions({
+                  eb,
+                  where,
+                  table,
+                  encoding: kind,
+                }),
+              );
+            }
+            return query;
+          })
+          .withSchema(namespaceInfo.userNamespace)
+          .updateTable(tableName)
+          .set(updateRow)
+          .from("latestRows")
+          .where(`${tableName}.id`, "=", sql.ref("latestRows.id"))
+          .returningAll()
+          .execute();
+
+        return rows.map((row) => decodeRow(row, table, kind));
+      }
+    });
+  },
+  upsert: async ({
+    tableName,
+    id,
+    create = {},
+    update = {},
+  }: {
+    tableName: string;
+    id: string | number | bigint;
+    create?: Omit<Row, "id">;
+    update?:
+      | Partial<Omit<Row, "id">>
+      | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
+  }) => {
+    const table = schema.tables[tableName];
+
+    return db.wrap({ method: `${tableName}.upsert` }, async () => {
+      const encodedId = encodeValue(id, table.id, kind);
+      const createRow = encodeRow({ id, ...create }, table, kind);
+
+      if (typeof update === "function") {
+        // Find the latest version of this instance.
+        const latestRow = await db
+          .withSchema(namespaceInfo.userNamespace)
+          .selectFrom(tableName)
+          .selectAll()
+          .where("id", "=", encodedId)
+          .executeTakeFirst();
+
+        // If there is no latest version, insert a new version using the create data.
+        if (latestRow === undefined) {
+          const row = await db
+            .withSchema(namespaceInfo.userNamespace)
+            .insertInto(tableName)
+            .values(createRow)
+            .returningAll()
+            .executeTakeFirstOrThrow();
+
+          return decodeRow(row, table, kind);
+        }
+
+        const current = decodeRow(latestRow, table, kind);
+        const updateObject = update({ current });
+        const updateRow = encodeRow({ id, ...updateObject }, table, kind);
+
+        const row = await db
+          .withSchema(namespaceInfo.userNamespace)
+          .updateTable(tableName)
+          .set(updateRow)
+          .where("id", "=", encodedId)
+          .returningAll()
+          .executeTakeFirstOrThrow();
+        return decodeRow(row, table, kind);
+      } else {
+        const updateRow = encodeRow({ id, ...update }, table, kind);
+
+        const row = await db
+          .withSchema(namespaceInfo.userNamespace)
+          .insertInto(tableName)
+          .values(createRow)
+          .onConflict((oc) => oc.column("id").doUpdateSet(updateRow))
+          .returningAll()
+          .executeTakeFirstOrThrow();
+
+        return decodeRow(row, table, kind);
+      }
+    });
+  },
+  delete: async ({
+    tableName,
+    id,
+  }: {
+    tableName: string;
+    id: string | number | bigint;
+  }) => {
+    const table = schema.tables[tableName];
+
+    return db.wrap({ method: `${tableName}.delete` }, async () => {
+      const encodedId = encodeValue(id, table.id, kind);
+
+      const deletedRow = await db
+        .withSchema(namespaceInfo.userNamespace)
+        .deleteFrom(tableName)
+        .where("id", "=", encodedId)
+        .returning(["id"])
+        .executeTakeFirst();
+
+      return !!deletedRow;
+    });
+  },
+});

--- a/packages/core/src/indexing-store/readStore.test.ts
+++ b/packages/core/src/indexing-store/readStore.test.ts
@@ -1,0 +1,574 @@
+import {
+  setupCommon,
+  setupDatabaseServices,
+  setupIsolatedDatabase,
+} from "@/_test/setup.js";
+import { createSchema } from "@/schema/schema.js";
+import {
+  type Checkpoint,
+  encodeCheckpoint,
+  zeroCheckpoint,
+} from "@/utils/checkpoint.js";
+import { beforeEach, expect, test } from "vitest";
+
+beforeEach(setupCommon);
+beforeEach(setupIsolatedDatabase);
+
+const schema = createSchema((p) => ({
+  PetKind: p.createEnum(["CAT", "DOG"]),
+  Pet: p.createTable({
+    id: p.string(),
+    name: p.string(),
+    age: p.int().optional(),
+    bigAge: p.bigint().optional(),
+    kind: p.enum("PetKind").optional(),
+    rating: p.float().optional(),
+  }),
+  Person: p.createTable({
+    id: p.string(),
+    name: p.string(),
+  }),
+}));
+
+const hexSchema = createSchema((p) => ({
+  table: p.createTable({
+    id: p.hex(),
+    n: p.int(),
+  }),
+}));
+
+function createCheckpoint(index: number): Checkpoint {
+  return { ...zeroCheckpoint, blockTimestamp: index };
+}
+
+test("findUnique() works with hex case sensitivity", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema: hexSchema,
+  });
+
+  await indexingStore.create({
+    tableName: "table",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "0x0a",
+    data: { n: 1 },
+  });
+
+  const instance = await indexingStore.findUnique({
+    tableName: "table",
+    id: "0x0A",
+  });
+  expect(instance).toMatchObject({ id: "0x0a", n: 1 });
+
+  await cleanup();
+});
+
+test("findMany() returns current versions of all records", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(8)),
+    id: "id1",
+    data: { name: "Skip", age: 12 },
+  });
+  await indexingStore.update({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id1",
+    data: { name: "SkipUpdated" },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id2",
+    data: { name: "Foo" },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id3",
+    data: { name: "Bar", bigAge: 100n },
+  });
+
+  const { items } = await indexingStore.findMany({ tableName: "Pet" });
+  expect(items).toHaveLength(3);
+  expect(items.map((i) => i.name)).toMatchObject(["SkipUpdated", "Foo", "Bar"]);
+
+  await cleanup();
+});
+
+test("findMany() orders by bigint field", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id1",
+    data: { name: "Skip", bigAge: 105n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id2",
+    data: { name: "Foo", bigAge: 10n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id3",
+    data: { name: "Bar", bigAge: 190n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id4",
+    data: { name: "Patch" },
+  });
+
+  const { items } = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { bigAge: "asc" },
+  });
+  expect(items.map((i) => i.bigAge)).toMatchObject([null, 10n, 105n, 190n]);
+
+  await cleanup();
+});
+
+test("findMany() filters on bigint gt", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id1",
+    data: { name: "Skip", bigAge: 105n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id2",
+    data: { name: "Foo", bigAge: 10n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id3",
+    data: { name: "Bar", bigAge: 190n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id4",
+    data: { name: "Patch" },
+  });
+
+  const { items } = await indexingStore.findMany({
+    tableName: "Pet",
+    where: { bigAge: { gt: 50n } },
+  });
+
+  expect(items.map((i) => i.bigAge)).toMatchObject([105n, 190n]);
+
+  await cleanup();
+});
+
+test("findMany() filters with complex OR condition", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.createMany({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    data: [
+      { id: "id1", name: "Skip", bigAge: 105n },
+      { id: "id2", name: "Foo", bigAge: 10n },
+      { id: "id3", name: "Bar", bigAge: 190n },
+      { id: "id4", name: "Zarbar" },
+      { id: "id5", name: "Winston", age: 12 },
+    ],
+  });
+
+  const { items } = await indexingStore.findMany({
+    tableName: "Pet",
+    where: {
+      OR: [
+        { bigAge: { gt: 50n } },
+        { AND: [{ name: "Foo" }, { bigAge: { lt: 20n } }] },
+      ],
+    },
+  });
+
+  expect(items).toMatchObject([
+    { id: "id1", name: "Skip", bigAge: 105n },
+    { id: "id2", name: "Foo", bigAge: 10n },
+    { id: "id3", name: "Bar", bigAge: 190n },
+  ]);
+
+  await cleanup();
+});
+
+test("findMany() sorts and filters together", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id1",
+    data: { name: "Skip", bigAge: 105n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id2",
+    data: { name: "Foo", bigAge: 10n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id3",
+    data: { name: "Bar", bigAge: 190n },
+  });
+  await indexingStore.create({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    id: "id4",
+    data: { name: "Zarbar" },
+  });
+
+  const { items } = await indexingStore.findMany({
+    tableName: "Pet",
+    where: { name: { endsWith: "ar" } },
+    orderBy: { name: "asc" },
+  });
+
+  expect(items.map((i) => i.name)).toMatchObject(["Bar", "Zarbar"]);
+
+  await cleanup();
+});
+
+test("findMany() errors on invalid filter condition", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  expect(() =>
+    indexingStore.findMany({
+      tableName: "Pet",
+      where: { name: { invalidWhereCondition: "ar" } },
+    }),
+  ).rejects.toThrow(
+    "Invalid filter condition for column 'name'. Got 'invalidWhereCondition', expected one of ['equals', 'not', 'in', 'notIn', 'contains', 'notContains', 'startsWith', 'notStartsWith', 'endsWith', 'notEndsWith']",
+  );
+
+  await cleanup();
+});
+
+test("findMany() cursor pagination ascending", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.createMany({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    data: [
+      { id: "id1", name: "Skip" },
+      { id: "id2", name: "Foo" },
+      { id: "id3", name: "Bar" },
+      { id: "id4", name: "Zarbar" },
+      { id: "id5", name: "Winston" },
+      { id: "id6", name: "Book" },
+      { id: "id7", name: "Shea" },
+      { id: "id8", name: "Snack" },
+      { id: "id9", name: "Last" },
+    ],
+  });
+
+  const resultOne = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { id: "asc" },
+    limit: 5,
+  });
+
+  expect(
+    resultOne.items.map((i) => ({ id: i.id, name: i.name })),
+  ).toMatchObject([
+    { id: "id1", name: "Skip" },
+    { id: "id2", name: "Foo" },
+    { id: "id3", name: "Bar" },
+    { id: "id4", name: "Zarbar" },
+    { id: "id5", name: "Winston" },
+  ]);
+  expect(resultOne.pageInfo).toMatchObject({
+    startCursor: expect.any(String),
+    endCursor: expect.any(String),
+    hasPreviousPage: false,
+    hasNextPage: true,
+  });
+
+  const resultTwo = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { id: "asc" },
+    after: resultOne.pageInfo.endCursor,
+  });
+
+  expect(
+    resultTwo.items.map((i) => ({ id: i.id, name: i.name })),
+  ).toMatchObject([
+    { id: "id6", name: "Book" },
+    { id: "id7", name: "Shea" },
+    { id: "id8", name: "Snack" },
+    { id: "id9", name: "Last" },
+  ]);
+  expect(resultTwo.pageInfo).toMatchObject({
+    startCursor: expect.any(String),
+    endCursor: expect.any(String),
+    hasPreviousPage: true,
+    hasNextPage: false,
+  });
+
+  const resultThree = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { id: "asc" },
+    before: resultTwo.pageInfo.startCursor,
+    limit: 2,
+  });
+
+  expect(
+    resultThree.items.map((i) => ({ id: i.id, name: i.name })),
+  ).toMatchObject([
+    { id: "id4", name: "Zarbar" },
+    { id: "id5", name: "Winston" },
+  ]);
+  expect(resultThree.pageInfo).toMatchObject({
+    startCursor: expect.any(String),
+    endCursor: expect.any(String),
+    hasPreviousPage: true,
+    hasNextPage: true,
+  });
+
+  await cleanup();
+});
+
+test("findMany() cursor pagination descending", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.createMany({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    data: [
+      { id: "id1", name: "Skip", bigAge: 105n },
+      { id: "id2", name: "Foo", bigAge: 10n },
+      { id: "id3", name: "Bar", bigAge: 190n },
+      { id: "id4", name: "Zarbar" },
+      { id: "id5", name: "Winston", age: 12 },
+    ],
+  });
+
+  const resultOne = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { name: "desc" },
+    limit: 2,
+  });
+
+  expect(
+    resultOne.items.map((i) => ({ id: i.id, name: i.name })),
+  ).toMatchObject([
+    { id: "id4", name: "Zarbar" },
+    { id: "id5", name: "Winston" },
+  ]);
+  expect(resultOne.pageInfo).toMatchObject({
+    startCursor: expect.any(String),
+    endCursor: expect.any(String),
+    hasPreviousPage: false,
+    hasNextPage: true,
+  });
+
+  const resultTwo = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { name: "desc" },
+    after: resultOne.pageInfo.endCursor,
+  });
+
+  expect(
+    resultTwo.items.map((i) => ({ id: i.id, name: i.name })),
+  ).toMatchObject([
+    { id: "id1", name: "Skip" },
+    { id: "id2", name: "Foo" },
+    { id: "id3", name: "Bar" },
+  ]);
+  expect(resultTwo.pageInfo).toMatchObject({
+    startCursor: expect.any(String),
+    endCursor: expect.any(String),
+    hasPreviousPage: true,
+    hasNextPage: false,
+  });
+
+  const resultThree = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { name: "desc" },
+    before: resultTwo.pageInfo.startCursor,
+    limit: 1,
+  });
+
+  expect(
+    resultThree.items.map((i) => ({ id: i.id, name: i.name })),
+  ).toMatchObject([{ id: "id5", name: "Winston" }]);
+  expect(resultThree.pageInfo).toMatchObject({
+    startCursor: expect.any(String),
+    endCursor: expect.any(String),
+    hasPreviousPage: true,
+    hasNextPage: true,
+  });
+
+  await cleanup();
+});
+
+test("findMany() returns start and end cursor if limited", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.createMany({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    data: [
+      { id: "id1", name: "Skip", bigAge: 105n },
+      { id: "id2", name: "Foo", bigAge: 10n },
+      { id: "id3", name: "Bar", bigAge: 190n },
+      { id: "id4", name: "Zarbar" },
+      { id: "id5", name: "Winston", age: 12 },
+    ],
+  });
+
+  const resultOne = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { name: "asc" },
+  });
+
+  expect(
+    resultOne.items.map((i) => ({ id: i.id, name: i.name })),
+  ).toMatchObject([
+    { id: "id3", name: "Bar" },
+    { id: "id2", name: "Foo" },
+    { id: "id1", name: "Skip" },
+    { id: "id5", name: "Winston" },
+    { id: "id4", name: "Zarbar" },
+  ]);
+  expect(resultOne.pageInfo).toMatchObject({
+    startCursor: expect.any(String),
+    endCursor: expect.any(String),
+    hasPreviousPage: false,
+    hasNextPage: false,
+  });
+
+  await cleanup();
+});
+
+test("findMany() returns hasPreviousPage if no results", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.createMany({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    data: [
+      { id: "id1", name: "Skip", bigAge: 105n },
+      { id: "id2", name: "Foo", bigAge: 10n },
+      { id: "id3", name: "Bar", bigAge: 190n },
+      { id: "id4", name: "Zarbar" },
+      { id: "id5", name: "Winston", age: 12 },
+    ],
+  });
+
+  const resultOne = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { name: "asc" },
+  });
+
+  const resultTwo = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { name: "asc" },
+    after: resultOne.pageInfo.endCursor,
+  });
+
+  expect(resultTwo.items).toHaveLength(0);
+  expect(resultTwo.pageInfo).toMatchObject({
+    startCursor: null,
+    endCursor: null,
+    hasPreviousPage: true,
+    hasNextPage: false,
+  });
+
+  await cleanup();
+});
+
+test("findMany() errors on orderBy object with multiple keys", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  expect(() =>
+    indexingStore.findMany({
+      tableName: "Pet",
+      orderBy: { name: "asc", bigAge: "desc" },
+    }),
+  ).rejects.toThrow("Invalid sort. Cannot sort by multiple columns.");
+
+  await cleanup();
+});
+
+test("findMany() ordering secondary sort inherits primary", async (context) => {
+  const { indexingStore, cleanup } = await setupDatabaseServices(context, {
+    schema,
+  });
+
+  await indexingStore.createMany({
+    tableName: "Pet",
+    encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
+    data: [
+      { id: "id1", name: "Skip", bigAge: 105n },
+      { id: "id2", name: "Foo", bigAge: 10n },
+      { id: "id3", name: "Bar", bigAge: 190n },
+      { id: "id4", name: "Zarbar", bigAge: 10n },
+    ],
+  });
+
+  const resultOne = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { bigAge: "desc" },
+  });
+
+  expect(resultOne.items).toMatchObject([
+    { id: "id3", name: "Bar", bigAge: 190n },
+    { id: "id1", name: "Skip", bigAge: 105n },
+    { id: "id4", name: "Zarbar", bigAge: 10n }, // secondary sort by ID is descending
+    { id: "id2", name: "Foo", bigAge: 10n },
+  ]);
+
+  const resultTwo = await indexingStore.findMany({
+    tableName: "Pet",
+    orderBy: { bigAge: "asc" },
+  });
+
+  expect(resultTwo.items).toMatchObject([
+    { id: "id2", name: "Foo", bigAge: 10n },
+    { id: "id4", name: "Zarbar", bigAge: 10n }, // secondary sort by ID is ascending
+    { id: "id1", name: "Skip", bigAge: 105n },
+    { id: "id3", name: "Bar", bigAge: 190n },
+  ]);
+
+  await cleanup();
+});

--- a/packages/core/src/indexing-store/readStore.ts
+++ b/packages/core/src/indexing-store/readStore.ts
@@ -1,0 +1,275 @@
+import { StoreError } from "@/common/errors.js";
+import type { HeadlessKysely } from "@/database/kysely.js";
+import type { NamespaceInfo } from "@/database/service.js";
+import type { Schema } from "@/schema/types.js";
+import { sql } from "kysely";
+import type { OrderByInput, ReadIndexingStore, WhereInput } from "./store.js";
+import {
+  buildCursorConditions,
+  decodeCursor,
+  encodeCursor,
+} from "./utils/cursor.js";
+import { decodeRow, encodeValue } from "./utils/encoding.js";
+import { buildWhereConditions } from "./utils/filter.js";
+import {
+  buildOrderByConditions,
+  reverseOrderByConditions,
+} from "./utils/sort.js";
+
+const DEFAULT_LIMIT = 50 as const;
+const MAX_LIMIT = 1_000 as const;
+
+export const getReadIndexingStore = ({
+  kind,
+  schema,
+  namespaceInfo,
+  db,
+}: {
+  kind: "sqlite" | "postgres";
+  schema: Schema;
+  namespaceInfo: NamespaceInfo;
+  db: HeadlessKysely<any>;
+}): ReadIndexingStore => ({
+  findUnique: async ({
+    tableName,
+    id,
+  }: {
+    tableName: string;
+    id: string | number | bigint;
+  }) => {
+    const table = schema.tables[tableName];
+
+    return db.wrap({ method: `${tableName}.findUnique` }, async () => {
+      const encodedId = encodeValue(id, table.id, kind);
+
+      const row = await db
+        .withSchema(namespaceInfo.userNamespace)
+        .selectFrom(tableName)
+        .selectAll()
+        .where("id", "=", encodedId)
+        .executeTakeFirst();
+
+      if (row === undefined) return null;
+
+      return decodeRow(row, table, kind);
+    });
+  },
+  findMany: async ({
+    tableName,
+    where,
+    orderBy,
+    before = null,
+    after = null,
+    limit = DEFAULT_LIMIT,
+  }: {
+    tableName: string;
+    where?: WhereInput<any>;
+    orderBy?: OrderByInput<any>;
+    before?: string | null;
+    after?: string | null;
+    limit?: number;
+  }) => {
+    const table = schema.tables[tableName];
+
+    return db.wrap({ method: `${tableName}.findMany` }, async () => {
+      let query = db
+        .withSchema(namespaceInfo.userNamespace)
+        .selectFrom(tableName)
+        .selectAll();
+
+      if (where) {
+        query = query.where((eb) =>
+          buildWhereConditions({ eb, where, table, encoding: kind }),
+        );
+      }
+
+      const orderByConditions = buildOrderByConditions({ orderBy, table });
+      for (const [column, direction] of orderByConditions) {
+        query = query.orderBy(
+          column,
+          kind === "sqlite"
+            ? direction
+            : direction === "asc"
+              ? sql`asc nulls first`
+              : sql`desc nulls last`,
+        );
+      }
+      const orderDirection = orderByConditions[0][1];
+
+      if (limit > MAX_LIMIT) {
+        throw new StoreError(
+          `Invalid limit. Got ${limit}, expected <=${MAX_LIMIT}.`,
+        );
+      }
+
+      if (after !== null && before !== null) {
+        throw new StoreError("Cannot specify both before and after cursors.");
+      }
+
+      let startCursor = null;
+      let endCursor = null;
+      let hasPreviousPage = false;
+      let hasNextPage = false;
+
+      // Neither cursors are specified, apply the order conditions and execute.
+      if (after === null && before === null) {
+        query = query.limit(limit + 1);
+        const rows = await query.execute();
+        const records = rows.map((row) => decodeRow(row, table, kind));
+
+        if (records.length === limit + 1) {
+          records.pop();
+          hasNextPage = true;
+        }
+
+        startCursor =
+          records.length > 0
+            ? encodeCursor(records[0], orderByConditions)
+            : null;
+        endCursor =
+          records.length > 0
+            ? encodeCursor(records[records.length - 1], orderByConditions)
+            : null;
+
+        return {
+          items: records,
+          pageInfo: { hasNextPage, hasPreviousPage, startCursor, endCursor },
+        };
+      }
+
+      if (after !== null) {
+        // User specified an 'after' cursor.
+        const rawCursorValues = decodeCursor(after, orderByConditions);
+        const cursorValues = rawCursorValues.map(([columnName, value]) => [
+          columnName,
+          encodeValue(value, table[columnName], kind),
+        ]) satisfies [string, any][];
+        query = query
+          .where((eb) =>
+            buildCursorConditions(cursorValues, "after", orderDirection, eb),
+          )
+          .limit(limit + 2);
+
+        const rows = await query.execute();
+        const records = rows.map((row) => decodeRow(row, table, kind));
+
+        if (records.length === 0) {
+          return {
+            items: records,
+            pageInfo: {
+              hasNextPage,
+              hasPreviousPage,
+              startCursor,
+              endCursor,
+            },
+          };
+        }
+
+        // If the cursor of the first returned record equals the `after` cursor,
+        // `hasPreviousPage` is true. Remove that record.
+        if (encodeCursor(records[0], orderByConditions) === after) {
+          records.shift();
+          hasPreviousPage = true;
+        } else {
+          // Otherwise, remove the last record.
+          records.pop();
+        }
+
+        // Now if the length of the records is still equal to limit + 1,
+        // there is a next page.
+        if (records.length === limit + 1) {
+          records.pop();
+          hasNextPage = true;
+        }
+
+        // Now calculate the cursors.
+        startCursor =
+          records.length > 0
+            ? encodeCursor(records[0], orderByConditions)
+            : null;
+        endCursor =
+          records.length > 0
+            ? encodeCursor(records[records.length - 1], orderByConditions)
+            : null;
+
+        return {
+          items: records,
+          pageInfo: { hasNextPage, hasPreviousPage, startCursor, endCursor },
+        };
+      } else {
+        // User specified a 'before' cursor.
+        const rawCursorValues = decodeCursor(before!, orderByConditions);
+        const cursorValues = rawCursorValues.map(([columnName, value]) => [
+          columnName,
+          encodeValue(value, table[columnName], kind),
+        ]) satisfies [string, any][];
+        query = query
+          .where((eb) =>
+            buildCursorConditions(cursorValues, "before", orderDirection, eb),
+          )
+          .limit(limit + 2);
+
+        // Reverse the order by conditions to get the previous page.
+        query = query.clearOrderBy();
+        const reversedOrderByConditions =
+          reverseOrderByConditions(orderByConditions);
+        for (const [column, direction] of reversedOrderByConditions) {
+          query = query.orderBy(column, direction);
+        }
+
+        const rows = await query.execute();
+        const records = rows
+          .map((row) => decodeRow(row, table, kind))
+          // Reverse the records again, back to the original order.
+          .reverse();
+
+        if (records.length === 0) {
+          return {
+            items: records,
+            pageInfo: {
+              hasNextPage,
+              hasPreviousPage,
+              startCursor,
+              endCursor,
+            },
+          };
+        }
+
+        // If the cursor of the last returned record equals the `before` cursor,
+        // `hasNextPage` is true. Remove that record.
+        if (
+          encodeCursor(records[records.length - 1], orderByConditions) ===
+          before
+        ) {
+          records.pop();
+          hasNextPage = true;
+        } else {
+          // Otherwise, remove the first record.
+          records.shift();
+        }
+
+        // Now if the length of the records is equal to limit + 1, we know
+        // there is a previous page.
+        if (records.length === limit + 1) {
+          records.shift();
+          hasPreviousPage = true;
+        }
+
+        // Now calculate the cursors.
+        startCursor =
+          records.length > 0
+            ? encodeCursor(records[0], orderByConditions)
+            : null;
+        endCursor =
+          records.length > 0
+            ? encodeCursor(records[records.length - 1], orderByConditions)
+            : null;
+
+        return {
+          items: records,
+          pageInfo: { hasNextPage, hasPreviousPage, startCursor, endCursor },
+        };
+      }
+    });
+  },
+});

--- a/packages/core/src/indexing-store/store.ts
+++ b/packages/core/src/indexing-store/store.ts
@@ -1,8 +1,98 @@
-import type { HeadlessKysely } from "@/database/kysely.js";
-import type { Schema } from "@/schema/types.js";
 import type { Prettify } from "@/types/utils.js";
-import type { Checkpoint } from "@/utils/checkpoint.js";
 import type { Hex } from "viem";
+
+export type ReadIndexingStore = {
+  findUnique(options: {
+    tableName: string;
+    id: string | number | bigint;
+  }): Promise<Row | null>;
+
+  findMany(options: {
+    tableName: string;
+    where?: WhereInput<any>;
+    orderBy?: OrderByInput<any>;
+    before?: string | null;
+    after?: string | null;
+    limit?: number;
+  }): Promise<{
+    items: Row[];
+    pageInfo: {
+      startCursor: string | null;
+      endCursor: string | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+    };
+  }>;
+};
+
+export type WriteIndexingStore<
+  env extends "historical" | "realtime",
+  ///
+  checkpointProp = env extends "realtime"
+    ? {
+        encodedCheckpoint: string;
+      }
+    : {
+        encodedCheckpoint?: never;
+      },
+> = {
+  create(
+    options: {
+      tableName: string;
+      id: string | number | bigint;
+      data?: Omit<Row, "id">;
+    } & checkpointProp,
+  ): Promise<Row>;
+
+  createMany(
+    options: {
+      tableName: string;
+      data: Row[];
+    } & checkpointProp,
+  ): Promise<Row[]>;
+
+  update(
+    options: {
+      tableName: string;
+      id: string | number | bigint;
+      data?:
+        | Partial<Omit<Row, "id">>
+        | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
+    } & checkpointProp,
+  ): Promise<Row>;
+
+  updateMany(
+    options: {
+      tableName: string;
+      where?: WhereInput<any>;
+      data?:
+        | Partial<Omit<Row, "id">>
+        | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
+    } & checkpointProp,
+  ): Promise<Row[]>;
+
+  upsert(
+    options: {
+      tableName: string;
+      id: string | number | bigint;
+      create?: Omit<Row, "id">;
+      update?:
+        | Partial<Omit<Row, "id">>
+        | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
+    } & checkpointProp,
+  ): Promise<Row>;
+
+  delete(
+    options: {
+      tableName: string;
+      id: string | number | bigint;
+    } & checkpointProp,
+  ): Promise<boolean>;
+};
+
+export type IndexingStore<
+  env extends "historical" | "realtime" = "historical" | "realtime",
+> = ReadIndexingStore & WriteIndexingStore<env>;
 
 export type Table = {
   [key: string]:
@@ -79,83 +169,3 @@ export type WhereInput<TTable extends Table> = {
 export type OrderByInput<table, columns extends keyof table = keyof table> = {
   [ColumnName in columns]?: "asc" | "desc";
 };
-
-export interface IndexingStore {
-  kind: "sqlite" | "postgres";
-  db: HeadlessKysely<any>;
-  schema: Schema;
-
-  revert({
-    checkpoint,
-    isCheckpointSafe,
-  }: { checkpoint: Checkpoint; isCheckpointSafe: boolean }): Promise<void>;
-
-  findUnique(options: {
-    tableName: string;
-    id: string | number | bigint;
-  }): Promise<Row | null>;
-
-  findMany(options: {
-    tableName: string;
-    where?: WhereInput<any>;
-    orderBy?: OrderByInput<any>;
-    before?: string | null;
-    after?: string | null;
-    limit?: number;
-  }): Promise<{
-    items: Row[];
-    pageInfo: {
-      startCursor: string | null;
-      endCursor: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-    };
-  }>;
-
-  create(options: {
-    tableName: string;
-    encodedCheckpoint: string;
-    id: string | number | bigint;
-    data?: Omit<Row, "id">;
-  }): Promise<Row>;
-
-  createMany(options: {
-    tableName: string;
-    encodedCheckpoint: string;
-    data: Row[];
-  }): Promise<Row[]>;
-
-  update(options: {
-    tableName: string;
-    encodedCheckpoint: string;
-    id: string | number | bigint;
-    data?:
-      | Partial<Omit<Row, "id">>
-      | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
-  }): Promise<Row>;
-
-  updateMany(options: {
-    tableName: string;
-    encodedCheckpoint: string;
-    where?: WhereInput<any>;
-    data?:
-      | Partial<Omit<Row, "id">>
-      | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
-  }): Promise<Row[]>;
-
-  upsert(options: {
-    tableName: string;
-    encodedCheckpoint: string;
-    id: string | number | bigint;
-    create?: Omit<Row, "id">;
-    update?:
-      | Partial<Omit<Row, "id">>
-      | ((args: { current: Row }) => Partial<Omit<Row, "id">>);
-  }): Promise<Row>;
-
-  delete(options: {
-    tableName: string;
-    encodedCheckpoint: string;
-    id: string | number | bigint;
-  }): Promise<boolean>;
-}

--- a/packages/core/src/indexing/service.test.ts
+++ b/packages/core/src/indexing/service.test.ts
@@ -9,7 +9,6 @@ import {
 import { getEventsErc20 } from "@/_test/utils.js";
 import { createSchema } from "@/schema/schema.js";
 import { createSyncService } from "@/sync/index.js";
-import { decodeCheckpoint, zeroCheckpoint } from "@/utils/checkpoint.js";
 import { promiseWithResolvers } from "@ponder/common";
 import { type Address, checksumAddress, parseEther, toHex } from "viem";
 import { beforeEach, expect, test, vi } from "vitest";
@@ -508,61 +507,6 @@ test("executeSetup() metrics", async (context) => {
   await cleanup();
 });
 
-test("executeSetup() retry", async (context) => {
-  const { common, sources, networks } = context;
-  const { syncStore, indexingStore, cleanup } = await setupDatabaseServices(
-    context,
-    { schema },
-  );
-
-  const syncService = await createSyncService({
-    common,
-    syncStore,
-    networks,
-    sources,
-    onRealtimeEvent: () => Promise.resolve(),
-    onFatalError: () => {},
-  });
-
-  const indexingFunctions = {
-    "Erc20:setup": vi.fn(),
-  };
-
-  const revertSpy = vi.spyOn(indexingStore, "revert");
-
-  const indexingService = create({
-    indexingFunctions,
-    common,
-    sources,
-    networks,
-    syncService,
-    indexingStore,
-    schema,
-  });
-
-  indexingFunctions["Erc20:setup"].mockRejectedValueOnce(new Error());
-
-  const result = await processSetupEvents(indexingService, {
-    sources,
-    networks,
-  });
-  expect(result).toStrictEqual({ status: "success" });
-
-  expect(indexingFunctions["Erc20:setup"]).toHaveBeenCalledTimes(2);
-
-  expect(revertSpy).toHaveBeenCalledTimes(1);
-  expect(revertSpy).toHaveBeenCalledWith({
-    checkpoint: {
-      ...zeroCheckpoint,
-      chainId: 1,
-      blockNumber: 0,
-    },
-    isCheckpointSafe: false,
-  });
-
-  await cleanup();
-});
-
 test("executeSetup() error", async (context) => {
   const { common, sources, networks } = context;
   const { syncStore, indexingStore, cleanup } = await setupDatabaseServices(
@@ -583,8 +527,6 @@ test("executeSetup() error", async (context) => {
     "Erc20:setup": vi.fn(),
   };
 
-  const revertSpy = vi.spyOn(indexingStore, "revert");
-
   const indexingService = create({
     indexingFunctions,
     common,
@@ -603,8 +545,7 @@ test("executeSetup() error", async (context) => {
   });
   expect(result).toStrictEqual({ status: "error", error: expect.any(Error) });
 
-  expect(indexingFunctions["Erc20:setup"]).toHaveBeenCalledTimes(4);
-  expect(revertSpy).toHaveBeenCalledTimes(3);
+  expect(indexingFunctions["Erc20:setup"]).toHaveBeenCalledTimes(1);
 
   await cleanup();
 });
@@ -762,67 +703,6 @@ test("executeLog() metrics", async (context) => {
   await cleanup();
 });
 
-test("executeLog() retry", async (context) => {
-  const { common, sources, networks } = context;
-  const { syncStore, indexingStore, cleanup } = await setupDatabaseServices(
-    context,
-    { schema },
-  );
-
-  const syncService = await createSyncService({
-    common,
-    syncStore,
-    networks,
-    sources,
-    onRealtimeEvent: () => Promise.resolve(),
-    onFatalError: () => {},
-  });
-
-  const indexingFunctions = {
-    "Erc20:Transfer(address indexed from, address indexed to, uint256 amount)":
-      vi.fn(),
-  };
-
-  const revertSpy = vi.spyOn(indexingStore, "revert");
-
-  const indexingService = create({
-    indexingFunctions,
-    common,
-    sources,
-    networks,
-    syncService,
-    indexingStore,
-    schema,
-  });
-
-  indexingFunctions[
-    "Erc20:Transfer(address indexed from, address indexed to, uint256 amount)"
-  ].mockRejectedValueOnce(new Error());
-
-  const rawEvents = await getEventsErc20(sources);
-  const events = decodeEvents(syncService, rawEvents);
-  const result = await processEvents(indexingService, {
-    events,
-  });
-
-  expect(result).toStrictEqual({
-    status: "success",
-  });
-  expect(
-    indexingFunctions[
-      "Erc20:Transfer(address indexed from, address indexed to, uint256 amount)"
-    ],
-  ).toHaveBeenCalledTimes(3);
-
-  expect(revertSpy).toHaveBeenCalledTimes(1);
-  expect(revertSpy).toHaveBeenCalledWith({
-    checkpoint: decodeCheckpoint(events[0].encodedCheckpoint),
-    isCheckpointSafe: false,
-  });
-
-  await cleanup();
-});
-
 test("executeLog() error", async (context) => {
   const { common, sources, networks } = context;
   const { syncStore, indexingStore, cleanup } = await setupDatabaseServices(
@@ -843,8 +723,6 @@ test("executeLog() error", async (context) => {
     "Erc20:Transfer(address indexed from, address indexed to, uint256 amount)":
       vi.fn(),
   };
-
-  const revertSpy = vi.spyOn(indexingStore, "revert");
 
   const indexingService = create({
     indexingFunctions,
@@ -874,8 +752,7 @@ test("executeLog() error", async (context) => {
     indexingFunctions[
       "Erc20:Transfer(address indexed from, address indexed to, uint256 amount)"
     ],
-  ).toHaveBeenCalledTimes(4);
-  expect(revertSpy).toHaveBeenCalledTimes(3);
+  ).toHaveBeenCalledTimes(1);
 
   await cleanup();
 });

--- a/packages/core/src/indexing/service.ts
+++ b/packages/core/src/indexing/service.ts
@@ -1,6 +1,5 @@
 import type { IndexingFunctions } from "@/build/configAndIndexingFunctions.js";
 import type { Common } from "@/common/common.js";
-import { NonRetryableError } from "@/common/errors.js";
 import type { Network } from "@/config/networks.js";
 import { type EventSource } from "@/config/sources.js";
 import type { IndexingStore, Row } from "@/indexing-store/store.js";
@@ -386,64 +385,44 @@ const executeSetup = async (
     network: networkByChainId[event.chainId].name,
   };
 
-  for (let i = 0; i < 4; i++) {
-    try {
-      // set currentEvent
-      currentEvent.context.network.chainId = event.chainId;
-      currentEvent.context.network.name = networkByChainId[event.chainId].name;
-      currentEvent.context.client = clientByChainId[event.chainId];
-      currentEvent.context.contracts = contractsByChainId[event.chainId];
-      currentEvent.contextState.encodedCheckpoint = event.encodedCheckpoint;
-      currentEvent.contextState.blockNumber = event.startBlock;
+  try {
+    // set currentEvent
+    currentEvent.context.network.chainId = event.chainId;
+    currentEvent.context.network.name = networkByChainId[event.chainId].name;
+    currentEvent.context.client = clientByChainId[event.chainId];
+    currentEvent.context.contracts = contractsByChainId[event.chainId];
+    currentEvent.contextState.encodedCheckpoint = event.encodedCheckpoint;
+    currentEvent.contextState.blockNumber = event.startBlock;
 
-      const endClock = startClock();
+    const endClock = startClock();
 
-      await indexingFunction({
-        context: currentEvent.context,
-      });
+    await indexingFunction({
+      context: currentEvent.context,
+    });
 
-      common.metrics.ponder_indexing_function_duration.observe(
-        metricLabel,
-        endClock(),
-      );
+    common.metrics.ponder_indexing_function_duration.observe(
+      metricLabel,
+      endClock(),
+    );
+  } catch (error_) {
+    if (indexingService.isKilled) return { status: "killed" };
+    const error = error_ as Error & { meta?: string };
 
-      break;
-    } catch (error_) {
-      if (indexingService.isKilled) return { status: "killed" };
-      const error = error_ as Error & { meta?: string };
+    common.metrics.ponder_indexing_function_error_total.inc(metricLabel);
 
-      common.metrics.ponder_indexing_function_error_total.inc(metricLabel);
+    const decodedCheckpoint = decodeCheckpoint(event.encodedCheckpoint);
 
-      if (error_ instanceof NonRetryableError) i = 3;
+    addUserStackTrace(error, common.options);
 
-      const decodedCheckpoint = decodeCheckpoint(event.encodedCheckpoint);
+    common.metrics.ponder_indexing_has_error.set(1);
 
-      if (i === 3) {
-        addUserStackTrace(error, common.options);
+    common.logger.error({
+      service: "indexing",
+      msg: `Error while processing "${eventName}" event at chainId=${decodedCheckpoint.chainId}, block=${decodedCheckpoint.blockNumber}: `,
+      error,
+    });
 
-        common.logger.error({
-          service: "indexing",
-          msg: `Error while processing "${eventName}" event at chainId=${decodedCheckpoint.chainId}, block=${decodedCheckpoint.blockNumber}: `,
-          error,
-        });
-
-        common.metrics.ponder_indexing_has_error.set(1);
-        return { status: "error", error: error };
-      } else {
-        common.logger.warn({
-          service: "indexing",
-          msg: `Indexing function failed, retrying... (event="${eventName}", chainId=${
-            decodedCheckpoint.chainId
-          }, block=${
-            decodedCheckpoint.blockNumber
-          }, error=${`${error.name}: ${error.message}`})`,
-        });
-        await indexingService.indexingStore.revert({
-          checkpoint: decodedCheckpoint,
-          isCheckpointSafe: false,
-        });
-      }
-    }
+    return { status: "error", error: error };
   }
 
   return { status: "success" };
@@ -473,78 +452,57 @@ const executeLog = async (
     network: networkByChainId[event.chainId].name,
   };
 
-  for (let i = 0; i < 4; i++) {
-    try {
-      // set currentEvent
-      currentEvent.context.network.chainId = event.chainId;
-      currentEvent.context.network.name = networkByChainId[event.chainId].name;
-      currentEvent.context.client = clientByChainId[event.chainId];
-      currentEvent.context.contracts = contractsByChainId[event.chainId];
-      currentEvent.contextState.encodedCheckpoint = event.encodedCheckpoint;
-      currentEvent.contextState.blockNumber = event.event.block.number;
+  try {
+    // set currentEvent
+    currentEvent.context.network.chainId = event.chainId;
+    currentEvent.context.network.name = networkByChainId[event.chainId].name;
+    currentEvent.context.client = clientByChainId[event.chainId];
+    currentEvent.context.contracts = contractsByChainId[event.chainId];
+    currentEvent.contextState.encodedCheckpoint = event.encodedCheckpoint;
+    currentEvent.contextState.blockNumber = event.event.block.number;
 
-      const endClock = startClock();
+    const endClock = startClock();
 
-      await indexingFunction({
-        event: {
-          name: event.logEventName,
-          args: event.event.args,
-          log: event.event.log,
-          block: event.event.block,
-          transaction: event.event.transaction,
-        },
-        context: currentEvent.context,
-      });
+    await indexingFunction({
+      event: {
+        name: event.logEventName,
+        args: event.event.args,
+        log: event.event.log,
+        block: event.event.block,
+        transaction: event.event.transaction,
+      },
+      context: currentEvent.context,
+    });
 
-      common.metrics.ponder_indexing_function_duration.observe(
-        metricLabel,
-        endClock(),
-      );
+    common.metrics.ponder_indexing_function_duration.observe(
+      metricLabel,
+      endClock(),
+    );
+  } catch (error_) {
+    if (indexingService.isKilled) return { status: "killed" };
+    const error = error_ as Error & { meta?: string };
 
-      break;
-    } catch (error_) {
-      if (indexingService.isKilled) return { status: "killed" };
-      const error = error_ as Error & { meta?: string };
+    common.metrics.ponder_indexing_function_error_total.inc(metricLabel);
 
-      common.metrics.ponder_indexing_function_error_total.inc(metricLabel);
+    const decodedCheckpoint = decodeCheckpoint(event.encodedCheckpoint);
 
-      if (error_ instanceof NonRetryableError) i = 3;
-
-      const decodedCheckpoint = decodeCheckpoint(event.encodedCheckpoint);
-
-      if (i === 3) {
-        addUserStackTrace(error, common.options);
-
-        if (error.meta) {
-          error.meta += `\nEvent args:\n${prettyPrint(event.event.args)}`;
-        } else {
-          error.meta = `Event args:\n${prettyPrint(event.event.args)}`;
-        }
-
-        common.logger.error({
-          service: "indexing",
-          msg: `Error while processing "${eventName}" event at chainId=${decodedCheckpoint.chainId}, block=${decodedCheckpoint.blockNumber}: `,
-          error,
-        });
-
-        common.metrics.ponder_indexing_has_error.set(1);
-
-        return { status: "error", error: error };
-      } else {
-        common.logger.warn({
-          service: "indexing",
-          msg: `Indexing function failed, retrying... (event="${eventName}", chainId=${
-            decodedCheckpoint.chainId
-          }, block=${
-            decodedCheckpoint.blockNumber
-          }, error=${`${error.name}: ${error.message}`})`,
-        });
-        await indexingService.indexingStore.revert({
-          checkpoint: decodedCheckpoint,
-          isCheckpointSafe: false,
-        });
-      }
+    if (error.meta) {
+      error.meta += `\nEvent args:\n${prettyPrint(event.event.args)}`;
+    } else {
+      error.meta = `Event args:\n${prettyPrint(event.event.args)}`;
     }
+
+    addUserStackTrace(error, common.options);
+
+    common.logger.error({
+      service: "indexing",
+      msg: `Error while processing "${eventName}" event at chainId=${decodedCheckpoint.chainId}, block=${decodedCheckpoint.blockNumber}: `,
+      error,
+    });
+
+    common.metrics.ponder_indexing_has_error.set(1);
+
+    return { status: "error", error: error };
   }
 
   return { status: "success" };

--- a/packages/core/src/server/graphql/buildLoaderCache.ts
+++ b/packages/core/src/server/graphql/buildLoaderCache.ts
@@ -1,9 +1,9 @@
-import type { IndexingStore } from "@/indexing-store/store.js";
+import type { ReadIndexingStore } from "@/indexing-store/store.js";
 import DataLoader from "dataloader";
 
 export type GetLoader = ReturnType<typeof buildLoaderCache>;
 
-export function buildLoaderCache({ store }: { store: IndexingStore }) {
+export function buildLoaderCache({ store }: { store: ReadIndexingStore }) {
   const loaderCache: Record<
     string,
     DataLoader<string | number | bigint, any> | undefined

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import type { Common } from "@/common/common.js";
-import type { IndexingStore } from "@/indexing-store/store.js";
+import type { ReadIndexingStore } from "@/indexing-store/store.js";
 import { graphiQLHtml } from "@/ui/graphiql.html.js";
 import { graphqlServer } from "@hono/graphql-server";
 import { serve } from "@hono/node-server";
@@ -14,7 +14,7 @@ import {
 } from "./graphql/buildLoaderCache.js";
 
 type Server = {
-  hono: Hono<{ Variables: { store: IndexingStore; getLoader: GetLoader } }>;
+  hono: Hono<{ Variables: { store: ReadIndexingStore; getLoader: GetLoader } }>;
   port: number;
   setHealthy: () => void;
   kill: () => Promise<void>;
@@ -26,11 +26,11 @@ export async function createServer({
   common,
 }: {
   graphqlSchema: GraphQLSchema;
-  indexingStore: IndexingStore;
+  indexingStore: ReadIndexingStore;
   common: Common;
 }): Promise<Server> {
   const hono = new Hono<{
-    Variables: { store: IndexingStore; getLoader: GetLoader };
+    Variables: { store: ReadIndexingStore; getLoader: GetLoader };
   }>();
 
   let port = common.options.port;

--- a/packages/core/src/sync-realtime/service.test.ts
+++ b/packages/core/src/sync-realtime/service.test.ts
@@ -8,6 +8,7 @@ import {
 import { testClient } from "@/_test/utils.js";
 import { type SyncBlock, _eth_getBlockByNumber } from "@/sync/index.js";
 import { maxCheckpoint } from "@/utils/checkpoint.js";
+import { wait } from "@/utils/wait.js";
 import { getAbiItem, getEventSelector } from "viem";
 import { beforeEach, expect, test, vi } from "vitest";
 import { syncBlockToLightBlock } from "./format.js";
@@ -266,8 +267,8 @@ test("start() retries on error", async (context) => {
 
   await queue.onIdle();
 
-  expect(realtimeSyncService.localChain).toHaveLength(4);
-  expect(insertSpy).toHaveBeenCalledTimes(3);
+  expect(realtimeSyncService.localChain).toHaveLength(3);
+  expect(insertSpy).toHaveBeenCalledTimes(2);
 
   await kill(realtimeSyncService);
 
@@ -289,7 +290,7 @@ test("start() emits fatal error", async (context) => {
   const realtimeSyncService = create({
     common,
     syncStore,
-    network: { ...networks[0], pollingInterval: 10_000 },
+    network: { ...networks[0], pollingInterval: 10 },
     requestQueue: requestQueues[0],
     sources,
     finalizedBlock: finalizedBlock as SyncBlock,
@@ -301,9 +302,10 @@ test("start() emits fatal error", async (context) => {
 
   const queue = await start(realtimeSyncService);
 
+  await wait(100);
+
   await queue.onIdle();
 
-  expect(insertSpy).toHaveBeenCalledTimes(6);
   expect(onFatalError).toHaveBeenCalled();
 
   await kill(realtimeSyncService);

--- a/packages/core/src/sync-realtime/service.ts
+++ b/packages/core/src/sync-realtime/service.ts
@@ -18,7 +18,6 @@ import {
 import { type Checkpoint, maxCheckpoint } from "@/utils/checkpoint.js";
 import { range } from "@/utils/range.js";
 import type { RequestQueue } from "@/utils/requestQueue.js";
-import { wait } from "@/utils/wait.js";
 import { type Queue, createQueue } from "@ponder/common";
 import { type Address, type Hex, hexToNumber } from "viem";
 import { isMatchedLogInBloomFilter, zeroLogsBloom } from "./bloom.js";
@@ -135,6 +134,32 @@ export const create = ({
 };
 
 export const start = (service: Service) => {
+  let consecutiveErrors = 0;
+  let newHeadBlockNumber: number;
+
+  const onSuccess = () => {
+    consecutiveErrors = 0;
+  };
+  const onError = (_error: unknown) => {
+    if (service.isKilled) return;
+
+    const error = _error as Error;
+
+    service.common.logger.warn({
+      service: "realtime",
+      msg: `Failed to process '${service.network.name}' block ${newHeadBlockNumber} with error: ${error}`,
+    });
+
+    if (consecutiveErrors++ === 5) {
+      service.common.logger.error({
+        service: "realtime",
+        msg: `Fatal error: Unable to process '${service.network.name}' block ${newHeadBlockNumber} after 5 attempts due to error:`,
+        error,
+      });
+      service.onFatalError(error);
+    }
+  };
+
   /**
    * The queue reacts to a new block. The four states are:
    * 1) Block is the same as the one just processed, no-op.
@@ -151,7 +176,7 @@ export const start = (service: Service) => {
     initialStart: true,
     worker: async (newHeadBlock: SyncBlock) => {
       const latestLocalBlock = getLatestLocalBlock(service);
-      const newHeadBlockNumber = hexToNumber(newHeadBlock.number);
+      newHeadBlockNumber = hexToNumber(newHeadBlock.number);
 
       // We already saw and handled this block. No-op.
       if (latestLocalBlock.hash === newHeadBlock.hash) {
@@ -163,110 +188,79 @@ export const start = (service: Service) => {
         return;
       }
 
-      for (let i = 0; i < 6; i++) {
-        try {
-          // Quickly check for a reorg by comparing block numbers. If the block
-          // number has not increased, a reorg must have occurred.
-          if (latestLocalBlock.number >= newHeadBlockNumber) {
-            await handleReorg(service, newHeadBlock);
+      // Quickly check for a reorg by comparing block numbers. If the block
+      // number has not increased, a reorg must have occurred.
+      if (latestLocalBlock.number >= newHeadBlockNumber) {
+        await handleReorg(service, newHeadBlock);
 
-            queue.clear();
-            return;
-          }
-
-          // Blocks are missing. They should be fetched and enqueued.
-          if (latestLocalBlock.number + 1 < newHeadBlockNumber) {
-            // Retrieve missing blocks, but only fetch 50 at most.
-            const missingBlockRange = range(
-              latestLocalBlock.number + 1,
-              Math.min(newHeadBlockNumber, latestLocalBlock.number + 51),
-            );
-            const pendingBlocks = await Promise.all(
-              missingBlockRange.map((blockNumber) =>
-                _eth_getBlockByNumber(service, { blockNumber }),
-              ),
-            );
-
-            service.common.logger.debug({
-              service: "realtime",
-              msg: `Fetched ${missingBlockRange.length} missing '${
-                service.network.name
-              }' blocks from ${latestLocalBlock.number + 1} to ${Math.min(
-                newHeadBlockNumber,
-                latestLocalBlock.number + 51,
-              )}`,
-            });
-
-            // This is needed to ensure proper `kill()` behavior. When the service
-            // is killed, nothing should be added to the queue, or else `onIdle()`
-            // will never resolve.
-            if (service.isKilled) return;
-
-            queue.clear();
-
-            for (const pendingBlock of pendingBlocks) {
-              queue.add(pendingBlock);
-            }
-
-            queue.add(newHeadBlock);
-
-            return;
-          }
-
-          // Check if a reorg occurred by validating the chain of block hashes.
-          if (newHeadBlock.parentHash !== latestLocalBlock.hash) {
-            await handleReorg(service, newHeadBlock);
-            queue.clear();
-            return;
-          }
-
-          // New block is exactly one block ahead of the local chain.
-          // Attempt to ingest it.
-          await handleBlock(service, { newHeadBlock });
-
-          return;
-        } catch (_error) {
-          if (service.isKilled) return;
-
-          const error = _error as Error;
-
-          service.common.logger.warn({
-            service: "realtime",
-            msg: `Failed to process '${service.network.name}' block ${newHeadBlockNumber} with error: ${error}`,
-          });
-
-          if (i === 5) {
-            service.common.logger.error({
-              service: "realtime",
-              msg: `Fatal error: Unable to process '${service.network.name}' block ${newHeadBlockNumber} after 5 attempts due to error:`,
-              error,
-            });
-
-            service.onFatalError(error);
-          } else {
-            await wait(250 * 2 ** i);
-          }
-        }
+        queue.clear();
+        return;
       }
+
+      // Blocks are missing. They should be fetched and enqueued.
+      if (latestLocalBlock.number + 1 < newHeadBlockNumber) {
+        // Retrieve missing blocks, but only fetch 50 at most.
+        const missingBlockRange = range(
+          latestLocalBlock.number + 1,
+          Math.min(newHeadBlockNumber, latestLocalBlock.number + 51),
+        );
+        const pendingBlocks = await Promise.all(
+          missingBlockRange.map((blockNumber) =>
+            _eth_getBlockByNumber(service, { blockNumber }),
+          ),
+        );
+
+        service.common.logger.debug({
+          service: "realtime",
+          msg: `Fetched ${missingBlockRange.length} missing '${
+            service.network.name
+          }' blocks from ${latestLocalBlock.number + 1} to ${Math.min(
+            newHeadBlockNumber,
+            latestLocalBlock.number + 51,
+          )}`,
+        });
+
+        // This is needed to ensure proper `kill()` behavior. When the service
+        // is killed, nothing should be added to the queue, or else `onIdle()`
+        // will never resolve.
+        if (service.isKilled) return;
+
+        queue.clear();
+
+        for (const pendingBlock of pendingBlocks) {
+          queue.add(pendingBlock).then(onSuccess).catch(onError);
+        }
+
+        queue.add(newHeadBlock).then(onSuccess).catch(onError);
+
+        return;
+      }
+
+      // Check if a reorg occurred by validating the chain of block hashes.
+      if (newHeadBlock.parentHash !== latestLocalBlock.hash) {
+        await handleReorg(service, newHeadBlock);
+        queue.clear();
+        return;
+      }
+
+      // New block is exactly one block ahead of the local chain.
+      // Attempt to ingest it.
+      await handleBlock(service, { newHeadBlock });
+
+      return;
     },
   });
 
   const enqueue = async () => {
+    const block = await _eth_getBlockByNumber(service, {
+      blockTag: "latest",
+    });
+
     try {
-      const block = await _eth_getBlockByNumber(service, {
-        blockTag: "latest",
-      });
-
-      return queue.add(block);
+      await queue.add(block);
+      onSuccess();
     } catch (_error) {
-      if (service.isKilled) return;
-
-      const error = _error as Error;
-
-      service.common.logger.warn({
-        service: "realtime",
-        msg: `Failed to fetch latest '${service.network.name}' block with error: ${error}`,
-      });
+      onError(_error);
     }
   };
 

--- a/packages/core/src/sync/service.ts
+++ b/packages/core/src/sync/service.ts
@@ -171,7 +171,7 @@ export const create = async ({
 
       const requestQueue = createRequestQueue({
         network,
-        metrics: common.metrics,
+        common,
       });
 
       const [{ latestBlock, finalizedBlock }, remoteChainId] =

--- a/packages/core/src/sync/transport.test.ts
+++ b/packages/core/src/sync/transport.test.ts
@@ -31,7 +31,7 @@ test("default", async (context) => {
         "key": "custom",
         "name": "Custom Provider",
         "request": [Function],
-        "retryCount": 3,
+        "retryCount": 0,
         "retryDelay": 150,
         "timeout": undefined,
         "type": "custom",

--- a/packages/core/src/sync/transport.ts
+++ b/packages/core/src/sync/transport.ts
@@ -85,6 +85,6 @@ export const cachedTransport = ({
         }
       },
     });
-    return c({ chain });
+    return c({ chain, retryCount: 0 });
   };
 };

--- a/packages/core/src/utils/requestQueue.test.ts
+++ b/packages/core/src/utils/requestQueue.test.ts
@@ -11,7 +11,7 @@ beforeEach(setupAnvil);
 const getQueue = (network: Network, common: Common) => {
   return createRequestQueue({
     network: { ...network, maxRequestsPerSecond: 1 },
-    metrics: common.metrics,
+    common,
   });
 };
 

--- a/packages/core/src/utils/requestQueue.ts
+++ b/packages/core/src/utils/requestQueue.ts
@@ -1,8 +1,15 @@
-import type { MetricsService } from "@/common/metrics.js";
+import type { Common } from "@/common/common.js";
 import type { Network } from "@/config/networks.js";
 import { type Queue, createQueue } from "@ponder/common";
-import { type EIP1193Parameters, type PublicRpcSchema } from "viem";
+import {
+  type EIP1193Parameters,
+  HttpRequestError,
+  InternalRpcError,
+  LimitExceededRpcError,
+  type PublicRpcSchema,
+} from "viem";
 import { startClock } from "./timer.js";
+import { wait } from "./wait.js";
 
 type RequestReturnType<
   method extends EIP1193Parameters<PublicRpcSchema>["method"],
@@ -25,30 +32,50 @@ export type RequestQueue = Omit<
  */
 export const createRequestQueue = ({
   network,
-  metrics,
-}: { network: Network; metrics: MetricsService }): RequestQueue => {
+  common,
+}: {
+  network: Network;
+  common: Common;
+}): RequestQueue => {
   const requestQueue = createQueue({
     frequency: network.maxRequestsPerSecond,
     concurrency: Math.ceil(network.maxRequestsPerSecond / 4),
     initialStart: true,
     browser: false,
-    worker: (task: {
+    worker: async (task: {
       request: EIP1193Parameters<PublicRpcSchema>;
       stopClockLag: () => number;
     }) => {
-      metrics.ponder_rpc_request_lag.observe(
+      common.metrics.ponder_rpc_request_lag.observe(
         { method: task.request.method, network: network.name },
         task.stopClockLag(),
       );
 
       const stopClock = startClock();
 
-      return network.transport.request(task.request).finally(() => {
-        metrics.ponder_rpc_request_duration.observe(
-          { method: task.request.method, network: network.name },
-          stopClock(),
-        );
-      });
+      for (let i = 0; i < 4; i++) {
+        try {
+          const response = await network.transport.request(task.request);
+          common.metrics.ponder_rpc_request_duration.observe(
+            { method: task.request.method, network: network.name },
+            stopClock(),
+          );
+
+          return response;
+        } catch (_error) {
+          const error = _error as Error;
+
+          if (shouldRetry(error) === false || i === 3) {
+            common.logger.error({
+              msg: "Request failed",
+              error,
+            });
+            throw error;
+          } else {
+            await wait(250 * 2 ** i);
+          }
+        }
+      }
     },
   });
 
@@ -63,3 +90,35 @@ export const createRequestQueue = ({
     },
   } as RequestQueue;
 };
+
+/**
+ * @link https://github.com/wevm/viem/blob/main/src/utils/buildRequest.ts#L192
+ */
+function shouldRetry(error: Error) {
+  if ("code" in error && typeof error.code === "number") {
+    if (error.code === -1) return true; // Unknown error
+    if (error.code === LimitExceededRpcError.code) return true;
+    if (error.code === InternalRpcError.code) return true;
+    return false;
+  }
+  if (error instanceof HttpRequestError && error.status) {
+    // Forbidden
+    if (error.status === 403) return true;
+    // Request Timeout
+    if (error.status === 408) return true;
+    // Request Entity Too Large
+    if (error.status === 413) return true;
+    // Too Many Requests
+    if (error.status === 429) return true;
+    // Internal Server Error
+    if (error.status === 500) return true;
+    // Bad Gateway
+    if (error.status === 502) return true;
+    // Service Unavailable
+    if (error.status === 503) return true;
+    // Gateway Timeout
+    if (error.status === 504) return true;
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Historical indexing can be made much faster because it doesn't need to maintain any information to handle a reorg.

Benchmarks show a 1.5x speedup in indexing speed with a full sync cache.