### PR TITLE
fix: retry deep reorgs

### DIFF
--- a/.changeset/green-cheetahs-march.md
+++ b/.changeset/green-cheetahs-march.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed an issues that would cause unexpected blocks to immediately cause a fatal error with a deep reorg.

--- a/packages/core/src/sync-realtime/service.ts
+++ b/packages/core/src/sync-realtime/service.ts
@@ -655,9 +655,10 @@ export const handleReorg = async (
   const msg = `Encountered unrecoverable '${service.network.name}' reorg beyond finalized block ${service.finalizedBlock.number}`;
 
   service.common.logger.warn({ service: "realtime", msg });
-  service.onFatalError(new Error(msg));
 
   service.localChain = [];
+
+  throw new Error(msg);
 };
 
 const getMatchedLogs = async (


### PR DESCRIPTION
Fixes an issue where a rpc with a flake returning a random block before the finalized block would cause an immediate crash. This "deep reorg" now throws an error and goes through the error logic with multiple timeouts and retries