### PR TITLE
Filter historical logs

### DIFF
--- a/packages/core/src/sync-historical/service.ts
+++ b/packages/core/src/sync-historical/service.ts
@@ -533,16 +533,18 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     this.progressLogInterval = setInterval(async () => {
       const historical = await getHistoricalSyncProgress(this.common.metrics);
 
-      historical.sources.forEach(({ sourceName, progress, eta }) => {
-        if (progress === 1) return;
-        this.common.logger.info({
-          service: "historical",
-          msg: `Sync is ${formatPercentage(progress ?? 0)} complete${
-            eta !== undefined ? ` with ~${formatEta(eta)} remaining` : ""
-          } (source=${sourceName}, network=${this.network.name})`,
-          network: this.network.name,
-        });
-      });
+      historical.sources.forEach(
+        ({ networkName, sourceName, progress, eta }) => {
+          if (progress === 1 || networkName !== this.network.name) return;
+          this.common.logger.info({
+            service: "historical",
+            msg: `Sync is ${formatPercentage(progress ?? 0)} complete${
+              eta !== undefined ? ` with ~${formatEta(eta)} remaining` : ""
+            } (source=${sourceName}, network=${this.network.name})`,
+            network: this.network.name,
+          });
+        },
+      );
     }, 10_000);
 
     // Edge case: If there are no tasks in the queue, this means the entire


### PR DESCRIPTION
Fix the issue of duplicate printing of progress log in synchronisation phase

```
9:27:05 AM INFO  historical Sync is 1.9% complete with ~4h 51m 6s remaining (source=HelixLnBridgeV3, network=sepolia)
9:27:05 AM INFO  historical Sync is 16.2% complete with ~39m 25s remaining (source=HelixLnBridgeV3, network=sepolia)
9:27:05 AM INFO  historical Sync is 69.9% complete with ~3m 45s remaining (source=HelixLnBridgeV3, network=sepolia)
9:27:05 AM INFO  historical Sync is 7.7% complete with ~2h 0m 5s remaining (source=HelixLnBridgeV3, network=sepolia)
9:27:05 AM INFO  historical Sync is 24.8% complete with ~22m 55s remaining (source=HelixLnBridgeV3, network=sepolia)
9:27:05 AM INFO  historical Sync is 1.9% complete with ~4h 51m 8s remaining (source=HelixLnBridgeV3, network=zksync-sepolia)
9:27:05 AM INFO  historical Sync is 16.2% complete with ~39m 26s remaining (source=HelixLnBridgeV3, network=zksync-sepolia)
9:27:05 AM INFO  historical Sync is 69.9% complete with ~3m 45s remaining (source=HelixLnBridgeV3, network=zksync-sepolia)
9:27:05 AM INFO  historical Sync is 7.7% complete with ~2h 0m 6s remaining (source=HelixLnBridgeV3, network=zksync-sepolia)
9:27:05 AM INFO  historical Sync is 24.8% complete with ~22m 55s remaining (source=HelixLnBridgeV3, network=zksync-sepolia)
9:27:15 AM INFO  historical Sync is 1.9% complete with ~4h 50m 51s remaining (source=HelixLnBridgeV3, network=arbitrum-sepolia)
9:27:15 AM INFO  historical Sync is 16.6% complete with ~38m 6s remaining (source=HelixLnBridgeV3, network=arbitrum-sepolia)
9:27:15 AM INFO  historical Sync is 71.0% complete with ~3m 39s remaining (source=HelixLnBridgeV3, network=arbitrum-sepolia)
9:27:15 AM INFO  historical Sync is 7.9% complete with ~1h 54m 20s remaining (source=HelixLnBridgeV3, network=arbitrum-sepolia)
9:27:15 AM INFO  historical Sync is 26.1% complete with ~20m 21s remaining (source=HelixLnBridgeV3, network=arbitrum-sepolia)
```