### PR TITLE
chore: bumping hono/node-server to support ipv6

### DIFF
--- a/.changeset/stupid-cooks-wash.md
+++ b/.changeset/stupid-cooks-wash.md
@@ -2,4 +2,4 @@
 "@ponder/core": patch
 ---
 
-Bumping hono/node-server to support ipv6
+Bumped `@hono/node-server` to fix a regression introduced in `0.5.0` that caused the HTTP server to not listen on IPv6 by default.

--- a/.changeset/stupid-cooks-wash.md
+++ b/.changeset/stupid-cooks-wash.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Bumping hono/node-server to support ipv6

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "@escape.tech/graphql-armor-max-aliases": "^2.3.0",
     "@escape.tech/graphql-armor-max-depth": "^2.2.0",
     "@escape.tech/graphql-armor-max-tokens": "^2.3.0",
-    "@hono/node-server": "^1.12.2",
+    "@hono/node-server": "^1.13.2",
     "@ponder/utils": "workspace:*",
     "abitype": "^0.10.2",
     "better-sqlite3": "^11.1.2",

--- a/packages/core/src/server/index.test.ts
+++ b/packages/core/src/server/index.test.ts
@@ -38,6 +38,42 @@ test("port", async (context) => {
   await cleanup();
 });
 
+test("listens on ipv4", async (context) => {
+  const { database, cleanup } = await setupDatabaseServices(context);
+
+  const server = await createServer({
+    common: context.common,
+    app: new Hono(),
+    routes: [],
+    schema: {},
+    database,
+  });
+
+  const response = await fetch(`http://localhost:${server.port}/health`);
+  expect(response.status).toBe(200);
+
+  await server.kill();
+  await cleanup();
+});
+
+test("listens on ipv6", async (context) => {
+  const { database, cleanup } = await setupDatabaseServices(context);
+
+  const server = await createServer({
+    common: context.common,
+    app: new Hono(),
+    routes: [],
+    schema: {},
+    database,
+  });
+
+  const response = await fetch(`http://[::1]:${server.port}/health`);
+  expect(response.status).toBe(200);
+
+  await server.kill();
+  await cleanup();
+});
+
 test("not ready", async (context) => {
   const { database, cleanup } = await setupDatabaseServices(context);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,8 +683,8 @@ importers:
         specifier: ^2.3.0
         version: 2.4.0
       '@hono/node-server':
-        specifier: ^1.12.2
-        version: 1.12.2(hono@4.5.0)
+        specifier: ^1.13.2
+        version: 1.13.2(hono@4.5.0)
       '@ponder/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2087,8 +2087,8 @@ packages:
       react: ^16 || ^17 || ^18
       react-dom: ^16 || ^17 || ^18
 
-  '@hono/node-server@1.12.2':
-    resolution: {integrity: sha512-xjzhqhSWUE/OhN0g3KCNVzNsQMlFUAL+/8GgPUr3TKcU7cvgZVBGswFofJ8WwGEHTqobzze1lDpGJl9ZNckDhA==}
+  '@hono/node-server@1.13.2':
+    resolution: {integrity: sha512-0w8nEmAyx0Ul0CQp8BL2VtAG4YVdpzXd/mvvM+l0G5Oq22pUyHS+KeFFPSY+czLOF5NAiV3MUNPD1n14Ol5svg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -9700,7 +9700,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@hono/node-server@1.12.2(hono@4.5.0)':
+  '@hono/node-server@1.13.2(hono@4.5.0)':
     dependencies:
       hono: 4.5.0
 


### PR DESCRIPTION
See context here: https://github.com/ponder-sh/ponder/pull/1146

Upstream change to hono/node-server was included @ https://github.com/honojs/node-server/pull/206

This PR bumps the version of hono/node-server to include the upstream change. I also added a test to ensure ipv6 works, which should help avoid future regressions as well!