### PR TITLE
Fetching receipts only for filters with includeTransactionReceipt: true

### DIFF
--- a/.changeset/friendly-bikes-work.md
+++ b/.changeset/friendly-bikes-work.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Eliminated unnecessary `eth_getTransactionReceipt` requests in realtime when `includeTransactionReceipts` was set to `true`.

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -463,7 +463,7 @@ export const createRealtimeSync = (
         (filter) => {
           const isMatched = isLogFilterMatched({ filter, block, log });
           isLogMatched ||= isMatched;
-          isMatched && filter.includeTransactionReceipts;
+          return isMatched && filter.includeTransactionReceipts;
         },
       );
 
@@ -492,7 +492,7 @@ export const createRealtimeSync = (
             callTrace,
           });
           isCallMatched ||= isMatched;
-          isMatched && filter.includeTransactionReceipts;
+          return isMatched && filter.includeTransactionReceipts;
         },
       );
 


### PR DESCRIPTION
In sync-realtime, added filtering for transactions whose tx receipts need to be fetched. Relates to #1128 issue