### PR TITLE
Fix hot reloading bug

### DIFF
--- a/.changeset/tiny-knives-yawn.md
+++ b/.changeset/tiny-knives-yawn.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where the dev server would often crash with the error "The database connection is not open" when using SQLite or "Cannot use a pool after calling end on the pool" when using Postgres.

--- a/.changeset/weak-sheep-care.md
+++ b/.changeset/weak-sheep-care.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Improved error messages for SQL constraint violations (unique, not-null, and no record found during an update).

--- a/packages/core/src/bin/utils/shutdown.ts
+++ b/packages/core/src/bin/utils/shutdown.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import readline from "node:readline";
 import type { Common } from "@/common/common.js";
+import { IgnorableError } from "@/common/errors.js";
 
 const SHUTDOWN_GRACE_PERIOD_MS = 5_000;
 
@@ -73,6 +74,7 @@ export function setupShutdown({
   );
 
   process.on("uncaughtException", (error: Error) => {
+    if (error instanceof IgnorableError) return;
     common.logger.error({
       service: "process",
       msg: "Caught uncaughtException event with error:",
@@ -81,6 +83,7 @@ export function setupShutdown({
     shutdown({ reason: "Received uncaughtException", code: 1 });
   });
   process.on("unhandledRejection", (error: Error) => {
+    if (error instanceof IgnorableError) return;
     common.logger.error({
       service: "process",
       msg: "Caught unhandledRejection event with error:",

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -24,3 +24,12 @@ export class DatabaseError extends NonRetryableError {
     Object.setPrototypeOf(this, DatabaseError.prototype);
   }
 }
+
+export class IgnorableError extends Error {
+  override name = "IgnorableError";
+
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, IgnorableError.prototype);
+  }
+}

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -1,35 +1,72 @@
-export class NonRetryableError extends Error {
+export class BaseError extends Error {
+  override name = "BaseError";
+
+  meta: string[] = [];
+
+  constructor(message?: string | undefined) {
+    super(message);
+    Object.setPrototypeOf(this, BaseError.prototype);
+  }
+}
+
+export function getBaseError(err: any) {
+  if (err instanceof BaseError) return err;
+  if (err instanceof Error) return new BaseError(err.message);
+  if (typeof err?.message === "string") return new BaseError(err.message);
+  if (typeof err === "string") return new BaseError(err);
+  return new BaseError("unknown error");
+}
+
+export class NonRetryableError extends BaseError {
   override name = "NonRetryableError";
 
-  constructor(message: string) {
+  constructor(message?: string | undefined) {
     super(message);
     Object.setPrototypeOf(this, NonRetryableError.prototype);
+  }
+}
+
+export class IgnorableError extends BaseError {
+  override name = "IgnorableError";
+
+  constructor(message?: string | undefined) {
+    super(message);
+    Object.setPrototypeOf(this, IgnorableError.prototype);
   }
 }
 
 export class StoreError extends NonRetryableError {
   override name = "StoreError";
 
-  constructor(message: string) {
+  constructor(message?: string | undefined) {
     super(message);
     Object.setPrototypeOf(this, StoreError.prototype);
   }
 }
 
-export class DatabaseError extends NonRetryableError {
-  override name = "DatabaseError";
+export class UniqueConstraintError extends NonRetryableError {
+  override name = "UniqueConstraintError";
 
-  constructor(message: string) {
+  constructor(message?: string | undefined) {
     super(message);
-    Object.setPrototypeOf(this, DatabaseError.prototype);
+    Object.setPrototypeOf(this, UniqueConstraintError.prototype);
   }
 }
 
-export class IgnorableError extends Error {
-  override name = "IgnorableError";
+export class NotNullConstraintError extends NonRetryableError {
+  override name = "NotNullConstraintError";
 
-  constructor(message?: string) {
+  constructor(message?: string | undefined) {
     super(message);
-    Object.setPrototypeOf(this, IgnorableError.prototype);
+    Object.setPrototypeOf(this, NotNullConstraintError.prototype);
+  }
+}
+
+export class RecordNotFoundError extends NonRetryableError {
+  override name = "RecordNotFoundError";
+
+  constructor(message?: string | undefined) {
+    super(message);
+    Object.setPrototypeOf(this, RecordNotFoundError.prototype);
   }
 }

--- a/packages/core/src/common/logger.ts
+++ b/packages/core/src/common/logger.ts
@@ -38,7 +38,10 @@ export class LoggerService {
             if (log.error) {
               const message = log.error.stack ?? log.error.message ?? log.error;
               console.log(message);
-              if (log.error?.meta) console.log(log.error.meta);
+              if (typeof log.error?.meta === "string")
+                console.log(log.error.meta);
+              if (Array.isArray(log.error?.meta))
+                console.log(log.error.meta.join("\n"));
             }
 
             // TODO: Consider also logging any inner `cause` errors.

--- a/packages/core/src/database/kysely.ts
+++ b/packages/core/src/database/kysely.ts
@@ -51,7 +51,7 @@ export class HeadlessKysely<DB> extends Kysely<DB> {
         });
 
         if (this.isKilled) {
-          this.common.logger.debug({
+          this.common.logger.trace({
             service: this.name,
             msg: `Ignored error during '${options.method}' (service is killed)`,
           });

--- a/packages/core/src/database/kysely.ts
+++ b/packages/core/src/database/kysely.ts
@@ -1,7 +1,10 @@
 import type { Common } from "@/common/common.js";
-import { NonRetryableError } from "@/common/errors.js";
+import { IgnorableError, NonRetryableError } from "@/common/errors.js";
 import { startClock } from "@/utils/timer.js";
 import { Kysely, type KyselyConfig, type KyselyProps } from "kysely";
+
+const RETRY_COUNT = 3;
+const BASE_DURATION = 100;
 
 export class HeadlessKysely<DB> extends Kysely<DB> {
   private common: Common;
@@ -23,14 +26,11 @@ export class HeadlessKysely<DB> extends Kysely<DB> {
   }
 
   wrap = async <T>(options: { method: string }, fn: () => Promise<T>) => {
-    const endClock = startClock();
-    const RETRY_COUNT = 3;
-    const BASE_DURATION = 100;
-
-    let error: any;
+    let firstError: any;
     let hasError = false;
 
     for (let i = 0; i < RETRY_COUNT + 1; i++) {
+      const endClock = startClock();
       try {
         const result = await fn();
         this.common.metrics.ponder_database_method_duration.observe(
@@ -38,21 +38,40 @@ export class HeadlessKysely<DB> extends Kysely<DB> {
           endClock(),
         );
         return result;
-      } catch (_error) {
-        if (this.isKilled || _error instanceof NonRetryableError) {
-          throw _error;
+      } catch (e) {
+        const error = e as Error;
+
+        this.common.metrics.ponder_database_method_duration.observe(
+          { service: this.name, method: options.method },
+          endClock(),
+        );
+        this.common.metrics.ponder_database_method_error_total.inc({
+          service: this.name,
+          method: options.method,
+        });
+
+        if (this.isKilled) {
+          this.common.logger.debug({
+            service: this.name,
+            msg: `Ignored error during '${options.method}' (service is killed)`,
+          });
+          throw new IgnorableError();
+        }
+
+        if (error instanceof NonRetryableError) {
+          throw error;
         }
 
         if (!hasError) {
           hasError = true;
-          error = _error;
+          firstError = error;
         }
 
         if (i < RETRY_COUNT) {
           const duration = BASE_DURATION * 2 ** i;
           this.common.logger.warn({
             service: this.name,
-            msg: `Database error while running ${options.method}, retrying after ${duration} milliseconds. Error: ${error.message}`,
+            msg: `Database error during '${options.method}', retrying after ${duration} milliseconds. Error: ${firstError.message}`,
           });
           await new Promise((_resolve) => {
             setTimeout(_resolve, duration);
@@ -61,11 +80,6 @@ export class HeadlessKysely<DB> extends Kysely<DB> {
       }
     }
 
-    this.common.metrics.ponder_database_method_error_total.inc({
-      service: this.name,
-      method: options.method,
-    });
-
-    throw error;
+    throw firstError;
   };
 }

--- a/packages/core/src/indexing-store/historicalStore.test.ts
+++ b/packages/core/src/indexing-store/historicalStore.test.ts
@@ -3,6 +3,7 @@ import {
   setupDatabaseServices,
   setupIsolatedDatabase,
 } from "@/_test/setup.js";
+import { UniqueConstraintError } from "@/common/errors.js";
 import { createSchema } from "@/schema/schema.js";
 import {
   type Checkpoint,
@@ -74,16 +75,16 @@ test("create() throws on unique constraint violation", async (context) => {
     data: { name: "Skip" },
   });
 
-  await expect(() =>
-    indexingStore.create({
+  const error = await indexingStore
+    .create({
       tableName: "Pet",
       encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
       id: "id1",
       data: { name: "Skip", age: 13 },
-    }),
-  ).rejects.toThrow(
-    "Cannot create Pet record with ID id1 because a record already exists with that ID (UNIQUE constraint violation). Hint: Did you forget to await the promise returned by a store method? Or, consider using Pet.upsert().",
-  );
+    })
+    .catch((_error) => _error);
+
+  expect(error).instanceOf(UniqueConstraintError);
 
   await cleanup();
 });

--- a/packages/core/src/indexing-store/historicalStore.ts
+++ b/packages/core/src/indexing-store/historicalStore.ts
@@ -1,10 +1,10 @@
-import { StoreError } from "@/common/errors.js";
 import { HeadlessKysely } from "@/database/kysely.js";
 import type { NamespaceInfo } from "@/database/service.js";
 import type { Schema } from "@/schema/types.js";
 import { sql } from "kysely";
 import type { Row, WhereInput, WriteIndexingStore } from "./store.js";
 import { decodeRow, encodeRow, encodeValue } from "./utils/encoding.js";
+import { parseStoreError } from "./utils/errors.js";
 import { buildWhereConditions } from "./utils/filter.js";
 
 const MAX_BATCH_SIZE = 1_000 as const;
@@ -34,26 +34,17 @@ export const getHistoricalIndexingStore = ({
     return db.wrap({ method: `${tableName}.create` }, async () => {
       const createRow = encodeRow({ id, ...data }, table, kind);
 
-      try {
-        const row = await db
-          .withSchema(namespaceInfo.userNamespace)
-          .insertInto(tableName)
-          .values(createRow)
-          .returningAll()
-          .executeTakeFirstOrThrow();
+      const row = await db
+        .withSchema(namespaceInfo.userNamespace)
+        .insertInto(tableName)
+        .values(createRow)
+        .returningAll()
+        .executeTakeFirstOrThrow()
+        .catch((err) => {
+          throw parseStoreError(err, { id, ...data });
+        });
 
-        return decodeRow(row, table, kind);
-      } catch (err) {
-        const error = err as Error;
-        throw (kind === "sqlite" &&
-          error.message.includes("UNIQUE constraint failed")) ||
-          (kind === "postgres" &&
-            error.message.includes("violates unique constraint"))
-          ? new StoreError(
-              `Cannot create ${tableName} record with ID ${id} because a record already exists with that ID (UNIQUE constraint violation). Hint: Did you forget to await the promise returned by a store method? Or, consider using ${tableName}.upsert().`,
-            )
-          : error;
-      }
+      return decodeRow(row, table, kind);
     });
   },
   createMany: async ({
@@ -69,30 +60,21 @@ export const getHistoricalIndexingStore = ({
 
     for (let i = 0, len = data.length; i < len; i += MAX_BATCH_SIZE) {
       await db.wrap({ method: `${tableName}.createMany` }, async () => {
-        try {
-          const createRows = data
-            .slice(i, i + MAX_BATCH_SIZE)
-            .map((d) => encodeRow(d, table, kind));
+        const createRows = data
+          .slice(i, i + MAX_BATCH_SIZE)
+          .map((d) => encodeRow(d, table, kind));
 
-          const _rows = await db
-            .withSchema(namespaceInfo.userNamespace)
-            .insertInto(tableName)
-            .values(createRows)
-            .returningAll()
-            .execute();
+        const _rows = await db
+          .withSchema(namespaceInfo.userNamespace)
+          .insertInto(tableName)
+          .values(createRows)
+          .returningAll()
+          .execute()
+          .catch((err) => {
+            throw parseStoreError(err, data.length > 0 ? data[0] : {});
+          });
 
-          rows.push(...(_rows as Row[]));
-        } catch (err) {
-          const error = err as Error;
-          throw (kind === "sqlite" &&
-            error.message.includes("UNIQUE constraint failed")) ||
-            (kind === "postgres" &&
-              error.message.includes("violates unique constraint"))
-            ? new StoreError(
-                `Cannot createMany ${tableName} records because one or more records already exist (UNIQUE constraint violation). Hint: Did you forget to await the promise returned by a store method?`,
-              )
-            : error;
-        }
+        rows.push(...(_rows as Row[]));
       });
     }
 
@@ -114,7 +96,7 @@ export const getHistoricalIndexingStore = ({
     return db.wrap({ method: `${tableName}.update` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
 
-      let updateRow: ReturnType<typeof encodeRow>;
+      let updateObject: Partial<Omit<Row, "id">>;
 
       if (typeof data === "function") {
         // Find the latest version of this instance.
@@ -123,28 +105,29 @@ export const getHistoricalIndexingStore = ({
           .selectFrom(tableName)
           .selectAll()
           .where("id", "=", encodedId)
-          .executeTakeFirst();
-        if (!latestRow)
-          throw new StoreError(
-            `Cannot update ${tableName} record with ID ${id} because no existing record was found with that ID. Consider using ${tableName}.upsert(), or create the record before updating it. Hint: Did you forget to await the promise returned by a store method?`,
-          );
+          .executeTakeFirstOrThrow()
+          .catch((err) => {
+            throw parseStoreError(err, { id, data: "(function)" });
+          });
 
         const current = decodeRow(latestRow, table, kind);
-        const updateObject = data({ current });
-        updateRow = encodeRow({ id, ...updateObject }, table, kind);
+        updateObject = data({ current });
       } else {
-        updateRow = encodeRow({ id, ...data }, table, kind);
+        updateObject = data;
       }
+
+      const updateRow = encodeRow({ id, ...updateObject }, table, kind);
       const row = await db
         .updateTable(tableName)
         .set(updateRow)
         .where("id", "=", encodedId)
         .returningAll()
-        .executeTakeFirstOrThrow();
+        .executeTakeFirstOrThrow()
+        .catch((err) => {
+          throw parseStoreError(err, { id, ...updateObject });
+        });
 
-      const result = decodeRow(row, table, kind);
-
-      return result;
+      return decodeRow(row, table, kind);
     });
   },
   updateMany: async ({
@@ -192,8 +175,10 @@ export const getHistoricalIndexingStore = ({
               .set(updateRow)
               .where("id", "=", latestRow.id)
               .returningAll()
-              .executeTakeFirstOrThrow();
-
+              .executeTakeFirstOrThrow()
+              .catch((err) => {
+                throw parseStoreError(err, updateObject);
+              });
             rows.push(row as Row);
           }
 
@@ -229,7 +214,10 @@ export const getHistoricalIndexingStore = ({
           .from("latestRows")
           .where(`${tableName}.id`, "=", sql.ref("latestRows.id"))
           .returningAll()
-          .execute();
+          .execute()
+          .catch((err) => {
+            throw parseStoreError(err, data);
+          });
 
         return rows.map((row) => decodeRow(row, table, kind));
       }
@@ -270,7 +258,14 @@ export const getHistoricalIndexingStore = ({
             .insertInto(tableName)
             .values(createRow)
             .returningAll()
-            .executeTakeFirstOrThrow();
+            .executeTakeFirstOrThrow()
+            .catch((err) => {
+              const prettyObject: any = { id };
+              for (const [key, value] of Object.entries(create))
+                prettyObject[`create.${key}`] = value;
+              prettyObject.update = "(function)";
+              throw parseStoreError(err, prettyObject);
+            });
 
           return decodeRow(row, table, kind);
         }
@@ -285,7 +280,16 @@ export const getHistoricalIndexingStore = ({
           .set(updateRow)
           .where("id", "=", encodedId)
           .returningAll()
-          .executeTakeFirstOrThrow();
+          .executeTakeFirstOrThrow()
+          .catch((err) => {
+            const prettyObject: any = { id };
+            for (const [key, value] of Object.entries(create))
+              prettyObject[`create.${key}`] = value;
+            for (const [key, value] of Object.entries(updateObject))
+              prettyObject[`update.${key}`] = value;
+            throw parseStoreError(err, prettyObject);
+          });
+
         return decodeRow(row, table, kind);
       } else {
         const updateRow = encodeRow({ id, ...update }, table, kind);
@@ -296,7 +300,15 @@ export const getHistoricalIndexingStore = ({
           .values(createRow)
           .onConflict((oc) => oc.column("id").doUpdateSet(updateRow))
           .returningAll()
-          .executeTakeFirstOrThrow();
+          .executeTakeFirstOrThrow()
+          .catch((err) => {
+            const prettyObject: any = { id };
+            for (const [key, value] of Object.entries(create))
+              prettyObject[`create.${key}`] = value;
+            for (const [key, value] of Object.entries(update))
+              prettyObject[`update.${key}`] = value;
+            throw parseStoreError(err, prettyObject);
+          });
 
         return decodeRow(row, table, kind);
       }
@@ -319,7 +331,10 @@ export const getHistoricalIndexingStore = ({
         .deleteFrom(tableName)
         .where("id", "=", encodedId)
         .returning(["id"])
-        .executeTakeFirst();
+        .executeTakeFirst()
+        .catch((err) => {
+          throw parseStoreError(err, { id });
+        });
 
       return !!deletedRow;
     });

--- a/packages/core/src/indexing-store/historicalStore.ts
+++ b/packages/core/src/indexing-store/historicalStore.ts
@@ -286,7 +286,12 @@ export const getHistoricalIndexingStore = ({
           .withSchema(namespaceInfo.userNamespace)
           .insertInto(tableName)
           .values(createRow)
-          .onConflict((oc) => oc.column("id").doUpdateSet(updateRow))
+          .onConflict((oc) =>
+            // If the updateRow is empty, DO UPDATE SET throws a syntax error.
+            Object.keys(updateRow).length === 0
+              ? oc.column("id").doNothing()
+              : oc.column("id").doUpdateSet(updateRow),
+          )
           .returningAll()
           .executeTakeFirstOrThrow()
           .catch((err) => {

--- a/packages/core/src/indexing-store/realtimeStore.test.ts
+++ b/packages/core/src/indexing-store/realtimeStore.test.ts
@@ -3,6 +3,7 @@ import {
   setupDatabaseServices,
   setupIsolatedDatabase,
 } from "@/_test/setup.js";
+import { UniqueConstraintError } from "@/common/errors.js";
 import { createSchema } from "@/schema/schema.js";
 import {
   type Checkpoint,
@@ -81,14 +82,16 @@ test("create() throws on unique constraint violation", async (context) => {
     data: { name: "Skip" },
   });
 
-  await expect(() =>
-    indexingStore.create({
+  const error = await indexingStore
+    .create({
       tableName: "Pet",
       encodedCheckpoint: encodeCheckpoint(createCheckpoint(10)),
       id: "id1",
       data: { name: "Skip", age: 13 },
-    }),
-  ).rejects.toThrow("UNIQUE constraint failed: Pet.id");
+    })
+    .catch((_error) => _error);
+
+  expect(error).instanceOf(UniqueConstraintError);
 
   await cleanup();
 });

--- a/packages/core/src/indexing-store/realtimeStore.test.ts
+++ b/packages/core/src/indexing-store/realtimeStore.test.ts
@@ -88,9 +88,7 @@ test("create() throws on unique constraint violation", async (context) => {
       id: "id1",
       data: { name: "Skip", age: 13 },
     }),
-  ).rejects.toThrow(
-    "Cannot create Pet record with ID id1 because a record already exists with that ID (UNIQUE constraint violation). Hint: Did you forget to await the promise returned by a store method? Or, consider using Pet.upsert().",
-  );
+  ).rejects.toThrow("UNIQUE constraint failed: Pet.id");
 
   await cleanup();
 });

--- a/packages/core/src/indexing-store/utils/errors.ts
+++ b/packages/core/src/indexing-store/utils/errors.ts
@@ -1,0 +1,34 @@
+import {
+  NotNullConstraintError,
+  RecordNotFoundError,
+  UniqueConstraintError,
+  getBaseError,
+} from "@/common/errors.js";
+import { prettyPrint } from "@/utils/print.js";
+
+export function parseStoreError(err: unknown, args: Record<string, unknown>) {
+  let error = getBaseError(err);
+
+  if (error.message?.includes("no result")) {
+    error = new RecordNotFoundError(
+      "No existing record was found with the specified ID",
+    );
+  } else if (
+    error.message?.includes("UNIQUE constraint failed") ||
+    error.message?.includes("violates unique constraint")
+  ) {
+    error = new UniqueConstraintError(error.message);
+    error.meta.push(
+      "Hints:\n  Did you forget to await the promise returned by a store method?\n  Did you mean to do an upsert?",
+    );
+  } else if (
+    error.message?.includes("NOT NULL constraint failed") ||
+    error.message?.includes("violates not-null constraint")
+  ) {
+    error = new NotNullConstraintError(error.message);
+  }
+
+  error.meta.push(`Store method arguments:\n${prettyPrint(args)}`);
+
+  return error;
+}

--- a/packages/core/src/utils/print.ts
+++ b/packages/core/src/utils/print.ts
@@ -5,7 +5,7 @@ export function prettyPrint(
 ) {
   const entries = Object.entries(args)
     .map(([key, value]) => {
-      if (value === undefined || value === false) return null;
+      if (value === undefined) return null;
 
       const trimmedValue =
         typeof value === "string" && value.length > 80
@@ -20,6 +20,6 @@ export function prettyPrint(
     0,
   );
   return entries
-    .map(([key, value]) => `  ${`${key}:`.padEnd(maxLength + 1)}  ${value}`)
+    .map(([key, value]) => `  ${`${key}`.padEnd(maxLength + 1)}  ${value}`)
     .join("\n");
 }


### PR DESCRIPTION
This PR improves error logging in two key ways:
1. Catches and ignores errors thrown by database methods that run after the database has been killed. This fixes a really annoying bug that caused the dev server to crash
2. Improved common SQL constraint + logic errors using custom error classes and better logging, see screenshots.
![Screen Shot 2024-04-23 at 6 12 55 PM](https://github.com/ponder-sh/ponder/assets/90073088/861452e1-e1cd-4d39-af23-06d1b618617b)
![Screen Shot 2024-04-23 at 4 02 25 PM](https://github.com/ponder-sh/ponder/assets/90073088/439f4125-9d55-4a22-8255-748eb805b981)
![Screen Shot 2024-04-23 at 3 53 18 PM](https://github.com/ponder-sh/ponder/assets/90073088/8d2cd165-292d-41ec-b689-4ec5955cb2aa)
