### PR TITLE
Move getLogs retry logic into request queue for better errors

### DIFF
--- a/packages/core/src/utils/requestQueue.ts
+++ b/packages/core/src/utils/requestQueue.ts
@@ -72,8 +72,10 @@ export const createRequestQueue = ({
           if (getLogsErrorResponse.shouldRetry === false) throw error;
 
           common.logger.debug({
-            service: "historical",
-            msg: `eth_getLogs request failed, retrying with ranges: [${getLogsErrorResponse.ranges
+            service: "sync",
+            msg: `Caught eth_getLogs error on '${
+              network.name
+            }', retrying with ranges: [${getLogsErrorResponse.ranges
               .map(
                 ({ fromBlock, toBlock }) =>
                   `[${hexToBigInt(fromBlock).toString()}, ${hexToBigInt(

--- a/packages/core/src/utils/requestQueue.ts
+++ b/packages/core/src/utils/requestQueue.ts
@@ -103,15 +103,9 @@ export const createRequestQueue = ({
           return logs;
         }
 
-        if (shouldRetry(error) === false || i === 3) {
-          common.logger.error({
-            msg: "Request failed",
-            error,
-          });
-          throw error;
-        } else {
-          await wait(250 * 2 ** i);
-        }
+        if (shouldRetry(error) === false || i === 3) throw error;
+
+        await wait(250 * 2 ** i);
       }
     }
   };


### PR DESCRIPTION
Consolidate request retry logic and error handling into the request queue.

This fixes a bug where error logs were thrown for eth_getLogs requests that were being correctly parsed.