### PR TITLE
chore: Export `TransactionReceipt` type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,11 @@
 export { createConfig } from "@/config/config.js";
 export { createSchema } from "@/schema/schema.js";
-export type { Block, Log, Transaction, TransactionReceipt } from "@/types/eth.js";
+export type { 
+  Block,
+  Log,
+  Transaction,
+  TransactionReceipt,  
+} from "@/types/eth.js";
 export type { Virtual } from "@/types/virtual.js";
 export {
   type MergeAbis,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { createConfig } from "@/config/config.js";
 export { createSchema } from "@/schema/schema.js";
-export type { 
+export type {
   Block,
   Log,
   Transaction,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ export type {
   Block,
   Log,
   Transaction,
-  TransactionReceipt,  
+  TransactionReceipt,
 } from "@/types/eth.js";
 export type { Virtual } from "@/types/virtual.js";
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { createConfig } from "@/config/config.js";
 export { createSchema } from "@/schema/schema.js";
-export type { Block, Log, Transaction } from "@/types/eth.js";
+export type { Block, Log, Transaction, TransactionReceipt } from "@/types/eth.js";
 export type { Virtual } from "@/types/virtual.js";
 export {
   type MergeAbis,


### PR DESCRIPTION
Export `TransactionReceipt` type from `@ponder/core` package.

Fix an issue where when using `includeTransactionReceipts: true` in `ponder.config.ts`, the type `TransactionReceipt` wasn't being exported leading to `Module '@ponder/core' declares 'TransactionReceipt' locally, but it is not exported.`.

Current workaround is to import this type from `viem`, but as `@ponder/code` provides `Transaction` and `Log`, it should be exported too.
This PR fixes this.