### PR TITLE
fix: typo in api-functions example in docs

### DIFF
--- a/docs/pages/docs/query/api-functions.mdx
+++ b/docs/pages/docs/query/api-functions.mdx
@@ -102,7 +102,7 @@ import { ponder } from "@/generated";
 ponder.get("/account/:address", async (c) => {
   const address = c.req.param("address");
 
-  const account = await c.db.select(c.tables.Account).limit(1);
+  const account = await c.db.select().from(c.tables.Account).limit(1);
 
   return c.json(account);
 });


### PR DESCRIPTION
fixing minor typo in docs