### PR TITLE
feat: Implement support for alternative Subgraph providers

### DIFF
--- a/.changeset/thirty-ants-warn.md
+++ b/.changeset/thirty-ants-warn.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Added support for Alchemy Subgraph (Satsuma) subgraphs in the `create-ponder` subgraph template via the `--subgraph-provider` option or prompt.

--- a/docs/pages/docs/api-reference/create-ponder.mdx
+++ b/docs/pages/docs/api-reference/create-ponder.mdx
@@ -35,17 +35,17 @@ Usage:
   $ create-ponder <directory> [options]
 
 Options:
-  -t, --template [id]        Use a template
-  --provider [provider]      Use an alternative subgraph provider
-  --etherscan [url]          Use the Etherscan template with the specified contract URL
-  --subgraph [id]            Use the subgraph template with the specified subgraph ID
-  --npm                      Use npm as your package manager
-  --pnpm                     Use pnpm as your package manager
-  --yarn                     Use yarn as your package manager
-  --skip-git                 Skip initializing a git repository
-  --etherscan-api-key [key]  Etherscan API key for Etherscan template
-  -h, --help                 Display this message
-  -v, --version              Display version number
+  -t, --template [id]             Use a template
+  --etherscan [url]               Use the Etherscan template with the specified contract URL
+  --subgraph [id]                 Use the subgraph template with the specified subgraph ID
+  --subgraph-provider [provider]  Specify the subgraph provider
+  --npm                           Use npm as your package manager
+  --pnpm                          Use pnpm as your package manager
+  --yarn                          Use yarn as your package manager
+  --skip-git                      Skip initializing a git repository
+  --etherscan-api-key [key]       Etherscan API key for Etherscan template
+  -h, --help                      Display this message
+  -v, --version                   Display version number
 ```
 
 ## Templates

--- a/docs/pages/docs/api-reference/create-ponder.mdx
+++ b/docs/pages/docs/api-reference/create-ponder.mdx
@@ -36,6 +36,7 @@ Usage:
 
 Options:
   -t, --template [id]        Use a template
+  --provider [provider]      Use an alternative subgraph provider
   --etherscan [url]          Use the Etherscan template with the specified contract URL
   --subgraph [id]            Use the subgraph template with the specified subgraph ID
   --npm                      Use npm as your package manager

--- a/packages/create-ponder/src/helpers/getGraphProtocolChainId.ts
+++ b/packages/create-ponder/src/helpers/getGraphProtocolChainId.ts
@@ -15,8 +15,6 @@ const chainIdByGraphNetwork: Record<string, number | undefined> = {
   fantom: 250,
   "fantom-testnet": 4002,
   bsc: 56,
-  chapel: -1,
-  clover: 0,
   avalanche: 43114,
   fuji: 43113,
   celo: 42220,
@@ -24,7 +22,6 @@ const chainIdByGraphNetwork: Record<string, number | undefined> = {
   fuse: 122,
   moonbeam: 1284,
   moonriver: 1285,
-  mbase: -1,
   base: 8453,
   "base-sepolia": 84532,
   "arbitrum-one": 42161,
@@ -36,7 +33,7 @@ const chainIdByGraphNetwork: Record<string, number | undefined> = {
 };
 
 export const getGraphProtocolChainId = (networkName: string) => {
-  return chainIdByGraphNetwork[networkName];
+  return chainIdByGraphNetwork[networkName] ?? 0;
 };
 
 export const subgraphYamlFileNames = ["subgraph.yaml"].concat(

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -24,7 +24,7 @@ import {
   validateProjectPath,
   validateTemplateName,
 } from "./helpers/validate.js";
-import { fromSubgraphId } from "./subgraph.js";
+import { fromSubgraphId, subgraphProviders } from "./subgraph.js";
 
 const log = console.log;
 
@@ -297,7 +297,11 @@ export async function run({
 
   if (templateMeta.id === "subgraph") {
     const result = await oraPromise(
-      fromSubgraphId({ rootDir: projectPath, subgraphId: subgraph! }),
+      fromSubgraphId({
+        rootDir: projectPath,
+        subgraphId: subgraph!,
+        providerId: options.subgraphProvider,
+      }),
       {
         text: "Fetching subgraph metadata. This may take a few seconds.",
         failText: "Failed to fetch subgraph metadata.",
@@ -501,6 +505,10 @@ export async function run({
     .option(
       "-t, --template [id]",
       `Use a template. Options: ${templates.map(({ id }) => id).join(", ")}`,
+    )
+    .option(
+      "--provider [provider]",
+      `Use an alternative subgraph provider. Options: ${subgraphProviders.map(({ id }) => id).join(", ")}`,
     )
     .option("--etherscan [url]", "Use the Etherscan template")
     .option("--subgraph [id]", "Use the subgraph template")

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -300,7 +300,7 @@ export async function run({
       fromSubgraphId({
         rootDir: projectPath,
         subgraphId: subgraph!,
-        providerId: options.subgraphProvider,
+        providerId: options.provider,
       }),
       {
         text: "Fetching subgraph metadata. This may take a few seconds.",

--- a/packages/create-ponder/src/subgraph.ts
+++ b/packages/create-ponder/src/subgraph.ts
@@ -102,10 +102,6 @@ export const fromSubgraphId = async ({
   const ponderContracts = dataSources.map((sourceInvalid) => {
     const source = validateGraphProtocolSource(sourceInvalid);
     const network = source.network || "mainnet";
-    const chainId = getGraphProtocolChainId(network);
-    if (!chainId || chainId === -1) {
-      throw new Error(`Unhandled network name: ${network}`);
-    }
     const abiRelativePath = `./abis/${source.source.abi}Abi.ts`;
 
     return {
@@ -125,10 +121,11 @@ export const fromSubgraphId = async ({
   const networksObject: any = {};
 
   ponderContracts.forEach((pc) => {
+    const chainId = getGraphProtocolChainId(pc.network);
     contractsObject[pc.name] = pc;
     networksObject[pc.network] = {
-      chainId: getGraphProtocolChainId(pc.network),
-      transport: `http(process.env.PONDER_RPC_URL_${getGraphProtocolChainId(pc.network)})`,
+      chainId,
+      transport: `http(process.env.PONDER_RPC_URL_${chainId})`,
     };
     contractsObject[pc.name].name = undefined;
   });


### PR DESCRIPTION
Hey there, 

I've added in cursory support for alternate subgraph providers, for example Alchemy Subgraph (formerly Satsuma)

I've used the templates format to allow for more graph-compliant spec subgraph providers in the future.

Would love ya'lls feedback on this.

One thing I noticed is the `chainIdByGraphNetwork` values being hard-coded is this possible something we could have as a param passed into the subgraph template so we could build ponder apps for l2s / l3s that are not yet in that file?