### PR TITLE
Fix: extra transactions added in realtime

### DIFF
--- a/.changeset/bright-bikes-enjoy.md
+++ b/.changeset/bright-bikes-enjoy.md
@@ -2,4 +2,12 @@
 "@ponder/core": patch
 ---
 
-Fixed a bug introduced in v0.6 where extra transaction may be added to the database in the "realtime" sync when using factory contracts."
+Fixed a bug introduced in v0.6 where extra transaction may be added to the database in the "realtime" sync when using factory contracts.
+
+Any users that were affected by this bug and want to reduce the database size can do so with the query:
+```sql
+DELETE FROM ponder_sync.transactions WHERE 
+  hash NOT IN (SELECT "transactionHash" FROM ponder_sync.logs) 
+  AND 
+  hash NOT IN (SELECT "transactionHash" FROM ponder_sync."callTraces");
+```

--- a/.changeset/bright-bikes-enjoy.md
+++ b/.changeset/bright-bikes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug introduced in v0.6 where extra transaction may be added to the database in the "realtime" sync when using factory contracts."

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -206,6 +206,20 @@ export const createRealtimeSync = (
       return isMatched;
     });
 
+    // Remove transactions and transaction receipts that may have been filtered out
+    const transactionHashes = new Set<Hash>();
+    for (const log of logs) {
+      transactionHashes.add(log.transactionHash);
+    }
+    for (const trace of callTraces) {
+      transactionHashes.add(trace.transactionHash);
+    }
+
+    transactions = transactions.filter((t) => transactionHashes.has(t.hash));
+    transactionReceipts = transactionReceipts.filter((t) =>
+      transactionHashes.has(t.transactionHash),
+    );
+
     // Record matched block filters
     for (const filter of blockFilters) {
       if (isBlockFilterMatched({ filter, block })) {


### PR DESCRIPTION
The realtime sync functions in two stages, one concurrent stage to extract chain information corresponding to a block such as logs, call traces, transactions, and transaction receipts. This stage does as much filtering as possible but doesn't have access to all factory addresses. 

The next stage is serial, and factory addresses are available. The logs and call traces are re-filtered but transactions and transaction receipts are not. This is causing extra transactions to be added to the database.

I fixed this issues by re-filtering transactions and transaction receipts in the second stage `handleBlock()`.