### PR TITLE
chore: Lint options

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "changeset:version": "changeset version && pnpm install --lockfile-only",
     "format": "biome format . --write",
     "lint": "biome check .",
-    "lint:fix": "pnpm lint --apply",
+    "lint:fix": "pnpm lint --write",
     "prepare": "npx simple-git-hooks",
     "test": "pnpm --parallel --no-bail test",
     "typecheck": "pnpm --filter \"./packages/**\" --parallel typecheck"


### PR DESCRIPTION
Fix deprecation alert related to Lint CLI options being used in the package.json

> Note: As this affect the main repo', and not a specific package, I've skipped the changeset as I wasn't sure which to choose.

```
DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ⚠ The argument --apply is deprecated, it will be removed in the next major release. Use --write instead.
```