### PR TITLE
Fixes bug in historical indexing update cache

### DIFF
--- a/.changeset/witty-guests-melt.md
+++ b/.changeset/witty-guests-melt.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed an issue introduced in v0.4.37 where updating a table with only an "id" column would cause a SQL syntax error.

--- a/packages/core/src/indexing-store/historical.test.ts
+++ b/packages/core/src/indexing-store/historical.test.ts
@@ -1154,3 +1154,45 @@ test("flush() partial", async (context) => {
 
   await cleanup();
 });
+
+test("flush() skips update w/ no data", async (context) => {
+  const schema = createSchema((p) => ({
+    table: p.createTable({
+      id: p.string(),
+    }),
+  }));
+
+  const { indexingStore, database, namespaceInfo, cleanup } =
+    await setupDatabaseServices(context, {
+      schema,
+    });
+
+  await indexingStore.create({
+    tableName: "table",
+    id: "id",
+  });
+
+  await (indexingStore as HistoricalStore).flush({ isFullFlush: true });
+
+  const instance = await indexingStore.upsert({
+    tableName: "table",
+    id: "id",
+  });
+
+  expect(instance).toMatchObject({ id: "id" });
+
+  await (indexingStore as HistoricalStore).flush({ isFullFlush: true });
+
+  const rows = await database.indexingDb
+    .withSchema(namespaceInfo.userNamespace)
+    .selectFrom("table")
+    .selectAll()
+    .execute();
+
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toMatchObject({
+    id: "id",
+  });
+
+  await cleanup();
+});


### PR DESCRIPTION
The "update" branch of the flush function uses `onConflict` to overwrite existing database rows, but when there are no rows besides "id", nothing needs to be updated. Previously this code path was causing an SQL syntax error, now it just exits early.