### PR TITLE
fix: Test

### DIFF
--- a/.changeset/chilly-ways-repair.md
+++ b/.changeset/chilly-ways-repair.md
@@ -1,5 +1,0 @@
----
-"create-ponder": patch
----
-
-Fixed test

--- a/.changeset/chilly-ways-repair.md
+++ b/.changeset/chilly-ways-repair.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Fixed test

--- a/packages/create-ponder/src/_test/cli.test.ts
+++ b/packages/create-ponder/src/_test/cli.test.ts
@@ -22,14 +22,10 @@ test("create empty", async () => {
   });
 
   const templateFiles = (
-    readdirSync(
-      path.join(__dirname, "..", "..", "templates", "empty"),
-    ) as string[]
+    readdirSync(path.join(__dirname, "..", "..", "templates", "empty"), {
+      recursive: true,
+    }) as string[]
   )
-    .concat([
-      path.join("abis", "ExampleContractAbi.ts"),
-      path.join("src", "index.ts"),
-    ])
     .map((filePath) =>
       filePath === "_dot_env.local"
         ? ".env.local"


### PR DESCRIPTION
As we can see in [some of the pull-request tests](https://github.com/ponder-sh/ponder/actions/runs/10020872731/job/27698926075?pr=984), the addition of the API Function added a sub-repository to `src` which is `/api`, causing the tests to `create-ponder` to fail, this pull-request fixes it.