### PR TITLE
chore: Broken Telemetry link

### DIFF
--- a/.changeset/happy-monkeys-beam.md
+++ b/.changeset/happy-monkeys-beam.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed broken link to Telemetry documentation

--- a/.changeset/happy-monkeys-beam.md
+++ b/.changeset/happy-monkeys-beam.md
@@ -2,4 +2,4 @@
 "@ponder/core": patch
 ---
 
-Fixed broken link to Telemetry documentation
+Fixed a broken link to the telemetry documentation.

--- a/packages/core/src/common/telemetry.ts
+++ b/packages/core/src/common/telemetry.ts
@@ -79,7 +79,7 @@ export function createTelemetry({
     conf.set("notifiedAt", Date.now().toString());
     logger.info({
       service: "telemetry",
-      msg: "Ponder collects anonymous telemetry data to identify issues and prioritize features. See https://ponder.sh/advanced/telemetry for more information.",
+      msg: "Ponder collects anonymous telemetry data to identify issues and prioritize features. See https://ponder.sh/docs/advanced/telemetry for more information.",
     });
   }
 


### PR DESCRIPTION
Fired up a new Ponder instance today for testing purposes and left Telemetry enabled; upon checking the application log, found out that the link to the Telemetry documentation was broken. Think the update is worthy given it's an application log; did check all other links within the codebase but found no other broken link. This pull-request fixes it.