### PR TITLE
fix: Hono usage docs

### DIFF
--- a/docs/pages/docs/query/api-functions.mdx
+++ b/docs/pages/docs/query/api-functions.mdx
@@ -225,9 +225,9 @@ Use `ponder.use(...){:ts}` to add middleware to your API functions. Middleware f
 ```ts filename="src/api/index.ts" {3}
 import { ponder } from "@/generated";
 
-ponder.use((c) => {
+ponder.use((c, next) => {
   console.log("Request received:", c.req.url);
-  return c.next();
+  return next();
 });
 ```
 


### PR DESCRIPTION
Fix incorrect usage of middleware use with Hono.
Current docs example does not work and errors with `Property 'next' does not exist on type 'MiddlewareContext<{ ... }>`.

Hono Middleware Documentation: https://hono.dev/docs/guides/middleware#custom-middleware