### PR TITLE
fix: `disableCache` running out of order

### DIFF
--- a/.changeset/lovely-spies-dance.md
+++ b/.changeset/lovely-spies-dance.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug introduced in v0.6.0 where the `disableCache` option did not correctly ignore the cache in some cases.


### PR DESCRIPTION
## Description

The `disableCache` option is applied out of order. It needs to be run before `historicalSync.start` because this is where the cache is read.

Currently, the `disableCache` option is applied after `historicalSync.start`, causing the cache progress to be recorded, then the cache to be pruned, which would cause the app to start from the wrong spot and eventually events to be missed.