### PR TITLE
Allow custom indexes to be defined in "ponder.schema.ts"

### DIFF
--- a/.changeset/proud-islands-taste.md
+++ b/.changeset/proud-islands-taste.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Added support for database indexes using the `p.index()` function in `ponder.schema.ts`. [Read more](https://ponder.sh/docs/schema#indexes).

--- a/docs/pages/docs/query/direct-sql.mdx
+++ b/docs/pages/docs/query/direct-sql.mdx
@@ -176,6 +176,10 @@ These are the [SQLite data types](https://www.sqlite.org/datatype3.html) used by
 
 SQLite does not natively support integers larger than 8 bytes. To safely store and compare large integers (such as 32-byte EVM `uint256{:solidity}` values) in SQLite, we designed an encoding that uses `VARCHAR(79){:sql}` and takes advantage of SQLite's native lexicographic sort. [Here is the reference implementation](https://github.com/ponder-sh/ponder/blob/main/packages/core/src/utils/encoding.ts) used by Ponder internally.
 
+### Indexes
+
+To create indexes on specific columns, use the `p.index()` function in `ponder.schema.ts` Do not manually construct database indexes. [Read more](/docs/schema#indexes).
+
 ## Postgres
 
 ### Database schema
@@ -328,3 +332,6 @@ These are the [Postgres data types](https://www.postgresql.org/docs/current/data
 | `p.float(){:ts}`   | `FLOAT8{:sql}`/`DOUBLE{:sql}` |                                                           |
 | `p.boolean(){:ts}` | `INTEGER{:sql}`               | `0` is `false{:ts}`, `1` is `true{:ts}`                   |
 
+### Indexes
+
+To create indexes on specific columns, use the `p.index()` function in `ponder.schema.ts` Do not manually construct database indexes. [Read more](/docs/schema#indexes).

--- a/docs/pages/docs/query/graphql.mdx
+++ b/docs/pages/docs/query/graphql.mdx
@@ -479,6 +479,15 @@ type Person {
 
 </div>
 
+## How to speed up queries
+
+Here are a few tips for speeding up slow queries.
+
+1. **Create database indexes**: Create indexes to speed up filters, joins, and sort conditions. [Read more](/docs/schema#indexes).
+2. **Enable horizontal scaling**: If the GraphQL API is struggling to keep up with reqeust volume, consider spreading the load across multiple instances. [Read more](/docs/production/horizontal-scaling).
+3. **Limit query depth**: Each layer of depth in a GraphQL query introduces at least one additional sequential database query. Avoid queries that are more than 2 layers deep.
+3. **Use pagination**: Use cursor-based pagination to fetch records in smaller, more manageable chunks. This can help reduce the load on the database.
+
 ## Time-travel queries
 
 <Callout type="warning">Native support for time-travel queries was removed in `0.4.0`. [Read more](/docs/indexing/time-series).</Callout>

--- a/docs/pages/docs/schema.mdx
+++ b/docs/pages/docs/schema.mdx
@@ -525,6 +525,25 @@ query {
 
 </div>
 
+## Custom Indexes
+
+Database indexes can be added to tables by passing a second argument to `p.createTable(){:ts}`. Then, use `p.index(){:ts}` passing the name of the column.
+
+```ts filename="ponder.schema.ts" {8}
+import { createSchema } from "@ponder/core";
+
+export default createSchema((p) => ({
+  Person: p.createTable({
+    id: p.string(),
+    age: p.int(),
+  }, {
+    ageIndex: p.index("age"),
+  }),
+}));
+```
+
+Multi column indexes can be created by passing an array of column names to `p.index(){:ts}`.
+
 ## ERC20 example
 
 Here's a schema for a simple ERC20 app.

--- a/docs/pages/docs/schema.mdx
+++ b/docs/pages/docs/schema.mdx
@@ -544,6 +544,8 @@ export default createSchema((p) => ({
 
 Multi column indexes can be created by passing an array of column names to `p.index(){:ts}`.
 
+Use the `.asc(){:ts}`, `.desc(){:ts}`, `.nullsFirst(){:ts}`, or `.nullsLast(){:ts}` modifiers to apply an ordering to a single column index.
+
 ## ERC20 example
 
 Here's a schema for a simple ERC20 app.

--- a/docs/pages/docs/schema.mdx
+++ b/docs/pages/docs/schema.mdx
@@ -525,26 +525,75 @@ query {
 
 </div>
 
-## Custom Indexes
+## Indexes
 
-Database indexes can be added to tables by passing a second argument to `p.createTable(){:ts}`. Then, use `p.index(){:ts}` passing the name of the column.
+To create a database index, include a second argument to the `p.createTable(){:ts}` function, and use `p.index(){:ts}` to specify which column(s) to include in the index.
 
-```ts filename="ponder.schema.ts" {8}
+<Callout type="info">
+  Database indexes are created _after_ historical indexing is complete, just
+  before the app becomes healthy.
+</Callout>
+
+### Single column
+
+To create a index on a single column, pass the column name to `p.index(){:ts}`.
+
+{/* prettier-ignore */}
+```ts filename="ponder.schema.ts" {10,17}
+import { createSchema } from "@ponder/core";
+
+export default createSchema((p) => ({
+  Person: p.createTable({
+    id: p.string(),
+    name: p.string(),
+    dogs: p.many("Dog.ownerId"),
+  }, {
+    // Index the `name` column to speed up search queries.
+    nameIndex: p.index("name"),
+  }),
+  Dog: p.createTable({
+    id: p.string(),
+    ownerId: p.string().references("Person.id"),
+  }, {
+    // Index the `ownerId` column to speed up relational queries (the `Person.dogs` field).
+    ownerIdIndex: p.index("ownerId"),
+  }),
+}));
+```
+
+For single-column indexes, you can also specify the direction of the index using `.asc(){:ts}` or `.desc(){:ts}`, and the null ordering behavior using `.nullsFirst(){:ts}` or `.nullsLast(){:ts}`. These options improve query performance if you use the column in an `ORDER BY{:sql}` clause.
+
+```ts filename="ponder.schema.ts" {6}
+import { createSchema } from "@ponder/core";
+
+export default createSchema((p) => ({
+  Person: p.createTable(
+    { id: p.string(), age: p.string() },
+    { ageIndex: p.index("age").asc().nullsLast() }
+  ),
+}));
+```
+
+### Multiple columns
+
+To create a multi-column index, pass an array of column names to `p.index(){:ts}`.
+
+{/* prettier-ignore */}
+```ts filename="ponder.schema.ts" {9}
 import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   Person: p.createTable({
     id: p.string(),
     age: p.int(),
+    salary: p.bigint(),
   }, {
-    ageIndex: p.index("age"),
+    seniorityIndex: p.index(["age", "salary"]),
   }),
 }));
 ```
 
-Multi column indexes can be created by passing an array of column names to `p.index(){:ts}`.
-
-Use the `.asc(){:ts}`, `.desc(){:ts}`, `.nullsFirst(){:ts}`, or `.nullsLast(){:ts}` modifiers to apply an ordering to a single column index.
+The `.asc(){:ts}`, `.desc(){:ts}`, `.nullsFirst(){:ts}` and `.nullsLast(){:ts}` modifiers are not currently supported for multi-column indexes.
 
 ## ERC20 example
 

--- a/docs/pages/docs/schema.mdx
+++ b/docs/pages/docs/schema.mdx
@@ -561,7 +561,7 @@ export default createSchema((p) => ({
 }));
 ```
 
-For single-column indexes, you can also specify the direction of the index using `.asc(){:ts}` or `.desc(){:ts}`, and the null ordering behavior using `.nullsFirst(){:ts}` or `.nullsLast(){:ts}`. These options improve query performance if you use the column in an `ORDER BY{:sql}` clause.
+For single-column indexes, you can also specify the direction of the index using `.asc(){:ts}` or `.desc(){:ts}`, and the null ordering behavior using `.nullsFirst(){:ts}` or `.nullsLast(){:ts}`. These options can improve query performance if you use the column in an `ORDER BY{:sql}` clause using the same options.
 
 ```ts filename="ponder.schema.ts" {6}
 import { createSchema } from "@ponder/core";
@@ -576,7 +576,7 @@ export default createSchema((p) => ({
 
 ### Multiple columns
 
-To create a multi-column index, pass an array of column names to `p.index(){:ts}`.
+To create a multi-column index, pass an array of column names to `p.index(){:ts}`. The index will be created using the same column order that you specify.
 
 {/* prettier-ignore */}
 ```ts filename="ponder.schema.ts" {9}

--- a/examples/reference-erc20/ponder.schema.ts
+++ b/examples/reference-erc20/ponder.schema.ts
@@ -22,17 +22,20 @@ export default createSchema((p) => ({
     owner: p.one("ownerId"),
     spender: p.one("spenderId"),
   }),
-  TransferEvent: p.createTable({
-    id: p.string(),
-    amount: p.bigint(),
-    timestamp: p.int(),
+  TransferEvent: p.createTable(
+    {
+      id: p.string(),
+      amount: p.bigint(),
+      timestamp: p.int(),
 
-    fromId: p.hex().references("Account.id"),
-    toId: p.hex().references("Account.id"),
+      fromId: p.hex().references("Account.id"),
+      toId: p.hex().references("Account.id"),
 
-    from: p.one("fromId"),
-    to: p.one("toId"),
-  }),
+      from: p.one("fromId"),
+      to: p.one("toId"),
+    },
+    { fromIdIndex: p.index("fromId") },
+  ),
   ApprovalEvent: p.createTable({
     id: p.string(),
     amount: p.bigint(),

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -350,7 +350,7 @@ export async function waitForHealthy(port: number) {
       reject(new Error("Timed out while waiting for app to become healthy."));
     }, 5_000);
     const interval = setInterval(async () => {
-      const response = await fetch(`http://localhost:${port}/health`);
+      const response = await fetch(`http://0.0.0.0:${port}/health`);
       if (response.status === 200) {
         clearTimeout(timeout);
         clearInterval(interval);
@@ -361,7 +361,7 @@ export async function waitForHealthy(port: number) {
 }
 
 export async function postGraphql(port: number, query: string) {
-  const response = await fetch(`http://localhost:${port}/graphql`, {
+  const response = await fetch(`http://0.0.0.0:${port}/graphql`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query: `query { ${query} }` }),
@@ -370,6 +370,6 @@ export async function postGraphql(port: number, query: string) {
 }
 
 export async function getMetrics(port: number) {
-  const response = await fetch(`http://localhost:${port}/metrics`);
+  const response = await fetch(`http://0.0.0.0:${port}/metrics`);
   return await response.text();
 }

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -350,7 +350,7 @@ export async function waitForHealthy(port: number) {
       reject(new Error("Timed out while waiting for app to become healthy."));
     }, 5_000);
     const interval = setInterval(async () => {
-      const response = await fetch(`http://0.0.0.0:${port}/health`);
+      const response = await fetch(`http://localhost:${port}/health`);
       if (response.status === 200) {
         clearTimeout(timeout);
         clearInterval(interval);
@@ -361,7 +361,7 @@ export async function waitForHealthy(port: number) {
 }
 
 export async function postGraphql(port: number, query: string) {
-  const response = await fetch(`http://0.0.0.0:${port}/graphql`, {
+  const response = await fetch(`http://localhost:${port}/graphql`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query: `query { ${query} }` }),
@@ -370,6 +370,6 @@ export async function postGraphql(port: number, query: string) {
 }
 
 export async function getMetrics(port: number) {
-  const response = await fetch(`http://0.0.0.0:${port}/metrics`);
+  const response = await fetch(`http://localhost:${port}/metrics`);
   return await response.text();
 }

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -270,7 +270,7 @@ export async function run({
     }
     await handleFinalize(syncService.finalizedCheckpoint);
 
-    await database.addIndexes({ schema });
+    await database.createIndexes({ schema });
 
     server.setHealthy();
     common.logger.info({

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -270,6 +270,8 @@ export async function run({
     }
     await handleFinalize(syncService.finalizedCheckpoint);
 
+    await database.addIndexes({ schema });
+
     server.setHealthy();
     common.logger.info({
       service: "server",

--- a/packages/core/src/build/schema.test.ts
+++ b/packages/core/src/build/schema.test.ts
@@ -327,3 +327,85 @@ test("safeBuildSchema() returns error for foreign key column type mismatch", () 
     "type does not match the referenced table's ID column type",
   );
 });
+
+test("safeBuildSchema() returns error for empty index", () => {
+  const schema = createSchema((p) => ({
+    myTable: p.createTable(
+      {
+        id: p.string(),
+        col: p.int(),
+      },
+      {
+        colIndex: p.index([]),
+      },
+    ),
+  }));
+
+  const result = safeBuildSchema({ schema });
+  expect(result.status).toBe("error");
+  expect(result.error?.message).toContain("Index 'colIndex' cannot be empty.");
+});
+
+test("safeBuildSchema() returns error for duplicate index", () => {
+  const schema = createSchema((p) => ({
+    myTable: p.createTable(
+      {
+        id: p.string(),
+        col: p.int(),
+      },
+      {
+        colIndex: p.index(["col", "col"]),
+      },
+    ),
+  }));
+
+  const result = safeBuildSchema({ schema });
+  expect(result.status).toBe("error");
+  expect(result.error?.message).toContain(
+    "Index 'colIndex' cannot contain duplicate columns.",
+  );
+});
+
+test("safeBuildSchema() returns error for invalid multi-column index", () => {
+  const schema = createSchema((p) => ({
+    // @ts-expect-error
+    myTable: p.createTable(
+      {
+        id: p.string(),
+        col: p.int(),
+      },
+      {
+        // @ts-expect-error
+        colIndex: p.index(["coll"]),
+      },
+    ),
+  }));
+
+  const result = safeBuildSchema({ schema });
+  expect(result.status).toBe("error");
+  expect(result.error?.message).toContain(
+    "Index 'colIndex' does not reference a valid column.",
+  );
+});
+
+test("safeBuildSchema() returns error for invalid index", () => {
+  const schema = createSchema((p) => ({
+    // @ts-expect-error
+    myTable: p.createTable(
+      {
+        id: p.string(),
+        col: p.int(),
+      },
+      {
+        // @ts-expect-error
+        colIndex: p.index("col1"),
+      },
+    ),
+  }));
+
+  const result = safeBuildSchema({ schema });
+  expect(result.status).toBe("error");
+  expect(result.error?.message).toContain(
+    "Index 'colIndex' does not reference a valid column.",
+  );
+});

--- a/packages/core/src/build/schema.ts
+++ b/packages/core/src/build/schema.ts
@@ -251,6 +251,16 @@ export const buildSchema = ({ schema }: { schema: Schema }) => {
                   table,
                 ).join(", ")}].`,
               );
+
+            if (isOneColumn(table[c]))
+              throw new Error(
+                `Validation failed: Invalid type for column '${column}' referenced by index '${name}'. Got 'one', expected one of ['string', 'hex', 'bigint', 'int', 'boolean', 'float'].`,
+              );
+
+            if (isManyColumn(table[c]))
+              throw new Error(
+                `Validation failed: Invalid type for column '${column}' referenced by index '${name}'. Got 'many', expected one of ['string', 'hex', 'bigint', 'int', 'boolean', 'float'].`,
+              );
           }
         } else {
           // TODO(kyle) should this be an error
@@ -262,6 +272,16 @@ export const buildSchema = ({ schema }: { schema: Schema }) => {
               `Validation failed: Index '${name}' does not reference a valid column. Got '${column}', expected one of [${Object.keys(
                 table,
               ).join(", ")}].`,
+            );
+
+          if (isOneColumn(table[column]))
+            throw new Error(
+              `Validation failed: Invalid type for column '${column}' referenced by index '${name}'. Got 'one', expected one of ['string', 'hex', 'bigint', 'int', 'boolean', 'float'].`,
+            );
+
+          if (isManyColumn(table[column]))
+            throw new Error(
+              `Validation failed: Invalid type for column '${column}' referenced by index '${name}'. Got 'many', expected one of ['string', 'hex', 'bigint', 'int', 'boolean', 'float'].`,
             );
         }
       }

--- a/packages/core/src/build/schema.ts
+++ b/packages/core/src/build/schema.ts
@@ -28,7 +28,7 @@ export const buildSchema = ({ schema }: { schema: Schema }) => {
   });
 
   // Validate tables
-  Object.entries(schemaToTables(schema)).forEach(([tableName, table]) => {
+  Object.entries(schemaToTables(schema)).forEach(([tableName, [table]]) => {
     validateTableOrColumnName(tableName, "Table");
 
     // Validate the id column
@@ -130,7 +130,7 @@ export const buildSchema = ({ schema }: { schema: Schema }) => {
           );
         }
 
-        const usedTableColumns = Object.entries(usedTable[1]);
+        const usedTableColumns = Object.entries(usedTable[1][0]);
         const usedColumn = usedTableColumns.find(
           ([columnName]) => columnName === column[" referenceColumn"],
         );
@@ -191,9 +191,9 @@ export const buildSchema = ({ schema }: { schema: Schema }) => {
           );
         }
 
-        if (referencedTable[1].id[" scalar"] !== column[" scalar"]) {
+        if (referencedTable[1][0].id[" scalar"] !== column[" scalar"]) {
           throw new Error(
-            `Validation failed: Foreign key column '${tableName}.${columnName}' type does not match the referenced table's ID column type. Got '${column[" scalar"]}', expected '${referencedTable[1].id[" scalar"]}'.`,
+            `Validation failed: Foreign key column '${tableName}.${columnName}' type does not match the referenced table's ID column type. Got '${column[" scalar"]}', expected '${referencedTable[1][0].id[" scalar"]}'.`,
           );
         }
 

--- a/packages/core/src/build/schema.ts
+++ b/packages/core/src/build/schema.ts
@@ -32,7 +32,7 @@ export const buildSchema = ({ schema }: { schema: Schema }) => {
 
   // Validate tables
   Object.entries(getTables(schema)).forEach(
-    ([tableName, [table, constraints]]) => {
+    ([tableName, { table, constraints }]) => {
       validateTableOrColumnName(tableName, "Table");
 
       // Validate the id column
@@ -134,7 +134,7 @@ export const buildSchema = ({ schema }: { schema: Schema }) => {
             );
           }
 
-          const usedTableColumns = Object.entries(usedTable[1][0]);
+          const usedTableColumns = Object.entries(usedTable[1].table);
           const usedColumn = usedTableColumns.find(
             ([columnName]) => columnName === column[" referenceColumn"],
           );
@@ -197,9 +197,9 @@ export const buildSchema = ({ schema }: { schema: Schema }) => {
             );
           }
 
-          if (referencedTable[1][0].id[" scalar"] !== column[" scalar"]) {
+          if (referencedTable[1].table.id[" scalar"] !== column[" scalar"]) {
             throw new Error(
-              `Validation failed: Foreign key column '${tableName}.${columnName}' type does not match the referenced table's ID column type. Got '${column[" scalar"]}', expected '${referencedTable[1][0].id[" scalar"]}'.`,
+              `Validation failed: Foreign key column '${tableName}.${columnName}' type does not match the referenced table's ID column type. Got '${column[" scalar"]}', expected '${referencedTable[1].table.id[" scalar"]}'.`,
             );
           }
 

--- a/packages/core/src/build/service.ts
+++ b/packages/core/src/build/service.ts
@@ -413,6 +413,10 @@ const validateAndBuild = async (
     return buildSchemaResult;
   }
 
+  for (const log of buildSchemaResult.logs) {
+    common.logger[log.level]({ service: "build", msg: log.msg });
+  }
+
   const graphqlSchema = buildGraphqlSchema(buildSchemaResult.schema);
 
   // Validates and build the config

--- a/packages/core/src/database/postgres/service.test.ts
+++ b/packages/core/src/database/postgres/service.test.ts
@@ -721,7 +721,7 @@ describe.skipIf(shouldSkip)("postgres database", () => {
 
     expect(indexes).toHaveLength(2);
 
-    expect(indexes[1]).toBe("Person_nameIndex");
+    expect(indexes).toContain("Person_nameIndex");
 
     await database.kill();
   });
@@ -742,7 +742,7 @@ describe.skipIf(shouldSkip)("postgres database", () => {
 
     expect(indexes).toHaveLength(2);
 
-    expect(indexes[1]).toBe("Pet_multiIndex");
+    expect(indexes).toContain("Pet_multiIndex");
 
     await database.kill();
   });

--- a/packages/core/src/database/postgres/service.test.ts
+++ b/packages/core/src/database/postgres/service.test.ts
@@ -705,7 +705,7 @@ describe.skipIf(shouldSkip)("postgres database", () => {
     await database.kill();
   });
 
-  test("addIndexes adds a single column index", async (context) => {
+  test("createIndexes adds a single column index", async (context) => {
     if (context.databaseConfig.kind !== "postgres") return;
     const database = new PostgresDatabaseService({
       common: context.common,
@@ -715,7 +715,7 @@ describe.skipIf(shouldSkip)("postgres database", () => {
 
     await database.setup({ schema, buildId: "abc" });
 
-    await database.addIndexes({ schema });
+    await database.createIndexes({ schema });
 
     const indexes = await getTableIndexes(database.db, "Person", "public");
 
@@ -726,7 +726,7 @@ describe.skipIf(shouldSkip)("postgres database", () => {
     await database.kill();
   });
 
-  test("addIndexes adds a multi column index", async (context) => {
+  test("createIndexes adds a multi column index", async (context) => {
     if (context.databaseConfig.kind !== "postgres") return;
     const database = new PostgresDatabaseService({
       common: context.common,
@@ -736,7 +736,7 @@ describe.skipIf(shouldSkip)("postgres database", () => {
 
     await database.setup({ schema, buildId: "abc" });
 
-    await database.addIndexes({ schema });
+    await database.createIndexes({ schema });
 
     const indexes = await getTableIndexes(database.db, "Pet", "public");
 

--- a/packages/core/src/database/postgres/service.test.ts
+++ b/packages/core/src/database/postgres/service.test.ts
@@ -779,6 +779,27 @@ describe.skipIf(shouldSkip)("postgres database", () => {
 
     await database.kill();
   });
+
+  test("createIndexes with a custom user namespace", async (context) => {
+    if (context.databaseConfig.kind !== "postgres") return;
+    const database = new PostgresDatabaseService({
+      common: context.common,
+      poolConfig: context.databaseConfig.poolConfig,
+      userNamespace: `_${context.databaseConfig.schema}`,
+    });
+
+    await database.setup({ schema, buildId: "abc" });
+
+    await database.createIndexes({ schema });
+
+    const indexes = await getTableIndexes(database.db, "Person", "_public");
+
+    expect(indexes).toHaveLength(2);
+
+    expect(indexes).toContain("Person_nameIndex");
+
+    await database.kill();
+  });
 });
 
 async function getTableNames(db: HeadlessKysely<any>, schemaName: string) {

--- a/packages/core/src/database/postgres/service.ts
+++ b/packages/core/src/database/postgres/service.ts
@@ -619,7 +619,11 @@ export class PostgresDatabaseService implements BaseDatabaseService {
 
           this.common.logger.info({
             service: "database",
-            msg: `Created index '${tableName}_${name}' on table '${tableName}' in schema '${this.userNamespace}'`,
+            msg: `Created index '${tableName}_${name}' on columns (${
+              Array.isArray(index[" column"])
+                ? index[" column"].join(", ")
+                : index[" column"]
+            }) in schema '${this.userNamespace}'`,
           });
         });
       }),

--- a/packages/core/src/database/postgres/service.ts
+++ b/packages/core/src/database/postgres/service.ts
@@ -597,13 +597,13 @@ export class PostgresDatabaseService implements BaseDatabaseService {
     });
   }
 
-  async addIndexes({ schema }: { schema: Schema }) {
+  async createIndexes({ schema }: { schema: Schema }) {
     await Promise.all(
       Object.entries(getTables(schema)).flatMap(([tableName, table]) => {
         if (table[1] === undefined) return [];
 
         return Object.entries(table[1]).map(async ([name, index]) => {
-          await this.db.wrap({ method: "addIndexes" }, async () => {
+          await this.db.wrap({ method: "createIndexes" }, async () => {
             const indexName = `${tableName}_${name}`;
 
             await this.db.schema

--- a/packages/core/src/database/postgres/service.ts
+++ b/packages/core/src/database/postgres/service.ts
@@ -216,7 +216,7 @@ export class PostgresDatabaseService implements BaseDatabaseService {
 
           // Function to create the operation log tables and user tables.
           const createTables = async () => {
-            for (const [tableName, columns] of Object.entries(
+            for (const [tableName, table] of Object.entries(
               schemaToTables(schema),
             )) {
               const tableId = namespaceInfo.internalTableIds[tableName];
@@ -225,7 +225,7 @@ export class PostgresDatabaseService implements BaseDatabaseService {
                 .withSchema(this.internalNamespace)
                 .createTable(tableId)
                 .$call((builder) =>
-                  this.buildOperationLogColumns(builder, columns),
+                  this.buildOperationLogColumns(builder, table[0]),
                 )
                 .execute();
 
@@ -241,7 +241,7 @@ export class PostgresDatabaseService implements BaseDatabaseService {
                   .withSchema(this.userNamespace)
                   .createTable(tableName)
                   .$call((builder) =>
-                    this.buildColumns(builder, schema, columns),
+                    this.buildColumns(builder, schema, table[0]),
                   )
                   .execute();
               } catch (err) {

--- a/packages/core/src/database/postgres/service.ts
+++ b/packages/core/src/database/postgres/service.ts
@@ -619,7 +619,7 @@ export class PostgresDatabaseService implements BaseDatabaseService {
 
           this.common.logger.info({
             service: "database",
-            msg: `Created index '${name}' on table '${tableName}' in schema '${this.userNamespace}'`,
+            msg: `Created index '${tableName}_${name}' on table '${tableName}' in schema '${this.userNamespace}'`,
           });
         });
       }),

--- a/packages/core/src/database/postgres/service.ts
+++ b/packages/core/src/database/postgres/service.ts
@@ -225,7 +225,7 @@ export class PostgresDatabaseService implements BaseDatabaseService {
                 .withSchema(this.internalNamespace)
                 .createTable(tableId)
                 .$call((builder) =>
-                  this.buildOperationLogColumns(builder, table[0]),
+                  this.buildOperationLogColumns(builder, table.table),
                 )
                 .execute();
 
@@ -241,7 +241,7 @@ export class PostgresDatabaseService implements BaseDatabaseService {
                   .withSchema(this.userNamespace)
                   .createTable(tableName)
                   .$call((builder) =>
-                    this.buildColumns(builder, schema, table[0]),
+                    this.buildColumns(builder, schema, table.table),
                   )
                   .execute();
               } catch (err) {
@@ -600,9 +600,9 @@ export class PostgresDatabaseService implements BaseDatabaseService {
   async createIndexes({ schema }: { schema: Schema }) {
     await Promise.all(
       Object.entries(getTables(schema)).flatMap(([tableName, table]) => {
-        if (table[1] === undefined) return [];
+        if (table.constraints === undefined) return [];
 
-        return Object.entries(table[1]).map(async ([name, index]) => {
+        return Object.entries(table.constraints).map(async ([name, index]) => {
           await this.db.wrap({ method: "createIndexes" }, async () => {
             const indexName = `${tableName}_${name}`;
 

--- a/packages/core/src/database/postgres/service.ts
+++ b/packages/core/src/database/postgres/service.ts
@@ -624,7 +624,7 @@ export class PostgresDatabaseService implements BaseDatabaseService {
 
             await this.db.executeQuery(
               sql`CREATE INDEX ${sql.ref(indexName)} ON ${sql.table(
-                tableName,
+                `${this.userNamespace}.${tableName}`,
               )} (${sql.raw(columns)})`.compile(this.db),
             );
           });

--- a/packages/core/src/database/service.ts
+++ b/packages/core/src/database/service.ts
@@ -37,5 +37,7 @@ export interface BaseDatabaseService {
     checkpoint,
   }: { checkpoint: Checkpoint }): Promise<void>;
 
+  addIndexes({ schema }: { schema: Schema }): Promise<void>;
+
   kill(): Promise<void>;
 }

--- a/packages/core/src/database/service.ts
+++ b/packages/core/src/database/service.ts
@@ -37,7 +37,7 @@ export interface BaseDatabaseService {
     checkpoint,
   }: { checkpoint: Checkpoint }): Promise<void>;
 
-  addIndexes({ schema }: { schema: Schema }): Promise<void>;
+  createIndexes({ schema }: { schema: Schema }): Promise<void>;
 
   kill(): Promise<void>;
 }

--- a/packages/core/src/database/sqlite/service.test.ts
+++ b/packages/core/src/database/sqlite/service.test.ts
@@ -538,7 +538,7 @@ describe.skipIf(shouldSkip)("sqlite database", () => {
     await databaseTwo.kill();
   });
 
-  test("addIndexes adds a single column index", async (context) => {
+  test("createIndexes adds a single column index", async (context) => {
     if (context.databaseConfig.kind !== "sqlite") return;
     const database = new SqliteDatabaseService({
       common: context.common,
@@ -547,7 +547,7 @@ describe.skipIf(shouldSkip)("sqlite database", () => {
 
     await database.setup({ schema, buildId: "abc" });
 
-    await database.addIndexes({ schema });
+    await database.createIndexes({ schema });
 
     const indexes = await getIndexNames(database.db, "Person", "public");
 
@@ -558,7 +558,7 @@ describe.skipIf(shouldSkip)("sqlite database", () => {
     await database.kill();
   });
 
-  test("addIndexes adds a multi column index", async (context) => {
+  test("createIndexes adds a multi column index", async (context) => {
     if (context.databaseConfig.kind !== "sqlite") return;
     const database = new SqliteDatabaseService({
       common: context.common,
@@ -567,7 +567,7 @@ describe.skipIf(shouldSkip)("sqlite database", () => {
 
     await database.setup({ schema, buildId: "abc" });
 
-    await database.addIndexes({ schema });
+    await database.createIndexes({ schema });
 
     const indexes = await getIndexNames(database.db, "Pet", "public");
 

--- a/packages/core/src/database/sqlite/service.test.ts
+++ b/packages/core/src/database/sqlite/service.test.ts
@@ -553,7 +553,7 @@ describe.skipIf(shouldSkip)("sqlite database", () => {
 
     expect(indexes).toHaveLength(2);
 
-    expect(indexes[1]).toBe("Person_nameIndex");
+    expect(indexes).toContain("Person_nameIndex");
 
     await database.kill();
   });
@@ -573,7 +573,7 @@ describe.skipIf(shouldSkip)("sqlite database", () => {
 
     expect(indexes).toHaveLength(2);
 
-    expect(indexes[1]).toBe("Pet_multiIndex");
+    expect(indexes).toContain("Pet_multiIndex");
 
     await database.kill();
   });

--- a/packages/core/src/database/sqlite/service.ts
+++ b/packages/core/src/database/sqlite/service.ts
@@ -188,7 +188,7 @@ export class SqliteDatabaseService implements BaseDatabaseService {
 
           // Function to create the operation log tables and user tables.
           const createTables = async () => {
-            for (const [tableName, columns] of Object.entries(
+            for (const [tableName, table] of Object.entries(
               schemaToTables(schema),
             )) {
               const tableId = namespaceInfo.internalTableIds[tableName];
@@ -197,7 +197,7 @@ export class SqliteDatabaseService implements BaseDatabaseService {
                 .withSchema(this.internalNamespace)
                 .createTable(tableId)
                 .$call((builder) =>
-                  this.buildOperationLogColumns(builder, columns),
+                  this.buildOperationLogColumns(builder, table[0]),
                 )
                 .execute();
 
@@ -212,7 +212,7 @@ export class SqliteDatabaseService implements BaseDatabaseService {
                   .withSchema(this.userNamespace)
                   .createTable(tableName)
                   .$call((builder) =>
-                    this.buildColumns(builder, schema, columns),
+                    this.buildColumns(builder, schema, table[0]),
                   )
                   .execute();
               } catch (err) {

--- a/packages/core/src/database/sqlite/service.ts
+++ b/packages/core/src/database/sqlite/service.ts
@@ -498,6 +498,25 @@ export class SqliteDatabaseService implements BaseDatabaseService {
     });
   }
 
+  async addIndexes({ schema }: { schema: Schema }) {
+    for (const [tableName, table] of Object.entries(schemaToTables(schema))) {
+      if (table[1] === undefined) continue;
+
+      for (const [name, index] of Object.entries(table[1])) {
+        await this.db.schema
+          .withSchema(this.userNamespace)
+          .createIndex(`${tableName}_${name}`)
+          .on(tableName)
+          .$call((builder) =>
+            Array.isArray(index[" column"])
+              ? builder.columns(index[" column"] as string[])
+              : builder.column(index[" column"]),
+          )
+          .execute();
+      }
+    }
+  }
+
   async kill() {
     await this.db.wrap({ method: "kill" }, async () => {
       clearInterval(this.heartbeatInterval);

--- a/packages/core/src/database/sqlite/service.ts
+++ b/packages/core/src/database/sqlite/service.ts
@@ -523,7 +523,11 @@ export class SqliteDatabaseService implements BaseDatabaseService {
 
           this.common.logger.info({
             service: "database",
-            msg: `Created index '${tableName}_${name}' on table '${tableName}' in '${this.userNamespace}.db'`,
+            msg: `Created index '${tableName}_${name}' on columns (${
+              Array.isArray(index[" column"])
+                ? index[" column"].join(", ")
+                : index[" column"]
+            }) in '${this.userNamespace}.db'`,
           });
         });
       }),

--- a/packages/core/src/database/sqlite/service.ts
+++ b/packages/core/src/database/sqlite/service.ts
@@ -499,22 +499,35 @@ export class SqliteDatabaseService implements BaseDatabaseService {
   }
 
   async addIndexes({ schema }: { schema: Schema }) {
-    for (const [tableName, table] of Object.entries(schemaToTables(schema))) {
-      if (table[1] === undefined) continue;
+    await Promise.all(
+      Object.entries(schemaToTables(schema)).flatMap(([tableName, table]) => {
+        if (table[1] === undefined) return [];
 
-      for (const [name, index] of Object.entries(table[1])) {
-        await this.db.schema
-          .withSchema(this.userNamespace)
-          .createIndex(`${tableName}_${name}`)
-          .on(tableName)
-          .$call((builder) =>
-            Array.isArray(index[" column"])
-              ? builder.columns(index[" column"] as string[])
-              : builder.column(index[" column"]),
-          )
-          .execute();
-      }
-    }
+        return Object.entries(table[1]).map(async ([name, index]) => {
+          await this.db.wrap({ method: "addIndexes" }, async () => {
+            const indexName = `${tableName}_${name}`;
+
+            const indexColumn = index[" column"];
+            const columns = Array.isArray(indexColumn)
+              ? indexColumn.map((ic) => `"${ic}"`).join(", ")
+              : `"${indexColumn}"`;
+
+            await this.db.executeQuery(
+              sql`CREATE INDEX "${sql.raw(this.userNamespace)}"."${sql.raw(
+                indexName,
+              )}" ON "${sql.raw(tableName)}" (${sql.raw(columns)})`.compile(
+                this.db,
+              ),
+            );
+          });
+
+          this.common.logger.info({
+            service: "database",
+            msg: `Created index '${tableName}_${name}' on table '${tableName}' in '${this.userNamespace}.db'`,
+          });
+        });
+      }),
+    );
   }
 
   async kill() {

--- a/packages/core/src/database/sqlite/service.ts
+++ b/packages/core/src/database/sqlite/service.ts
@@ -498,13 +498,13 @@ export class SqliteDatabaseService implements BaseDatabaseService {
     });
   }
 
-  async addIndexes({ schema }: { schema: Schema }) {
+  async createIndexes({ schema }: { schema: Schema }) {
     await Promise.all(
       Object.entries(getTables(schema)).flatMap(([tableName, table]) => {
         if (table[1] === undefined) return [];
 
         return Object.entries(table[1]).map(async ([name, index]) => {
-          await this.db.wrap({ method: "addIndexes" }, async () => {
+          await this.db.wrap({ method: "createIndexes" }, async () => {
             const indexName = `${tableName}_${name}`;
 
             const indexColumn = index[" column"];

--- a/packages/core/src/database/sqlite/service.ts
+++ b/packages/core/src/database/sqlite/service.ts
@@ -508,14 +508,19 @@ export class SqliteDatabaseService implements BaseDatabaseService {
             const indexName = `${tableName}_${name}`;
 
             const indexColumn = index[" column"];
+            const order = index[" order"];
+            const nulls = index[" nulls"];
+
             const columns = Array.isArray(indexColumn)
               ? indexColumn.map((ic) => `"${ic}"`).join(", ")
-              : `"${indexColumn}"`;
+              : `"${indexColumn}" ${
+                  order === "asc" ? "ASC" : order === "desc" ? "DESC" : ""
+                }`;
 
             await this.db.executeQuery(
-              sql`CREATE INDEX "${sql.raw(this.userNamespace)}"."${sql.raw(
+              sql`CREATE INDEX ${sql.ref(this.userNamespace)}.${sql.ref(
                 indexName,
-              )}" ON "${sql.raw(tableName)}" (${sql.raw(columns)})`.compile(
+              )} ON ${sql.table(tableName)} (${sql.raw(columns)})`.compile(
                 this.db,
               ),
             );

--- a/packages/core/src/database/sqlite/service.ts
+++ b/packages/core/src/database/sqlite/service.ts
@@ -197,7 +197,7 @@ export class SqliteDatabaseService implements BaseDatabaseService {
                 .withSchema(this.internalNamespace)
                 .createTable(tableId)
                 .$call((builder) =>
-                  this.buildOperationLogColumns(builder, table[0]),
+                  this.buildOperationLogColumns(builder, table.table),
                 )
                 .execute();
 
@@ -212,7 +212,7 @@ export class SqliteDatabaseService implements BaseDatabaseService {
                   .withSchema(this.userNamespace)
                   .createTable(tableName)
                   .$call((builder) =>
-                    this.buildColumns(builder, schema, table[0]),
+                    this.buildColumns(builder, schema, table.table),
                   )
                   .execute();
               } catch (err) {
@@ -501,15 +501,14 @@ export class SqliteDatabaseService implements BaseDatabaseService {
   async createIndexes({ schema }: { schema: Schema }) {
     await Promise.all(
       Object.entries(getTables(schema)).flatMap(([tableName, table]) => {
-        if (table[1] === undefined) return [];
+        if (table.constraints === undefined) return [];
 
-        return Object.entries(table[1]).map(async ([name, index]) => {
+        return Object.entries(table.constraints).map(async ([name, index]) => {
           await this.db.wrap({ method: "createIndexes" }, async () => {
             const indexName = `${tableName}_${name}`;
 
             const indexColumn = index[" column"];
             const order = index[" order"];
-            const nulls = index[" nulls"];
 
             const columns = Array.isArray(indexColumn)
               ? indexColumn.map((ic) => `"${ic}"`).join(", ")

--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -30,7 +30,7 @@ export const getHistoricalStore = ({
     id: UserIdColumn;
     data?: Omit<UserRow, "id">;
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.create` }, async () => {
       const createRow = encodeRow({ id, ...data }, table, kind);
@@ -55,7 +55,7 @@ export const getHistoricalStore = ({
     tableName: string;
     data: UserRow[];
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     const rows: DatabaseRow[] = [];
 
@@ -92,7 +92,7 @@ export const getHistoricalStore = ({
       | Partial<Omit<UserRow, "id">>
       | ((args: { current: UserRow }) => Partial<Omit<UserRow, "id">>);
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.update` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -140,7 +140,7 @@ export const getHistoricalStore = ({
       | Partial<Omit<UserRow, "id">>
       | ((args: { current: UserRow }) => Partial<Omit<UserRow, "id">>);
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.updateMany` }, async () => {
       if (typeof data === "function") {
@@ -232,7 +232,7 @@ export const getHistoricalStore = ({
       | Partial<Omit<UserRow, "id">>
       | ((args: { current: UserRow }) => Partial<Omit<UserRow, "id">>);
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.upsert` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -315,7 +315,7 @@ export const getHistoricalStore = ({
     tableName: string;
     id: UserIdColumn;
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.delete` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);

--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -30,7 +30,7 @@ export const getHistoricalStore = ({
     id: UserId;
     data?: Omit<UserRecord, "id">;
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.create` }, async () => {
       const createRow = encodeRow({ id, ...data }, table, kind);
@@ -55,7 +55,7 @@ export const getHistoricalStore = ({
     tableName: string;
     data: UserRecord[];
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     const rows: DatabaseRecord[] = [];
 
@@ -92,7 +92,7 @@ export const getHistoricalStore = ({
       | Partial<Omit<UserRecord, "id">>
       | ((args: { current: UserRecord }) => Partial<Omit<UserRecord, "id">>);
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.update` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -140,7 +140,7 @@ export const getHistoricalStore = ({
       | Partial<Omit<UserRecord, "id">>
       | ((args: { current: UserRecord }) => Partial<Omit<UserRecord, "id">>);
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.updateMany` }, async () => {
       if (typeof data === "function") {
@@ -232,7 +232,7 @@ export const getHistoricalStore = ({
       | Partial<Omit<UserRecord, "id">>
       | ((args: { current: UserRecord }) => Partial<Omit<UserRecord, "id">>);
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.upsert` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -315,7 +315,7 @@ export const getHistoricalStore = ({
     tableName: string;
     id: UserId;
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.delete` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);

--- a/packages/core/src/indexing-store/readonly.ts
+++ b/packages/core/src/indexing-store/readonly.ts
@@ -38,7 +38,7 @@ export const getReadonlyStore = ({
     tableName: string;
     id: UserIdColumn;
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.findUnique` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -70,7 +70,7 @@ export const getReadonlyStore = ({
     after?: string | null;
     limit?: number;
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.findMany` }, async () => {
       let query = db

--- a/packages/core/src/indexing-store/readonly.ts
+++ b/packages/core/src/indexing-store/readonly.ts
@@ -38,7 +38,7 @@ export const getReadonlyStore = ({
     tableName: string;
     id: UserId;
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.findUnique` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -70,7 +70,7 @@ export const getReadonlyStore = ({
     after?: string | null;
     limit?: number;
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.findMany` }, async () => {
       let query = db

--- a/packages/core/src/indexing-store/realtime.ts
+++ b/packages/core/src/indexing-store/realtime.ts
@@ -31,7 +31,7 @@ export const getRealtimeStore = ({
     id: UserIdColumn;
     data?: Omit<UserRow, "id">;
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.create` }, async () => {
       const createRow = encodeRow({ id, ...data }, table, kind);
@@ -70,7 +70,7 @@ export const getRealtimeStore = ({
     encodedCheckpoint: string;
     data: UserRow[];
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.createMany` }, async () => {
       const rows: DatabaseRow[] = [];
@@ -122,7 +122,7 @@ export const getRealtimeStore = ({
       | Partial<Omit<UserRow, "id">>
       | ((args: { current: UserRow }) => Partial<Omit<UserRow, "id">>);
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.update` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -186,7 +186,7 @@ export const getRealtimeStore = ({
       | Partial<Omit<UserRow, "id">>
       | ((args: { current: UserRow }) => Partial<Omit<UserRow, "id">>);
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.updateMany` }, async () => {
       const rows = await db.transaction().execute(async (tx) => {
@@ -262,7 +262,7 @@ export const getRealtimeStore = ({
       | Partial<Omit<UserRow, "id">>
       | ((args: { current: UserRow }) => Partial<Omit<UserRow, "id">>);
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.upsert` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -358,7 +358,7 @@ export const getRealtimeStore = ({
     encodedCheckpoint: string;
     id: UserIdColumn;
   }) => {
-    const table = schema[tableName] as Table;
+    const table = schema[tableName][0] as Table;
 
     return db.wrap({ method: `${tableName}.delete` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);

--- a/packages/core/src/indexing-store/realtime.ts
+++ b/packages/core/src/indexing-store/realtime.ts
@@ -31,7 +31,7 @@ export const getRealtimeStore = ({
     id: UserId;
     data?: Omit<UserRecord, "id">;
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.create` }, async () => {
       const createRow = encodeRow({ id, ...data }, table, kind);
@@ -70,7 +70,7 @@ export const getRealtimeStore = ({
     encodedCheckpoint: string;
     data: UserRecord[];
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.createMany` }, async () => {
       const rows: DatabaseRecord[] = [];
@@ -122,7 +122,7 @@ export const getRealtimeStore = ({
       | Partial<Omit<UserRecord, "id">>
       | ((args: { current: UserRecord }) => Partial<Omit<UserRecord, "id">>);
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.update` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -186,7 +186,7 @@ export const getRealtimeStore = ({
       | Partial<Omit<UserRecord, "id">>
       | ((args: { current: UserRecord }) => Partial<Omit<UserRecord, "id">>);
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.updateMany` }, async () => {
       const rows = await db.transaction().execute(async (tx) => {
@@ -262,7 +262,7 @@ export const getRealtimeStore = ({
       | Partial<Omit<UserRecord, "id">>
       | ((args: { current: UserRecord }) => Partial<Omit<UserRecord, "id">>);
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.upsert` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);
@@ -358,7 +358,7 @@ export const getRealtimeStore = ({
     encodedCheckpoint: string;
     id: UserId;
   }) => {
-    const table = schema[tableName][0] as Table;
+    const table = (schema[tableName] as { table: Table }).table;
 
     return db.wrap({ method: `${tableName}.delete` }, async () => {
       const encodedId = encodeValue(id, table.id, kind);

--- a/packages/core/src/indexing-store/utils/cursor.test.ts
+++ b/packages/core/src/indexing-store/utils/cursor.test.ts
@@ -23,7 +23,7 @@ const schema = createSchema((p) => ({
 test("cursor encoding handles default order by condition", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { id: "asc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   const record = { id: "abc" };
@@ -39,7 +39,7 @@ test("cursor encoding handles default order by condition", () => {
 test("cursor encoding handles custom order by condition", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { age: "desc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   const record = { id: "abc", age: 10 };
@@ -58,7 +58,7 @@ test("cursor encoding handles custom order by condition", () => {
 test("cursor encoding handles null values", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { age: "desc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   const record = { id: "abc", age: null };
@@ -77,7 +77,7 @@ test("cursor encoding handles null values", () => {
 test("cursor encoding handles bigint values", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { bigAge: "desc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   const record = { id: "abc", bigAge: 20n };
@@ -96,7 +96,7 @@ test("cursor encoding handles bigint values", () => {
 test("cursor encoding handles bigint list values", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { bigAges: "desc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   const record = { id: "abc", bigAges: [20n, -12n] };

--- a/packages/core/src/indexing-store/utils/cursor.test.ts
+++ b/packages/core/src/indexing-store/utils/cursor.test.ts
@@ -23,7 +23,7 @@ const schema = createSchema((p) => ({
 test("cursor encoding handles default order by condition", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { id: "asc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   const record = { id: "abc" };
@@ -39,7 +39,7 @@ test("cursor encoding handles default order by condition", () => {
 test("cursor encoding handles custom order by condition", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { age: "desc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   const record = { id: "abc", age: 10 };
@@ -58,7 +58,7 @@ test("cursor encoding handles custom order by condition", () => {
 test("cursor encoding handles null values", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { age: "desc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   const record = { id: "abc", age: null };
@@ -77,7 +77,7 @@ test("cursor encoding handles null values", () => {
 test("cursor encoding handles bigint values", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { bigAge: "desc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   const record = { id: "abc", bigAge: 20n };
@@ -96,7 +96,7 @@ test("cursor encoding handles bigint values", () => {
 test("cursor encoding handles bigint list values", () => {
   const orderByConditions = buildOrderByConditions({
     orderBy: { bigAges: "desc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   const record = { id: "abc", bigAges: [20n, -12n] };

--- a/packages/core/src/indexing-store/utils/filter.test.ts
+++ b/packages/core/src/indexing-store/utils/filter.test.ts
@@ -31,7 +31,7 @@ test("buildWhereConditions handles equals shortcut", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { id: "abc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "sqlite",
   });
 
@@ -44,7 +44,7 @@ test("buildWhereConditions handles not", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { id: { not: "abc" } },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "sqlite",
   });
 
@@ -57,7 +57,7 @@ test("buildWhereConditions handles multiple conditions for one column", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { id: { contains: "abc", notStartsWith: "z" } },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "sqlite",
   });
 
@@ -73,7 +73,7 @@ test("buildWhereConditions uses specified encoding", () => {
   const conditionsSqlite = buildWhereConditions({
     eb: buildMockEb(),
     where: { bigAge: { lt: 10n } },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "sqlite",
   });
 
@@ -90,7 +90,7 @@ test("buildWhereConditions uses specified encoding", () => {
   const conditionsPostgres = buildWhereConditions({
     eb: buildMockEb(),
     where: { bigAge: { lt: 10n } },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "postgres",
   });
 
@@ -103,7 +103,7 @@ test("buildWhereConditions handles list filters with encoding", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { bigAge: { in: [12n, 15n] } },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "sqlite",
   });
 
@@ -125,7 +125,7 @@ test("buildWhereConditions filters on reference column", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { personId: 5n },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "postgres",
   });
 
@@ -138,7 +138,7 @@ test("buildWhereConditions handles list column 'has' and 'notHas' special case",
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { names: { has: "Marty" } },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "sqlite",
   });
 
@@ -152,7 +152,7 @@ test("buildWhereConditions handles or operator", () => {
       bigAge: { lt: 10n },
       OR: [{ id: { contains: "abc" } }, { id: { notStartsWith: "z" } }],
     },
-    table: schema.Pet,
+    table: schema.Pet[0],
     encoding: "postgres",
   });
 
@@ -174,7 +174,7 @@ test("buildWhereConditions throws for unknown column", () => {
     buildWhereConditions({
       eb: buildMockEb(),
       where: { someFakeColumn: { equals: false } },
-      table: schema.Pet,
+      table: schema.Pet[0],
       encoding: "sqlite",
     }),
   ).toThrow(
@@ -187,7 +187,7 @@ test("buildWhereConditions throws for virtual column", () => {
     buildWhereConditions({
       eb: buildMockEb(),
       where: { person: { equals: 5n } },
-      table: schema.Pet,
+      table: schema.Pet[0],
       encoding: "sqlite",
     }),
   ).toThrow("Invalid filter. Cannot filter on virtual column 'person'");
@@ -199,7 +199,7 @@ test("buildWhereConditions throws for invalid filter condition", () => {
       eb: buildMockEb(),
       // @ts-ignore
       where: { personId: { notACondition: 5n } },
-      table: schema.Pet,
+      table: schema.Pet[0],
       encoding: "sqlite",
     }),
   ).toThrow(

--- a/packages/core/src/indexing-store/utils/filter.test.ts
+++ b/packages/core/src/indexing-store/utils/filter.test.ts
@@ -31,7 +31,7 @@ test("buildWhereConditions handles equals shortcut", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { id: "abc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "sqlite",
   });
 
@@ -44,7 +44,7 @@ test("buildWhereConditions handles not", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { id: { not: "abc" } },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "sqlite",
   });
 
@@ -57,7 +57,7 @@ test("buildWhereConditions handles multiple conditions for one column", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { id: { contains: "abc", notStartsWith: "z" } },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "sqlite",
   });
 
@@ -73,7 +73,7 @@ test("buildWhereConditions uses specified encoding", () => {
   const conditionsSqlite = buildWhereConditions({
     eb: buildMockEb(),
     where: { bigAge: { lt: 10n } },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "sqlite",
   });
 
@@ -90,7 +90,7 @@ test("buildWhereConditions uses specified encoding", () => {
   const conditionsPostgres = buildWhereConditions({
     eb: buildMockEb(),
     where: { bigAge: { lt: 10n } },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "postgres",
   });
 
@@ -103,7 +103,7 @@ test("buildWhereConditions handles list filters with encoding", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { bigAge: { in: [12n, 15n] } },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "sqlite",
   });
 
@@ -125,7 +125,7 @@ test("buildWhereConditions filters on reference column", () => {
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { personId: 5n },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "postgres",
   });
 
@@ -138,7 +138,7 @@ test("buildWhereConditions handles list column 'has' and 'notHas' special case",
   const conditions = buildWhereConditions({
     eb: buildMockEb(),
     where: { names: { has: "Marty" } },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "sqlite",
   });
 
@@ -152,7 +152,7 @@ test("buildWhereConditions handles or operator", () => {
       bigAge: { lt: 10n },
       OR: [{ id: { contains: "abc" } }, { id: { notStartsWith: "z" } }],
     },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
     encoding: "postgres",
   });
 
@@ -174,7 +174,7 @@ test("buildWhereConditions throws for unknown column", () => {
     buildWhereConditions({
       eb: buildMockEb(),
       where: { someFakeColumn: { equals: false } },
-      table: schema.Pet[0],
+      table: schema.Pet.table,
       encoding: "sqlite",
     }),
   ).toThrow(
@@ -187,7 +187,7 @@ test("buildWhereConditions throws for virtual column", () => {
     buildWhereConditions({
       eb: buildMockEb(),
       where: { person: { equals: 5n } },
-      table: schema.Pet[0],
+      table: schema.Pet.table,
       encoding: "sqlite",
     }),
   ).toThrow("Invalid filter. Cannot filter on virtual column 'person'");
@@ -199,7 +199,7 @@ test("buildWhereConditions throws for invalid filter condition", () => {
       eb: buildMockEb(),
       // @ts-ignore
       where: { personId: { notACondition: 5n } },
-      table: schema.Pet[0],
+      table: schema.Pet.table,
       encoding: "sqlite",
     }),
   ).toThrow(

--- a/packages/core/src/indexing-store/utils/sort.test.ts
+++ b/packages/core/src/indexing-store/utils/sort.test.ts
@@ -21,7 +21,7 @@ const schema = createSchema((p) => ({
 test("buildOrderByConditions defaults to id ascending", () => {
   const conditions = buildOrderByConditions({
     orderBy: undefined,
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   expect(conditions).toEqual([["id", "asc"]]);
@@ -30,7 +30,7 @@ test("buildOrderByConditions defaults to id ascending", () => {
 test("buildOrderByConditions adds secondary sort for non-id columns using the same direction", () => {
   const conditionsAsc = buildOrderByConditions({
     orderBy: { names: "asc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   expect(conditionsAsc).toEqual([
@@ -40,7 +40,7 @@ test("buildOrderByConditions adds secondary sort for non-id columns using the sa
 
   const conditionsDesc = buildOrderByConditions({
     orderBy: { names: "desc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   expect(conditionsDesc).toEqual([
@@ -53,7 +53,7 @@ test("buildOrderByConditions throws for sorting on multiple columns", () => {
   expect(() =>
     buildOrderByConditions({
       orderBy: { names: "desc", age: "asc" },
-      table: schema.Pet,
+      table: schema.Pet[0],
     }),
   ).toThrow("Cannot sort by multiple columns.");
 });
@@ -62,7 +62,7 @@ test("buildOrderByConditions throws for unknown column", () => {
   expect(() =>
     buildOrderByConditions({
       orderBy: { someFakeColumn: "asc" },
-      table: schema.Pet,
+      table: schema.Pet[0],
     }),
   ).toThrow(
     "Invalid sort. Column does not exist. Got 'someFakeColumn', expected one of ['id', 'names', 'age', 'bigAge', 'kind', 'personId']",
@@ -73,7 +73,7 @@ test("buildOrderByConditions throws for virtual column", () => {
   expect(() =>
     buildOrderByConditions({
       orderBy: { person: "desc" },
-      table: schema.Pet,
+      table: schema.Pet[0],
     }),
   ).toThrow("Invalid sort. Cannot filter on virtual column 'person'");
 });
@@ -83,7 +83,7 @@ test("buildOrderByConditions throws for invalid order direction", () => {
     buildOrderByConditions({
       // @ts-ignore
       orderBy: { personId: "aaaaasc" },
-      table: schema.Pet,
+      table: schema.Pet[0],
     }),
   ).toThrow("Invalid sort direction. Got 'aaaaasc', expected 'asc' or 'desc'");
 });
@@ -91,7 +91,7 @@ test("buildOrderByConditions throws for invalid order direction", () => {
 test("reverseOrderByConditions reverses with one condition", () => {
   const conditions = buildOrderByConditions({
     orderBy: undefined,
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   expect(conditions).toEqual([["id", "asc"]]);
@@ -103,7 +103,7 @@ test("reverseOrderByConditions reverses with one condition", () => {
 test("reverseOrderByConditions reverses with two conditions", () => {
   const conditions = buildOrderByConditions({
     orderBy: { names: "desc" },
-    table: schema.Pet,
+    table: schema.Pet[0],
   });
 
   expect(conditions).toEqual([

--- a/packages/core/src/indexing-store/utils/sort.test.ts
+++ b/packages/core/src/indexing-store/utils/sort.test.ts
@@ -21,7 +21,7 @@ const schema = createSchema((p) => ({
 test("buildOrderByConditions defaults to id ascending", () => {
   const conditions = buildOrderByConditions({
     orderBy: undefined,
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   expect(conditions).toEqual([["id", "asc"]]);
@@ -30,7 +30,7 @@ test("buildOrderByConditions defaults to id ascending", () => {
 test("buildOrderByConditions adds secondary sort for non-id columns using the same direction", () => {
   const conditionsAsc = buildOrderByConditions({
     orderBy: { names: "asc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   expect(conditionsAsc).toEqual([
@@ -40,7 +40,7 @@ test("buildOrderByConditions adds secondary sort for non-id columns using the sa
 
   const conditionsDesc = buildOrderByConditions({
     orderBy: { names: "desc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   expect(conditionsDesc).toEqual([
@@ -53,7 +53,7 @@ test("buildOrderByConditions throws for sorting on multiple columns", () => {
   expect(() =>
     buildOrderByConditions({
       orderBy: { names: "desc", age: "asc" },
-      table: schema.Pet[0],
+      table: schema.Pet.table,
     }),
   ).toThrow("Cannot sort by multiple columns.");
 });
@@ -62,7 +62,7 @@ test("buildOrderByConditions throws for unknown column", () => {
   expect(() =>
     buildOrderByConditions({
       orderBy: { someFakeColumn: "asc" },
-      table: schema.Pet[0],
+      table: schema.Pet.table,
     }),
   ).toThrow(
     "Invalid sort. Column does not exist. Got 'someFakeColumn', expected one of ['id', 'names', 'age', 'bigAge', 'kind', 'personId']",
@@ -73,7 +73,7 @@ test("buildOrderByConditions throws for virtual column", () => {
   expect(() =>
     buildOrderByConditions({
       orderBy: { person: "desc" },
-      table: schema.Pet[0],
+      table: schema.Pet.table,
     }),
   ).toThrow("Invalid sort. Cannot filter on virtual column 'person'");
 });
@@ -83,7 +83,7 @@ test("buildOrderByConditions throws for invalid order direction", () => {
     buildOrderByConditions({
       // @ts-ignore
       orderBy: { personId: "aaaaasc" },
-      table: schema.Pet[0],
+      table: schema.Pet.table,
     }),
   ).toThrow("Invalid sort direction. Got 'aaaaasc', expected 'asc' or 'desc'");
 });
@@ -91,7 +91,7 @@ test("buildOrderByConditions throws for invalid order direction", () => {
 test("reverseOrderByConditions reverses with one condition", () => {
   const conditions = buildOrderByConditions({
     orderBy: undefined,
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   expect(conditions).toEqual([["id", "asc"]]);
@@ -103,7 +103,7 @@ test("reverseOrderByConditions reverses with one condition", () => {
 test("reverseOrderByConditions reverses with two conditions", () => {
   const conditions = buildOrderByConditions({
     orderBy: { names: "desc" },
-    table: schema.Pet[0],
+    table: schema.Pet.table,
   });
 
   expect(conditions).toEqual([

--- a/packages/core/src/schema/columns.test-d.ts
+++ b/packages/core/src/schema/columns.test-d.ts
@@ -1,5 +1,5 @@
 import { assertType, test } from "vitest";
-import { _enum, many, one, string } from "./columns.js";
+import { _enum, index, many, one, string } from "./columns.js";
 
 test("base", () => {
   const c = string();
@@ -197,6 +197,18 @@ test("enum list + optional", () => {
       " enum": "enum";
       " optional": true;
       " list": true;
+    },
+  );
+});
+
+test("index", () => {
+  const i = index(["column"]);
+  //    ^?
+
+  assertType<typeof i>(
+    {} as unknown as {
+      " type": "index";
+      " column": readonly ["column"];
     },
   );
 });

--- a/packages/core/src/schema/columns.test-d.ts
+++ b/packages/core/src/schema/columns.test-d.ts
@@ -202,7 +202,7 @@ test("enum list + optional", () => {
 });
 
 test("index", () => {
-  const i = index(["column"]);
+  const i = index("column");
   //    ^?
 
   assertType<keyof typeof i>(
@@ -211,7 +211,7 @@ test("index", () => {
   assertType<Omit<typeof i, "asc" | "desc" | "nullsFirst" | "nullsLast">>(
     {} as unknown as {
       " type": "index";
-      " column": readonly ["column"];
+      " column": "column";
       " order": undefined;
       " nulls": undefined;
     },
@@ -219,14 +219,14 @@ test("index", () => {
 });
 
 test("index asc", () => {
-  const i = index(["column"]).asc();
+  const i = index("column").asc();
   //    ^?
 
   assertType<keyof typeof i>({} as unknown as "nullsFirst" | "nullsLast");
   assertType<Omit<typeof i, "nullsFirst" | "nullsLast">>(
     {} as unknown as {
       " type": "index";
-      " column": readonly ["column"];
+      " column": "column";
       " order": "asc";
       " nulls": undefined;
     },
@@ -234,14 +234,14 @@ test("index asc", () => {
 });
 
 test("index nullsFirst", () => {
-  const i = index(["column"]).nullsFirst();
+  const i = index("column").nullsFirst();
   //    ^?
 
   assertType<keyof typeof i>({} as unknown as "asc" | "desc");
   assertType<Omit<typeof i, "asc" | "desc">>(
     {} as unknown as {
       " type": "index";
-      " column": readonly ["column"];
+      " column": "column";
       " order": undefined;
       " nulls": "first";
     },
@@ -249,14 +249,14 @@ test("index nullsFirst", () => {
 });
 
 test("index desc + nullsLast", () => {
-  const i = index(["column"]).desc().nullsLast();
+  const i = index("column").desc().nullsLast();
   //    ^?
 
   assertType<keyof typeof i>({} as unknown as never);
   assertType<typeof i>(
     {} as unknown as {
       " type": "index";
-      " column": readonly ["column"];
+      " column": "column";
       " order": "desc";
       " nulls": "last";
     },
@@ -264,16 +264,31 @@ test("index desc + nullsLast", () => {
 });
 
 test("index nullsLast + desc", () => {
-  const i = index(["column"]).nullsLast().desc();
+  const i = index("column").nullsLast().desc();
   //    ^?
 
   assertType<keyof typeof i>({} as unknown as never);
   assertType<typeof i>(
     {} as unknown as {
       " type": "index";
-      " column": readonly ["column"];
+      " column": "column";
       " order": "desc";
       " nulls": "last";
+    },
+  );
+});
+
+test("index multi column", () => {
+  const i = index(["col1", "col2"]);
+  //    ^?
+
+  assertType<keyof typeof i>({} as unknown as never);
+  assertType<typeof i>(
+    {} as unknown as {
+      " type": "index";
+      " column": readonly ["col1", "col2"];
+      " order": undefined;
+      " nulls": undefined;
     },
   );
 });

--- a/packages/core/src/schema/columns.test-d.ts
+++ b/packages/core/src/schema/columns.test-d.ts
@@ -205,10 +205,75 @@ test("index", () => {
   const i = index(["column"]);
   //    ^?
 
+  assertType<keyof typeof i>(
+    {} as unknown as "asc" | "desc" | "nullsFirst" | "nullsLast",
+  );
+  assertType<Omit<typeof i, "asc" | "desc" | "nullsFirst" | "nullsLast">>(
+    {} as unknown as {
+      " type": "index";
+      " column": readonly ["column"];
+      " order": undefined;
+      " nulls": undefined;
+    },
+  );
+});
+
+test("index asc", () => {
+  const i = index(["column"]).asc();
+  //    ^?
+
+  assertType<keyof typeof i>({} as unknown as "nullsFirst" | "nullsLast");
+  assertType<Omit<typeof i, "nullsFirst" | "nullsLast">>(
+    {} as unknown as {
+      " type": "index";
+      " column": readonly ["column"];
+      " order": "asc";
+      " nulls": undefined;
+    },
+  );
+});
+
+test("index nullsFirst", () => {
+  const i = index(["column"]).nullsFirst();
+  //    ^?
+
+  assertType<keyof typeof i>({} as unknown as "asc" | "desc");
+  assertType<Omit<typeof i, "asc" | "desc">>(
+    {} as unknown as {
+      " type": "index";
+      " column": readonly ["column"];
+      " order": undefined;
+      " nulls": "first";
+    },
+  );
+});
+
+test("index desc + nullsLast", () => {
+  const i = index(["column"]).desc().nullsLast();
+  //    ^?
+
+  assertType<keyof typeof i>({} as unknown as never);
   assertType<typeof i>(
     {} as unknown as {
       " type": "index";
       " column": readonly ["column"];
+      " order": "desc";
+      " nulls": "last";
+    },
+  );
+});
+
+test("index nullsLast + desc", () => {
+  const i = index(["column"]).nullsLast().desc();
+  //    ^?
+
+  assertType<keyof typeof i>({} as unknown as never);
+  assertType<typeof i>(
+    {} as unknown as {
+      " type": "index";
+      " column": readonly ["column"];
+      " order": "desc";
+      " nulls": "last";
     },
   );
 });

--- a/packages/core/src/schema/columns.ts
+++ b/packages/core/src/schema/columns.ts
@@ -193,14 +193,14 @@ export type BuilderScalarColumn<
          * - Docs: https://ponder.sh/docs/schema#optional
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   t: p.createTable({
          *     id: p.string(),
          *     o: p.int().optional(),
          *   })
-         * })
+         * }));
          */
         optional: Optional<base>;
         /**
@@ -209,14 +209,14 @@ export type BuilderScalarColumn<
          * - Docs: https://ponder.sh/docs/schema#list
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   t: p.createTable({
          *     id: p.string(),
          *     l: p.int().list(),
          *   })
-         * })
+         * }));
          */
         list: List<base>;
         references: References<base>;
@@ -228,14 +228,14 @@ export type BuilderScalarColumn<
          * - Docs: https://ponder.sh/docs/schema#list
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   t: p.createTable({
          *     id: p.string(),
          *     l: p.int().list(),
          *   })
-         * })
+         * }))
          */
         list: List<base>;
         /**
@@ -246,9 +246,9 @@ export type BuilderScalarColumn<
          * @param references Table that this column is a key of.
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   a: p.createTable({
          *     id: p.string(),
          *     b_id: p.string.references("b.id"),
@@ -256,7 +256,7 @@ export type BuilderScalarColumn<
          *   b: p.createTable({
          *     id: p.string(),
          *   })
-         * })
+         * }));
          */
         references: References<base>;
       }
@@ -268,14 +268,14 @@ export type BuilderScalarColumn<
          * - Docs: https://ponder.sh/docs/schema#optional
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   t: p.createTable({
          *     id: p.string(),
          *     o: p.int().optional(),
          *   })
-         * })
+         * }));
          */
         optional: Optional<base>;
       }
@@ -299,9 +299,9 @@ export type BuilderReferenceColumn<
        * - Docs: https://ponder.sh/docs/schema#optional
        *
        * @example
-       * import { p } from '@ponder/core'
+       * import { createSchema } from "@ponder/core";
        *
-       * export default p.createSchema({
+       * export default createSchema((p) => ({
        *   t: p.createTable({
        *     id: p.string(),
        *     o: p.int().optional(),
@@ -345,15 +345,15 @@ export type BuilderEnumColumn<
          * - Docs: https://ponder.sh/docs/schema#optional
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   e: p.createEnum(["ONE", "TWO"])
          *   t: p.createTable({
          *     id: p.string(),
          *     a: p.enum("e").optional(),
          *   })
-         * })
+         * }));
          */
         optional: EnumOptional<base>;
         /**
@@ -362,15 +362,15 @@ export type BuilderEnumColumn<
          * - Docs: https://ponder.sh/docs/schema#list
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   e: p.createEnum(["ONE", "TWO"])
          *   t: p.createTable({
          *     id: p.string(),
          *     a: p.enum("e").list(),
          *   })
-         * })
+         * }));
          */
         list: EnumList<base>;
       }
@@ -381,15 +381,15 @@ export type BuilderEnumColumn<
          * - Docs: https://ponder.sh/docs/schema#list
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   e: p.createEnum(["ONE", "TWO"])
          *   t: p.createTable({
          *     id: p.string(),
          *     a: p.enum("e").list(),
          *   })
-         * })
+         * }));
          */
         list: EnumList<base>;
       }
@@ -401,15 +401,15 @@ export type BuilderEnumColumn<
          * - Docs: https://ponder.sh/docs/schema#optional
          *
          * @example
-         * import { p } from '@ponder/core'
+         * import { createSchema } from "@ponder/core";
          *
-         * export default p.createSchema({
+         * export default createSchema((p) => ({
          *   e: p.createEnum(["ONE", "TWO"])
          *   t: p.createTable({
          *     id: p.string(),
          *     a: p.enum("e").optional(),
          *   })
-         * })
+         * }));
          */
         optional: EnumOptional<base>;
       }

--- a/packages/core/src/schema/columns.ts
+++ b/packages/core/src/schema/columns.ts
@@ -532,20 +532,30 @@ export type BuilderIndex<
   nulls extends "first" | "last" | undefined = "first" | "last" | undefined,
   ///
   base extends Index<column, order, nulls> = Index<column, order, nulls>,
+  isSingleColumn = column extends readonly string[] ? false : true,
 > = order extends undefined
   ? nulls extends undefined
-    ? base & {
-        asc: Asc<base>;
-        desc: Desc<base>;
-        nullsFirst: NullsFirst<base>;
-        nullsLast: NullsLast<base>;
-      }
-    : base & {
-        asc: Asc<base>;
-        desc: Desc<base>;
-      }
+    ? isSingleColumn extends true
+      ? base & {
+          asc: Asc<base>;
+          desc: Desc<base>;
+          nullsFirst: NullsFirst<base>;
+          nullsLast: NullsLast<base>;
+        }
+      : base
+    : isSingleColumn extends true
+      ? base & {
+          asc: Asc<base>;
+          desc: Desc<base>;
+        }
+      : base
   : nulls extends undefined
-    ? base & { nullsFirst: NullsFirst<base>; nullsLast: NullsLast<base> }
+    ? isSingleColumn extends true
+      ? base & {
+          nullsFirst: NullsFirst<base>;
+          nullsLast: NullsLast<base>;
+        }
+      : base
     : base;
 
 export const string = scalarColumn("string");
@@ -606,5 +616,5 @@ export const index = <const column extends string | readonly string[]>(
     desc: desc(index),
     nullsFirst: nullsFirst(index),
     nullsLast: nullsLast(index),
-  };
+  } as BuilderIndex<column, undefined, undefined>;
 };

--- a/packages/core/src/schema/columns.ts
+++ b/packages/core/src/schema/columns.ts
@@ -1,6 +1,7 @@
 import type { Prettify } from "@/types/utils.js";
 import type {
   EnumColumn,
+  Index,
   ReferenceColumn,
   Scalar,
   ScalarColumn,
@@ -294,5 +295,14 @@ export const _enum = <_enum extends string>(
     ...column,
     optional: enumOptional(column),
     list: enumList(column),
+  };
+};
+
+export const index = <const column extends string | readonly string[]>(
+  c: column,
+): Index<column> => {
+  return {
+    " type": "index",
+    " column": c,
   };
 };

--- a/packages/core/src/schema/common.ts
+++ b/packages/core/src/schema/common.ts
@@ -151,3 +151,16 @@ export type ExtractReferenceColumnNames<
     ? columnNames
     : never
   : never;
+
+export type ExtractNonVirtualColumnNames<
+  table extends Table | unknown,
+  ///
+  columnNames = keyof table & string,
+> = columnNames extends columnNames
+  ? table[columnNames & keyof table] extends
+      | ReferenceColumn
+      | ScalarColumn
+      | EnumColumn
+    ? columnNames
+    : never
+  : never;

--- a/packages/core/src/schema/common.ts
+++ b/packages/core/src/schema/common.ts
@@ -50,6 +50,11 @@ export type EnumColumn<
   " list": list;
 };
 
+export type Index<column extends string | readonly string[]> = {
+  " type": "index";
+  " column": column;
+};
+
 export type Column =
   | ScalarColumn
   | ReferenceColumn
@@ -63,18 +68,22 @@ export type Table = { id: IdColumn } & {
 
 export type Enum = readonly string[];
 
+export type Constraints = {
+  [name: string]: Index<string | readonly string[]>;
+};
+
 export type IsTable<a extends Table | Enum> = a extends readonly unknown[]
   ? false
   : true;
 
-export type Schema = { [name: string]: Table | Enum };
+export type Schema = { [name: string]: readonly [Table, Constraints] | Enum };
 
 export type ExtractTableNames<
   schema extends Schema | unknown,
   ///
   names = keyof schema & string,
 > = names extends names
-  ? schema[names & keyof schema] extends Table
+  ? schema[names & keyof schema] extends readonly [Table, Constraints]
     ? names
     : never
   : never;
@@ -90,8 +99,11 @@ export type ExtractEnumNames<
   : never;
 
 export type ExtractOptionalColumnNames<
-  table extends Table | unknown,
+  tableAndConstraints extends readonly [Table, Constraints] | unknown,
   ///
+  table = tableAndConstraints extends readonly [Table, Constraints]
+    ? tableAndConstraints[0]
+    : Table,
   columnNames = keyof table & string,
 > = columnNames extends columnNames
   ? table[columnNames & keyof table] extends
@@ -105,8 +117,11 @@ export type ExtractOptionalColumnNames<
   : never;
 
 export type ExtractRequiredColumnNames<
-  table extends Table | unknown,
+  tableAndConstraints extends readonly [Table, Constraints] | unknown,
   ///
+  table = tableAndConstraints extends readonly [Table, Constraints]
+    ? tableAndConstraints[0]
+    : Table,
   columnNames = keyof table & string,
 > = columnNames extends columnNames
   ? table[columnNames & keyof table] extends
@@ -120,9 +135,12 @@ export type ExtractRequiredColumnNames<
   : never;
 
 export type ExtractReferenceColumnNames<
-  table extends Table | unknown,
+  tableAndConstraints extends readonly [Table, Constraints] | unknown,
   referenceTable extends string = string,
   ///
+  table = tableAndConstraints extends readonly [Table, Constraints]
+    ? tableAndConstraints[0]
+    : Table,
   columnNames = keyof table & string,
 > = columnNames extends columnNames
   ? table[columnNames & keyof table] extends ReferenceColumn<

--- a/packages/core/src/schema/common.ts
+++ b/packages/core/src/schema/common.ts
@@ -50,9 +50,15 @@ export type EnumColumn<
   " list": list;
 };
 
-export type Index<column extends string | readonly string[]> = {
+export type Index<
+  column extends string | readonly string[] = string | readonly string[],
+  order extends "asc" | "desc" | undefined = "asc" | "desc" | undefined,
+  nulls extends "first" | "last" | undefined = "first" | "last" | undefined,
+> = {
   " type": "index";
   " column": column;
+  " order": order;
+  " nulls": nulls;
 };
 
 export type Column =
@@ -69,7 +75,7 @@ export type Table = { id: IdColumn } & {
 export type Enum = readonly string[];
 
 export type Constraints = {
-  [name: string]: Index<string | readonly string[]>;
+  [name: string]: Index;
 };
 
 export type IsTable<a extends Table | Enum> = a extends readonly unknown[]

--- a/packages/core/src/schema/common.ts
+++ b/packages/core/src/schema/common.ts
@@ -82,14 +82,19 @@ export type IsTable<a extends Table | Enum> = a extends readonly unknown[]
   ? false
   : true;
 
-export type Schema = { [name: string]: readonly [Table, Constraints] | Enum };
+export type Schema = {
+  [name: string]: { table: Table; constraints: Constraints } | Enum;
+};
 
 export type ExtractTableNames<
   schema extends Schema | unknown,
   ///
   names = keyof schema & string,
 > = names extends names
-  ? schema[names & keyof schema] extends readonly [Table, Constraints]
+  ? schema[names & keyof schema] extends {
+      table: Table;
+      constraints: Constraints;
+    }
     ? names
     : never
   : never;
@@ -105,10 +110,12 @@ export type ExtractEnumNames<
   : never;
 
 export type ExtractOptionalColumnNames<
-  tableAndConstraints extends readonly [Table, Constraints] | unknown,
+  tableAndConstraints extends
+    | { table: Table; constraints: Constraints }
+    | unknown,
   ///
-  table = tableAndConstraints extends readonly [Table, Constraints]
-    ? tableAndConstraints[0]
+  table = tableAndConstraints extends { table: Table; constraints: Constraints }
+    ? tableAndConstraints["table"]
     : Table,
   columnNames = keyof table & string,
 > = columnNames extends columnNames
@@ -123,10 +130,12 @@ export type ExtractOptionalColumnNames<
   : never;
 
 export type ExtractRequiredColumnNames<
-  tableAndConstraints extends readonly [Table, Constraints] | unknown,
+  tableAndConstraints extends
+    | { table: Table; constraints: Constraints }
+    | unknown,
   ///
-  table = tableAndConstraints extends readonly [Table, Constraints]
-    ? tableAndConstraints[0]
+  table = tableAndConstraints extends { table: Table; constraints: Constraints }
+    ? tableAndConstraints["table"]
     : Table,
   columnNames = keyof table & string,
 > = columnNames extends columnNames
@@ -141,11 +150,13 @@ export type ExtractRequiredColumnNames<
   : never;
 
 export type ExtractReferenceColumnNames<
-  tableAndConstraints extends readonly [Table, Constraints] | unknown,
+  tableAndConstraints extends
+    | { table: Table; constraints: Constraints }
+    | unknown,
   referenceTable extends string = string,
   ///
-  table = tableAndConstraints extends readonly [Table, Constraints]
-    ? tableAndConstraints[0]
+  table = tableAndConstraints extends { table: Table; constraints: Constraints }
+    ? tableAndConstraints["table"]
     : Table,
   columnNames = keyof table & string,
 > = columnNames extends columnNames

--- a/packages/core/src/schema/infer.test-d.ts
+++ b/packages/core/src/schema/infer.test-d.ts
@@ -82,14 +82,17 @@ test("infer enum", () => {
 test("infer table", () => {
   type inferred = InferTableType<
     // ^?
-    {
-      id: ScalarColumn<"string", false, false>;
-      col: ScalarColumn<"string", true, false>;
-      ref: ReferenceColumn<"string", false, "table.id">;
-      one: OneColumn<"ref">;
-      many: ManyColumn<"table", "col">;
-      enum: EnumColumn<"enum", false, false>;
-    },
+    readonly [
+      {
+        id: ScalarColumn<"string", false, false>;
+        col: ScalarColumn<"string", true, false>;
+        ref: ReferenceColumn<"string", false, "table.id">;
+        one: OneColumn<"ref">;
+        many: ManyColumn<"table", "col">;
+        enum: EnumColumn<"enum", false, false>;
+      },
+      {},
+    ],
     { enum: ["one", "two"] }
   >;
 

--- a/packages/core/src/schema/infer.test-d.ts
+++ b/packages/core/src/schema/infer.test-d.ts
@@ -82,17 +82,17 @@ test("infer enum", () => {
 test("infer table", () => {
   type inferred = InferTableType<
     // ^?
-    readonly [
-      {
+    {
+      table: {
         id: ScalarColumn<"string", false, false>;
         col: ScalarColumn<"string", true, false>;
         ref: ReferenceColumn<"string", false, "table.id">;
         one: OneColumn<"ref">;
         many: ManyColumn<"table", "col">;
         enum: EnumColumn<"enum", false, false>;
-      },
-      {},
-    ],
+      };
+      constraints: {};
+    },
     { enum: ["one", "two"] }
   >;
 

--- a/packages/core/src/schema/infer.ts
+++ b/packages/core/src/schema/infer.ts
@@ -2,6 +2,7 @@ import type { Prettify } from "@/types/utils.js";
 import type { Hex } from "viem";
 import type {
   Column,
+  Constraints,
   Enum,
   EnumColumn,
   ExtractOptionalColumnNames,
@@ -11,6 +12,7 @@ import type {
   Scalar,
   ScalarColumn,
   Schema,
+  Table,
 } from "./common.js";
 
 export type InferScalarType<scalar extends Scalar> = scalar extends "string"
@@ -40,19 +42,24 @@ export type InferColumnType<
       ? (schema[column[" enum"] & keyof schema] & Enum)[number]
       : never;
 
-export type InferTableType<table, schema> = Prettify<
-  {
-    [columnName in ExtractRequiredColumnNames<table>]: InferColumnType<
-      table[columnName],
-      schema
-    >;
-  } & {
-    [columnName in ExtractOptionalColumnNames<table>]?: InferColumnType<
-      table[columnName],
-      schema
-    >;
-  }
->;
+export type InferTableType<table, schema> = table extends readonly [
+  Table,
+  Constraints,
+]
+  ? Prettify<
+      {
+        [columnName in ExtractRequiredColumnNames<table>]: InferColumnType<
+          table[0][columnName],
+          schema
+        >;
+      } & {
+        [columnName in ExtractOptionalColumnNames<table>]?: InferColumnType<
+          table[0][columnName],
+          schema
+        >;
+      }
+    >
+  : never;
 
 export type InferSchemaType<schema extends Schema | unknown> = {
   [tableName in ExtractTableNames<schema>]: InferTableType<

--- a/packages/core/src/schema/infer.ts
+++ b/packages/core/src/schema/infer.ts
@@ -42,19 +42,19 @@ export type InferColumnType<
       ? (schema[column[" enum"] & keyof schema] & Enum)[number]
       : never;
 
-export type InferTableType<table, schema> = table extends readonly [
-  Table,
-  Constraints,
-]
+export type InferTableType<table, schema> = table extends {
+  table: Table;
+  constraints: Constraints;
+}
   ? Prettify<
       {
         [columnName in ExtractRequiredColumnNames<table>]: InferColumnType<
-          table[0][columnName],
+          table["table"][columnName],
           schema
         >;
       } & {
         [columnName in ExtractOptionalColumnNames<table>]?: InferColumnType<
-          table[0][columnName],
+          table["table"][columnName],
           schema
         >;
       }

--- a/packages/core/src/schema/schema.test-d.ts
+++ b/packages/core/src/schema/schema.test-d.ts
@@ -158,3 +158,38 @@ test("createSchema enum error", () => {
     }),
   }));
 });
+
+test("createSchema index", () => {
+  const schema = createSchema((p) => ({
+    //  ^?
+    t: p.createTable(
+      {
+        id: p.string(),
+      },
+      {
+        idIndex: p.index(["id"]),
+      },
+    ),
+  }));
+
+  type inferred = InferSchemaType<typeof schema>;
+  //   ^?
+
+  assertType<inferred>({} as unknown as { t: { id: string } });
+});
+
+test("createSchema index error", () => {
+  createSchema((p) => ({
+    //  ^?
+    // @ts-expect-error
+    t: p.createTable(
+      {
+        id: p.string(),
+      },
+      {
+        // @ts-expect-error
+        idIndex: p.index("idd"),
+      },
+    ),
+  }));
+});

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -309,6 +309,21 @@ type P = {
   enum: <_enum extends string>(
     __enum: _enum,
   ) => BuilderEnumColumn<_enum, false, false>;
+  /**
+   * Create a table index.
+   *
+   * - Docs: TODO(kyle)
+   *
+   * @example
+   * export default createSchema({
+   *   t: p.createTable({
+   *     id: p.string(),
+   *     age: p.int(),
+   *   }, {
+   *     ageIndex: p.index("age"),
+   *   })
+   * })
+   */
   index: <const column extends string | readonly string[]>(
     c: column,
   ) => Index<column>;

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -19,6 +19,7 @@ import type {
   Constraints,
   EnumColumn,
   ExtractEnumNames,
+  ExtractNonVirtualColumnNames,
   ExtractReferenceColumnNames,
   ExtractTableNames,
   IdColumn,
@@ -86,7 +87,7 @@ type GetConstraints<
   constraints,
   table,
   ///
-  columnName extends string = keyof table & string,
+  columnName extends string = ExtractNonVirtualColumnNames<table>,
 > = {} extends constraints
   ? {}
   : {

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -1,5 +1,6 @@
 import {
   type BuilderEnumColumn,
+  type BuilderIndex,
   type BuilderManyColumn,
   type BuilderOneColumn,
   type BuilderScalarColumn,
@@ -327,7 +328,7 @@ type P = {
    */
   index: <const column extends string | readonly string[]>(
     c: column,
-  ) => Index<column>;
+  ) => BuilderIndex<column, undefined, undefined>;
 };
 
 type CreateSchemaParameters<schema> = {} extends schema

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -124,11 +124,11 @@ type P = {
    * - Docs: https://ponder.sh/docs/schema#tables
    *
    * @example
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   t: p.createTable({
    *     id: p.string(),
    *   })
-   * })
+   * }));
    */
   createTable: <const table, const constraints>(
     t: GetTable<table>,
@@ -140,13 +140,13 @@ type P = {
    * - Docs: https://ponder.sh/docs/schema#tables
    *
    * @example
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   e: p.createEnum(["ONE", "TWO"])
    *   t: p.createTable({
    *     id: p.string(),
    *     a: p.enum("e"),
    *   })
-   * })
+   * }));
    */
 
   createEnum: <const _enum extends readonly string[]>(e: _enum) => _enum;
@@ -156,13 +156,13 @@ type P = {
    * - Docs: https://ponder.sh/docs/schema#primitives
    *
    * @example
-   * import { p } from '@ponder/core'
+   * import { createSchema } from "@ponder/core";
    *
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   t: p.createTable({
    *     id: p.string(),
    *   })
-   * })
+   * }));
    */
   string: () => BuilderScalarColumn<"string", false, false>;
   /**
@@ -171,13 +171,13 @@ type P = {
    * - Docs: https://ponder.sh/docs/schema#primitives
    *
    * @example
-   * import { p } from '@ponder/core'
+   * import { createSchema } from "@ponder/core";
    *
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   t: p.createTable({
    *     id: p.bigint(),
    *   })
-   * })
+   * }));
    */
   bigint: () => BuilderScalarColumn<"bigint", false, false>;
   /**
@@ -186,13 +186,13 @@ type P = {
    * - Docs: https://ponder.sh/docs/schema#primitives
    *
    * @example
-   * import { p } from '@ponder/core'
+   * import { createSchema } from "@ponder/core";
    *
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   t: p.createTable({
    *     id: p.int(),
    *   })
-   * })
+   * }));
    */
   int: () => BuilderScalarColumn<"int", false, false>;
   /**
@@ -201,14 +201,14 @@ type P = {
    * - Docs: https://ponder.sh/docs/schema#primitives
    *
    * @example
-   * import { p } from '@ponder/core'
+   * import { createSchema } from "@ponder/core";
    *
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   t: p.createTable({
    *     id: p.string(),
    *     f: p.float(),
    *   })
-   * })
+   * }));
    */
 
   float: () => BuilderScalarColumn<"float", false, false>;
@@ -218,13 +218,13 @@ type P = {
    * - Docs: https://ponder.sh/docs/schema#primitives
    *
    * @example
-   * import { p } from '@ponder/core'
+   * import { createSchema } from "@ponder/core";
    *
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   t: p.createTable({
    *     id: p.hex(),
    *   })
-   * })
+   * }));
    */
   hex: () => BuilderScalarColumn<"hex", false, false>;
   /**
@@ -233,14 +233,14 @@ type P = {
    * - Docs: https://ponder.sh/docs/schema#primitives
    *
    * @example
-   * import { p } from '@ponder/core'
+   * import { createSchema } from "@ponder/core";
    *
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   t: p.createTable({
    *     id: p.string(),
    *     b: p.boolean(),
    *   })
-   * })
+   * }));
    */
   boolean: () => BuilderScalarColumn<"boolean", false, false>;
   /**
@@ -251,9 +251,9 @@ type P = {
    * @param reference Reference column to be resolved.
    *
    * @example
-   * import { p } from '@ponder/core'
+   * import { createSchema } from "@ponder/core";
    *
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   a: p.createTable({
    *     id: p.string(),
    *     b_id: p.string.references("b.id"),
@@ -262,7 +262,7 @@ type P = {
    *   b: p.createTable({
    *     id: p.string(),
    *   })
-   * })
+   * }));
    */
   one: <reference extends string>(
     ref: reference,
@@ -275,9 +275,9 @@ type P = {
    * @param reference Reference column that references the `id` column of the current table.
    *
    * @example
-   * import { p } from '@ponder/core'
+   * import { createSchema } from "@ponder/core";
    *
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   a: p.createTable({
    *     id: p.string(),
    *     ref: p.string.references("b.id"),
@@ -286,7 +286,7 @@ type P = {
    *     id: p.string(),
    *     m: p.many("a.ref"),
    *   })
-   * })
+   * }));
    */
   many: <referenceTable extends string, referenceColumn extends string>(
     ref: `${referenceTable}.${referenceColumn}`,
@@ -299,13 +299,13 @@ type P = {
    * @param type Enum defined elsewhere in the schema with `p.createEnum()`.
    *
    * @example
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   e: p.createEnum(["ONE", "TWO"])
    *   t: p.createTable({
    *     id: p.string(),
    *     a: p.enum("e"),
    *   })
-   * })
+   * }));
    */
   enum: <_enum extends string>(
     __enum: _enum,
@@ -316,14 +316,14 @@ type P = {
    * - Docs: TODO(kyle)
    *
    * @example
-   * export default createSchema({
+   * export default createSchema((p) => ({
    *   t: p.createTable({
    *     id: p.string(),
    *     age: p.int(),
    *   }, {
    *     ageIndex: p.index("age"),
    *   })
-   * })
+   * }));
    */
   index: <const column extends string | readonly string[]>(
     c: column,

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -98,7 +98,10 @@ type GetConstraints<
 export const createTable = <const table, const constraints>(
   t: GetTable<table>,
   c?: GetConstraints<constraints, table>,
-): readonly [table, constraints] => [t as table, c as constraints];
+): { table: table; constraints: constraints } => ({
+  table: t as table,
+  constraints: c as constraints,
+});
 
 export const createEnum = <const _enum extends readonly string[]>(e: _enum) =>
   e;
@@ -134,7 +137,7 @@ type P = {
   createTable: <const table, const constraints>(
     t: GetTable<table>,
     c?: GetConstraints<constraints, table>,
-  ) => readonly [table, constraints];
+  ) => { table: table; constraints: constraints };
   /**
    * Create an Enum type for the database.
    *
@@ -334,14 +337,14 @@ type P = {
 type CreateSchemaParameters<schema> = {} extends schema
   ? {}
   : {
-      [tableName in keyof schema]: schema[tableName] extends readonly [
-        infer table extends Table,
-        infer constraints extends Constraints,
-      ]
-        ? readonly [
-            GetTable<table, tableName & string, schema>,
-            GetConstraints<constraints, table>,
-          ]
+      [tableName in keyof schema]: schema[tableName] extends {
+        table: infer table extends Table;
+        constraints: infer constraints extends Constraints;
+      }
+        ? {
+            table: GetTable<table, tableName & string, schema>;
+            constraints: GetConstraints<constraints, table>;
+          }
         : readonly string[];
     };
 

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -1,5 +1,6 @@
 import type {
   Column,
+  Constraints,
   Enum,
   EnumColumn,
   ManyColumn,
@@ -36,16 +37,18 @@ export const isListColumn = (column: Column): boolean => {
   return column[" list"];
 };
 
-export const isTable = (tableOrEnum: Schema[string]): tableOrEnum is Table =>
-  Array.isArray(tableOrEnum) === false;
+export const isTable = (
+  tableOrEnum: Schema[string],
+): tableOrEnum is readonly [Table, Constraints] =>
+  typeof tableOrEnum[0] === "object";
 
 export const isEnum = (tableOrEnum: Schema[string]): tableOrEnum is Enum =>
-  Array.isArray(tableOrEnum) === true;
+  typeof tableOrEnum[0] === "string";
 
 export const schemaToTables = (
   schema: Schema,
-): { [tableName: string]: Table } => {
-  const tables: { [tableName: string]: Table } = {};
+): { [tableName: string]: readonly [Table, Constraints] } => {
+  const tables: { [tableName: string]: readonly [Table, Constraints] } = {};
 
   for (const [name, tableOrEnum] of Object.entries(schema)) {
     if (isTable(tableOrEnum)) {

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -39,16 +39,18 @@ export const isListColumn = (column: Column): boolean => {
 
 export const isTable = (
   tableOrEnum: Schema[string],
-): tableOrEnum is readonly [Table, Constraints] =>
-  typeof tableOrEnum[0] === "object";
+): tableOrEnum is { table: Table; constraints: Constraints } =>
+  !Array.isArray(tableOrEnum);
 
 export const isEnum = (tableOrEnum: Schema[string]): tableOrEnum is Enum =>
-  typeof tableOrEnum[0] === "string";
+  Array.isArray(tableOrEnum);
 
 export const getTables = (
   schema: Schema,
-): { [tableName: string]: readonly [Table, Constraints] } => {
-  const tables: { [tableName: string]: readonly [Table, Constraints] } = {};
+): { [tableName: string]: { table: Table; constraints: Constraints } } => {
+  const tables: {
+    [tableName: string]: { table: Table; constraints: Constraints };
+  } = {};
 
   for (const [name, tableOrEnum] of Object.entries(schema)) {
     if (isTable(tableOrEnum)) {

--- a/packages/core/src/server/graphql/buildGraphqlSchema.ts
+++ b/packages/core/src/server/graphql/buildGraphqlSchema.ts
@@ -37,7 +37,7 @@ export const buildGraphqlSchema = (schema: Schema): GraphQLSchema => {
     entityFilterTypes,
   });
 
-  for (const [tableName, table] of Object.entries(schemaToTables(schema))) {
+  for (const [tableName, [table]] of Object.entries(schemaToTables(schema))) {
     const entityType = entityTypes[tableName];
     const entityPageType = entityPageTypes[tableName];
     const entityFilterType = entityFilterTypes[tableName];

--- a/packages/core/src/server/graphql/buildGraphqlSchema.ts
+++ b/packages/core/src/server/graphql/buildGraphqlSchema.ts
@@ -37,7 +37,7 @@ export const buildGraphqlSchema = (schema: Schema): GraphQLSchema => {
     entityFilterTypes,
   });
 
-  for (const [tableName, [table]] of Object.entries(getTables(schema))) {
+  for (const [tableName, { table }] of Object.entries(getTables(schema))) {
     const entityType = entityTypes[tableName];
     const entityPageType = entityPageTypes[tableName];
     const entityFilterType = entityFilterTypes[tableName];

--- a/packages/core/src/server/graphql/entity.ts
+++ b/packages/core/src/server/graphql/entity.ts
@@ -49,7 +49,7 @@ export const buildEntityTypes = ({
   const entityTypes: Record<string, GraphQLObjectType<Parent, Context>> = {};
   const entityPageTypes: Record<string, GraphQLObjectType> = {};
 
-  for (const [tableName, table] of Object.entries(schemaToTables(schema))) {
+  for (const [tableName, [table]] of Object.entries(schemaToTables(schema))) {
     entityTypes[tableName] = new GraphQLObjectType({
       name: tableName,
       fields: () => {

--- a/packages/core/src/server/graphql/entity.ts
+++ b/packages/core/src/server/graphql/entity.ts
@@ -49,7 +49,7 @@ export const buildEntityTypes = ({
   const entityTypes: Record<string, GraphQLObjectType<Parent, Context>> = {};
   const entityPageTypes: Record<string, GraphQLObjectType> = {};
 
-  for (const [tableName, [table]] of Object.entries(getTables(schema))) {
+  for (const [tableName, { table }] of Object.entries(getTables(schema))) {
     entityTypes[tableName] = new GraphQLObjectType({
       name: tableName,
       fields: () => {

--- a/packages/core/src/server/graphql/filter.ts
+++ b/packages/core/src/server/graphql/filter.ts
@@ -37,7 +37,7 @@ export const buildEntityFilterTypes = ({
 }: { schema: Schema; enumTypes: Record<string, GraphQLEnumType> }) => {
   const entityFilterTypes: Record<string, GraphQLInputObjectType> = {};
 
-  for (const [tableName, table] of Object.entries(schemaToTables(schema))) {
+  for (const [tableName, [table]] of Object.entries(schemaToTables(schema))) {
     const filterType = new GraphQLInputObjectType({
       name: `${tableName}Filter`,
       fields: () => {

--- a/packages/core/src/server/graphql/filter.ts
+++ b/packages/core/src/server/graphql/filter.ts
@@ -37,7 +37,7 @@ export const buildEntityFilterTypes = ({
 }: { schema: Schema; enumTypes: Record<string, GraphQLEnumType> }) => {
   const entityFilterTypes: Record<string, GraphQLInputObjectType> = {};
 
-  for (const [tableName, [table]] of Object.entries(getTables(schema))) {
+  for (const [tableName, { table }] of Object.entries(getTables(schema))) {
     const filterType = new GraphQLInputObjectType({
       name: `${tableName}Filter`,
       fields: () => {


### PR DESCRIPTION
```js
import { createSchema } from "@ponder/core";

export default createSchema((p) => ({
  Account: p.createTable(
    {
      id: p.hex(),
      balance: p.bigint(),
      isOwner: p.boolean(),
    },
    {
      balanceIndex: p.index(["balance", "isOwner"]),
    },
  ),
}));
```