### PR TITLE
support ipv6 by default

### DIFF
--- a/.changeset/curvy-carrots-cough.md
+++ b/.changeset/curvy-carrots-cough.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Setting default hostname to "::" to support ipv6

--- a/docs/pages/docs/api-reference/ponder-cli.mdx
+++ b/docs/pages/docs/api-reference/ponder-cli.mdx
@@ -43,7 +43,7 @@ Start the development server with hot reloading
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0" or "::")
+  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "::")
   -h, --help                 display help for command
 ```
 
@@ -61,7 +61,7 @@ Start the production server
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0" or "::")
+  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "::")
   -h, --help                 display help for command
 ```
 
@@ -81,7 +81,7 @@ Start the production HTTP server without the indexer
 
 Options:
   -p, --port <PORT>          Port for the web server (default: 42069)
-  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "0.0.0.0" or "::")
+  -H, --hostname <HOSTNAME>  Hostname for the web server (default: "::")
   -h, --help                 display help for command
 ```
 

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -61,13 +61,12 @@ type GlobalOptions = {
 const devCommand = new Command("dev")
   .description("Start the development server with hot reloading")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
-  // NOTE: Do not set a default for hostname. We currently rely on the Node.js
-  // default behavior when passing undefined to http.Server.listen(), which
-  // detects the available interfaces (IPv4 and/or IPv6) and uses them.
-  // Documentation: https://arc.net/l/quote/dnjmtumq
+  // NOTE: hono/node-server's default behavior is to listen only on IPv4.
+  // Reference: https://github.com/honojs/node-server/blob/main/src/server.ts#L24
   .option(
     "-H, --hostname <HOSTNAME>",
-    'Hostname for the web server (default: "0.0.0.0" or "::")',
+    'Hostname for the web server (default: "::")',
+    "::",
   )
   .showHelpAfterError()
   .action(async (_, command) => {
@@ -83,7 +82,8 @@ const startCommand = new Command("start")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
   .option(
     "-H, --hostname <HOSTNAME>",
-    'Hostname for the web server (default: "0.0.0.0" or "::")',
+    'Hostname for the web server (default: "::")',
+    "::",
   )
   .showHelpAfterError()
   .action(async (_, command) => {
@@ -99,7 +99,8 @@ const serveCommand = new Command("serve")
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
   .option(
     "-H, --hostname <HOSTNAME>",
-    'Hostname for the web server (default: "0.0.0.0" or "::")',
+    'Hostname for the web server (default: "::")',
+    "::",
   )
   .showHelpAfterError()
   .action(async (_, command) => {

--- a/packages/core/src/common/options.ts
+++ b/packages/core/src/common/options.ts
@@ -16,7 +16,7 @@ export type Options = {
   logDir: string;
 
   port: number;
-  hostname?: string;
+  hostname: string;
 
   telemetryUrl: string;
   telemetryDisabled: boolean;
@@ -73,7 +73,7 @@ export const buildOptions = ({ cliOptions }: { cliOptions: CliOptions }) => {
         ? cliOptions.port
         : 42069;
 
-  const hostname = cliOptions.hostname;
+  const hostname = cliOptions.hostname ?? "::";
 
   return {
     command: cliOptions.command,

--- a/packages/core/src/server/index.test.ts
+++ b/packages/core/src/server/index.test.ts
@@ -38,6 +38,29 @@ test("port", async (context) => {
   await cleanup();
 });
 
+test("ipv4 and ipv6", async (context) => {
+  const { database, cleanup } = await setupDatabaseServices(context);
+
+  const server = await createServer({
+    common: context.common,
+    app: new Hono(),
+    routes: [],
+    schema: {},
+    database,
+  });
+
+  const ipv4Url = `http://localhost:${server.port}`;
+  const ipv4Response = await fetch(`${ipv4Url}/health`);
+  expect(ipv4Response.status).toBe(200);
+
+  const ipv6Url = `http://[::1]:${server.port}`;
+  const ipv6Response = await fetch(`${ipv6Url}/health`);
+  expect(ipv6Response.status).toBe(200);
+
+  await server.kill();
+  await cleanup();
+});
+
 test("not ready", async (context) => {
   const { database, cleanup } = await setupDatabaseServices(context);
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -207,9 +207,6 @@ export async function createServer({
         fetch: hono.fetch,
         createServer: createServerWithNextAvailablePort,
         port,
-        // Note that common.options.hostname can be undefined if the user did not specify one.
-        // In this case, Node.js uses `::` if IPv6 is available and `0.0.0.0` otherwise.
-        // https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback
         hostname: common.options.hostname,
       },
       () => {


### PR DESCRIPTION
Since updating the internal server to hono, it seems this behavior has changed; looks like ponder always defaults to using `0.0.0.0` as the hostname when unspecified, rather than adaptively choosing between that and `::` as node did. See [here](https://github.com/honojs/node-server/blob/main/src/server.ts#L24) for where this behavior lives.

I added a small fix that defaults the `hostname` arg to `::` when unset, and a test that validates this behavior.

As with before, this can easily be worked around via using the --hostname flag (eg. `ponder start --hostname=::`)