### PR TITLE
fix: ipv6 support by default

### DIFF
--- a/.changeset/wise-tomatoes-appear.md
+++ b/.changeset/wise-tomatoes-appear.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fix default ipv6 support

--- a/docs/pages/docs/api-reference/ponder-cli.mdx
+++ b/docs/pages/docs/api-reference/ponder-cli.mdx
@@ -43,7 +43,7 @@ Start the development server with hot reloading
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0")
+  -H, --hostname <HOSTNAME>  Hostname for the web server
   -h, --help                 display help for command
 ```
 
@@ -61,7 +61,7 @@ Start the production server
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0")
+  -H, --hostname <HOSTNAME>  Hostname for the web server
   -h, --help                 display help for command
 ```
 
@@ -81,7 +81,7 @@ Start the production HTTP server without the indexer
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0")
+  -H, --hostname <HOSTNAME>  Hostname for the web server
   -h, --help                 display help for command
 ```
 

--- a/docs/pages/docs/api-reference/ponder-cli.mdx
+++ b/docs/pages/docs/api-reference/ponder-cli.mdx
@@ -43,7 +43,7 @@ Start the development server with hot reloading
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server
+  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0" or "::")
   -h, --help                 display help for command
 ```
 
@@ -61,7 +61,7 @@ Start the production server
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server
+  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0" or "::")
   -h, --help                 display help for command
 ```
 
@@ -81,7 +81,7 @@ Start the production HTTP server without the indexer
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server
+  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0" or "::")
   -h, --help                 display help for command
 ```
 

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -62,7 +62,14 @@ type GlobalOptions = {
 const devCommand = new Command("dev")
   .description("Start the development server with hot reloading")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
-  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "")
+  // NOTE: Do not set a default for hostname. We currently rely on the Node.js
+  // default behavior when passing undefined to http.Server.listen(), which
+  // detects the available interfaces (IPv4 and/or IPv6) and uses them.
+  // Documentation: https://arc.net/l/quote/dnjmtumq
+  .option(
+    "-H, --hostname <HOSTNAME>",
+    'Hostname for the web server (default: "0.0.0.0" or "::")',
+  )
   .showHelpAfterError()
   .action(async (_, command) => {
     const cliOptions = {
@@ -75,7 +82,10 @@ const devCommand = new Command("dev")
 const startCommand = new Command("start")
   .description("Start the production server")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
-  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "")
+  .option(
+    "-H, --hostname <HOSTNAME>",
+    'Hostname for the web server (default: "0.0.0.0" or "::")',
+  )
   .showHelpAfterError()
   .action(async (_, command) => {
     const cliOptions = {
@@ -88,7 +98,10 @@ const startCommand = new Command("start")
 const serveCommand = new Command("serve")
   .description("Start the production HTTP server without the indexer")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
-  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "")
+  .option(
+    "-H, --hostname <HOSTNAME>",
+    'Hostname for the web server (default: "0.0.0.0" or "::")',
+  )
   .showHelpAfterError()
   .action(async (_, command) => {
     const cliOptions = {

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -62,7 +62,7 @@ type GlobalOptions = {
 const devCommand = new Command("dev")
   .description("Start the development server with hot reloading")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
-  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "0.0.0.0")
+  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "")
   .showHelpAfterError()
   .action(async (_, command) => {
     const cliOptions = {
@@ -75,7 +75,7 @@ const devCommand = new Command("dev")
 const startCommand = new Command("start")
   .description("Start the production server")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
-  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "0.0.0.0")
+  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "")
   .showHelpAfterError()
   .action(async (_, command) => {
     const cliOptions = {
@@ -88,7 +88,7 @@ const startCommand = new Command("start")
 const serveCommand = new Command("serve")
   .description("Start the production HTTP server without the indexer")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
-  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "0.0.0.0")
+  .option("-H, --hostname <HOSTNAME>", "Hostname for the web server", "")
   .showHelpAfterError()
   .action(async (_, command) => {
     const cliOptions = {


### PR DESCRIPTION
Even though there's [a comment in the code](https://github.com/ponder-sh/ponder/blob/main/packages/core/src/server/service.ts#L216-L218) indicating that the default hostname behavior should adaptively use ipv6 when possible, the default CLI arg prevents this from actually happening in practice. An easy way to verify this is running a simple example project and attempting to navigate to `http://[::1]:42069/health`, which should fail.

This PR updates the default param to be an empty string, which seems to exhibit the intended behavior. 

Tested locally by verifying both normal `http://localhost:4069/health` and `http://[::1]:42069/health` work for one of the example projects.

Note that it's possible to work around this issue by specifying `--hostname ::` when running `ponder start`.