### PR TITLE
fix: Invalid default contract address on empty template

### DIFF
--- a/.changeset/nervous-baboons-destroy.md
+++ b/.changeset/nervous-baboons-destroy.md
@@ -2,4 +2,4 @@
 "create-ponder": patch
 ---
 
-Fixed default contract address in `create-ponder` empty template
+Fixed default contract address in `create-ponder` empty template.

--- a/.changeset/nervous-baboons-destroy.md
+++ b/.changeset/nervous-baboons-destroy.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Fixed default contract address in `create-ponder` empty template

--- a/packages/create-ponder/templates/empty/ponder.config.ts
+++ b/packages/create-ponder/templates/empty/ponder.config.ts
@@ -14,7 +14,7 @@ export default createConfig({
     ExampleContract: {
       network: "mainnet",
       abi: ExampleContractAbi,
-      address: "0x0",
+      address: "0x0000000000000000000000000000000000000000",
       startBlock: 1234567,
     },
   },


### PR DESCRIPTION
Fix #720 

Updated default contract address provided on `create-ponder` empty template to be a valid address