### PR TITLE
Improve `sync-historical` logs: network name, missing commas

### DIFF
--- a/.changeset/forty-rice-dress.md
+++ b/.changeset/forty-rice-dress.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Added the network name to the historical sync log message and inserted missing commas in logs that contain more than one variable.

--- a/packages/core/src/sync-historical/service.ts
+++ b/packages/core/src/sync-historical/service.ts
@@ -455,7 +455,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           service: "historical",
           msg: `Sync is ${formatPercentage(progress ?? 0)} complete${
             eta !== undefined ? ` with ~${formatEta(eta)} remaining` : ""
-          } (contract=${contractName})`,
+          } (contract=${contractName}, network=${this.network.name})`,
           network: this.network.name,
         });
       });

--- a/packages/core/src/sync-historical/service.ts
+++ b/packages/core/src/sync-historical/service.ts
@@ -265,7 +265,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
             service: "historical",
             msg: `Started sync with ${formatPercentage(
               Math.min(1, cachedBlockCount / (targetBlockCount || 1)),
-            )} cached (contract=${source.contractName} network=${
+            )} cached (contract=${source.contractName}, network=${
               this.network.name
             })`,
           });
@@ -433,7 +433,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
             service: "historical",
             msg: `Started sync with ${formatPercentage(
               cacheRate,
-            )} cached (contract=${source.contractName} network=${
+            )} cached (contract=${source.contractName}, network=${
               this.network.name
             })`,
           });


### PR DESCRIPTION
Closes #819 