### PR TITLE
fix: SQLite Directory Selection to Prefer Config Directory

### DIFF
--- a/.changeset/metal-apes-care.md
+++ b/.changeset/metal-apes-care.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where the SQLite `directory` option in `ponder.config.ts` was not respected.

--- a/packages/core/src/build/configAndIndexingFunctions.test.ts
+++ b/packages/core/src/build/configAndIndexingFunctions.test.ts
@@ -640,6 +640,27 @@ test("buildConfigAndIndexingFunctions() database uses sqlite by default", async 
   process.env.DATABASE_URL = prev;
 });
 
+test("buildConfigAndIndexingFunctions() database respects custom sqlite path", async () => {
+  const config = createConfig({
+    database: { kind: "sqlite", directory: "custom-sqlite/directory" },
+    networks: { mainnet: { chainId: 1, transport: http() } },
+    contracts: { a: { network: "mainnet", abi: [event0] } },
+  });
+
+  const { databaseConfig } = await buildConfigAndIndexingFunctions({
+    config,
+    rawIndexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+    options,
+  });
+
+  console.log(databaseConfig);
+
+  expect(databaseConfig).toMatchObject({
+    kind: "sqlite",
+    directory: expect.stringContaining(path.join("custom-sqlite", "directory")),
+  });
+});
+
 test("buildConfigAndIndexingFunctions() database uses sqlite if specified even if DATABASE_URL env var present", async () => {
   const config = createConfig({
     database: { kind: "sqlite" },

--- a/packages/core/src/build/configAndIndexingFunctions.ts
+++ b/packages/core/src/build/configAndIndexingFunctions.ts
@@ -55,14 +55,11 @@ export async function buildConfigAndIndexingFunctions({
   let databaseConfig: DatabaseConfig;
 
   // Determine SQLite directory, preferring config.database.directory if available
-  let sqliteDir: string;
-  if (config.database?.kind === "sqlite") {
-    sqliteDir = config.database.directory
+  const sqliteDir =
+    config.database?.kind === "sqlite" && config.database.directory
       ? path.resolve(config.database.directory)
       : path.join(ponderDir, "sqlite");
-  } else {
-    sqliteDir = path.join(ponderDir, "sqlite");
-  }
+
   const sqlitePrintPath = path.relative(rootDir, sqliteDir);
 
   if (config.database?.kind) {

--- a/packages/core/src/build/configAndIndexingFunctions.ts
+++ b/packages/core/src/build/configAndIndexingFunctions.ts
@@ -54,7 +54,15 @@ export async function buildConfigAndIndexingFunctions({
   // Build database.
   let databaseConfig: DatabaseConfig;
 
-  const sqliteDir = path.join(ponderDir, "sqlite");
+  // Determine SQLite directory, preferring config.database.directory if available
+  let sqliteDir: string;
+  if (config.database?.kind === "sqlite") {
+    sqliteDir = config.database.directory
+      ? path.resolve(config.database.directory)
+      : path.join(ponderDir, "sqlite");
+  } else {
+    sqliteDir = path.join(ponderDir, "sqlite");
+  }
   const sqlitePrintPath = path.relative(rootDir, sqliteDir);
 
   if (config.database?.kind) {


### PR DESCRIPTION
## Summary

This PR addresses an issue with the SQLite directory selection process in `packages/core/src/build/configAndIndexingFunctions.ts`. The code has been updated to prefer the `config.database.directory` if it is provided. If the directory is not specified in the configuration, it will fall back to the default directory `{ponderDir}/sqlite`.

## Changes

- Updated `packages/core/src/build/configAndIndexingFunctions.ts` to use `config.database.directory` if available when setting the SQLite directory.
- Ensured proper resolution of the directory path.

## Testing

I didn't test this, couldn't figure out how to. Would appreciate your help @kyscott18 @0xOlias.

## Related Work

- https://github.com/ponder-sh/ponder/pull/679