### PR TITLE
fix: progress >100%

### DIFF
--- a/.changeset/tough-tigers-approve.md
+++ b/.changeset/tough-tigers-approve.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug introduced in v0.6 that caused some apps to show progress > 100% and re-sync blocks unnecessarily.

--- a/.changeset/tough-tigers-approve.md
+++ b/.changeset/tough-tigers-approve.md
@@ -2,4 +2,4 @@
 "@ponder/core": patch
 ---
 
-Fixed a bug introduced in v0.6 that caused some apps to show progress > 100% and re-sync blocks unnecessarily.
+Fixed a bug introduced in `0.6.0` that caused some apps to log progress greater than 100% and re-sync blocks unnecessarily.

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -997,8 +997,15 @@ export async function* localHistoricalSyncGenerator({
   // Cursor to track progress.
   let fromBlock = hexToNumber(syncProgress.start.number);
 
-  // Handle a cache hit by fast forwarding and potentially exiting
-  if (syncProgress.current !== undefined) {
+  /**
+   * Handle a cache hit by fast forwarding and potentially exiting
+   */
+  if (
+    syncProgress.current !== undefined &&
+    (syncProgress.cached === undefined ||
+      hexToNumber(syncProgress.current.number) >
+        hexToNumber(syncProgress.cached.number))
+  ) {
     fromBlock = hexToNumber(syncProgress.current.number) + 1;
   } else if (syncProgress.cached !== undefined) {
     // `getEvents` can make progress without calling `sync`, so immediately "yield"

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -998,7 +998,10 @@ export async function* localHistoricalSyncGenerator({
   let fromBlock = hexToNumber(syncProgress.start.number);
 
   /**
-   * Handle a cache hit by fast forwarding and potentially exiting
+   * Handle a cache hit by fast forwarding and potentially exiting.
+   * A cache hit can either be: (listed by priority)
+   *   1) recovering progress from earlier invocations with different `finalized` blocks
+   *   2) recovering progress from the interval cache
    */
   if (
     syncProgress.current !== undefined &&

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -998,7 +998,9 @@ export async function* localHistoricalSyncGenerator({
   let fromBlock = hexToNumber(syncProgress.start.number);
 
   // Handle a cache hit by fast forwarding and potentially exiting
-  if (syncProgress.cached !== undefined) {
+  if (syncProgress.current !== undefined) {
+    fromBlock = hexToNumber(syncProgress.current.number) + 1;
+  } else if (syncProgress.cached !== undefined) {
     // `getEvents` can make progress without calling `sync`, so immediately "yield"
     yield;
 
@@ -1026,7 +1028,7 @@ export async function* localHistoricalSyncGenerator({
      * time spent syncing ≈ time before indexing function feedback.
      */
     const interval: Interval = [
-      fromBlock,
+      Math.min(fromBlock, hexToNumber(historicalLast.number)),
       Math.min(fromBlock + estimateRange, hexToNumber(historicalLast.number)),
     ];
 


### PR DESCRIPTION
## Description
This fixes a bug that would result in the progress showing > 100%. This was reported in the telegram a few times.

![telegram-cloud-photo-size-4-6039785064532919156-x](https://github.com/user-attachments/assets/74d79d66-834e-4360-969d-8bf726d66e1e)

## Diagnosis
This is a result of incorrect handling of `finalized` block refetching. The current logic is as follows:
- sync all blocks from `start` to `historicalLast`(minimum of `finalized` and `end`)
- check if `finalized` is stale (last fetched more than 5 mins ago)
- if not stale, enter realtime
- else, re-run this loop

However, `start` should not be used on iterations after the first, because this would lead to blocks being re-synced (they have already been synced on the first iteration) 

## Solution
The solution was to detect when `localHistoricalSyncGenerator` should skip blocks that have already been synced, by checking `syncProgress.current`. I validated this worked on the `project-uniswap-v3` example, which I was also able to recreate the original bug with.