### PR TITLE
fix `ponder_realtime_is_connected` metric

### DIFF
--- a/.changeset/nine-meals-attend.md
+++ b/.changeset/nine-meals-attend.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed "ponder_realtime_is_connected" metric.

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -38,7 +38,7 @@ export type HistoricalSync = {
   latestBlock: SyncBlock | undefined;
   /** Extract raw data for `interval`. */
   sync(interval: Interval): Promise<void>;
-  initializeMetrics(finalizedBlock: SyncBlock, showStart: boolean): void;
+  initializeMetrics(finalizedBlock: SyncBlock, isInitialCall: boolean): void;
   kill(): void;
 };
 
@@ -525,8 +525,14 @@ export const createHistoricalSync = async (
       blockCache.clear();
       transactionsCache.clear();
     },
-    initializeMetrics(finalizedBlock, showStart) {
-      args.common.metrics.ponder_historical_start_timestamp.set(Date.now());
+    initializeMetrics(finalizedBlock, isInitialCall) {
+      if (isInitialCall) {
+        args.common.metrics.ponder_historical_start_timestamp.set(Date.now());
+        args.common.metrics.ponder_realtime_is_connected.set(
+          { network: args.network.name },
+          0,
+        );
+      }
 
       for (const source of args.sources) {
         const label = {
@@ -538,7 +544,7 @@ export const createHistoricalSync = async (
         if (source.filter.fromBlock > hexToNumber(finalizedBlock.number)) {
           args.common.metrics.ponder_historical_total_blocks.set(label, 0);
 
-          if (showStart) {
+          if (isInitialCall) {
             args.common.logger.warn({
               service: "historical",
               msg: `Skipped syncing '${source.networkName}' for '${source.name}' because the start block is not finalized`,
@@ -571,7 +577,7 @@ export const createHistoricalSync = async (
             cachedBlocks,
           );
 
-          if (showStart) {
+          if (isInitialCall) {
             args.common.logger.info({
               service: "historical",
               msg: `Started syncing '${source.networkName}' for '${

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -513,6 +513,10 @@ export const createSync = async (args: CreateSyncParameters): Promise<Sync> => {
              * defined has become finalized.
              */
             if (localSync.isComplete()) {
+              args.common.metrics.ponder_realtime_is_connected.set(
+                { network: network.name },
+                0,
+              );
               args.common.logger.info({
                 service: "sync",
                 msg: `Synced final end block for '${network.name}' (${hexToNumber(localSync.endBlock!.number)}), killing realtime sync service`,
@@ -588,6 +592,10 @@ export const createSync = async (args: CreateSyncParameters): Promise<Sync> => {
               }),
             onFatalError: args.onFatalError,
           });
+          args.common.metrics.ponder_realtime_is_connected.set(
+            { network: network.name },
+            1,
+          );
           realtimeSync.start(localSync.finalizedBlock);
           realtimeSyncs.set(network, realtimeSync);
         }


### PR DESCRIPTION
Initializes the value to 0 and then updates it when realtime is started / when realtime is killed