### PR TITLE
Fix `block.hash` and `log.blockHash` comparaison during sync

### DIFF
--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -491,7 +491,7 @@ export const createRealtimeSync = (
 
       // Check that logs refer to the correct block
       for (const log of logs) {
-        if (log.blockHash !== block.hash) {
+        if (BigInt(log.blockHash) !== BigInt(block.hash)) {
           throw new Error(
             "Detected invalid eth_getLogs response. `log.blockHash` does not match requested block hash.",
           );


### PR DESCRIPTION
The hash comparaison was done on the hex string values, thus failing in some case due to case sensitivity or leading zero.

For our use case we where indexing with alchemy + envio rpcs, and every version after the v0.6.11 was failing to index our events due to this condition and case sensitivity.

Using BigInt wrapping ensure we are comparing the real hex value (it's also possible to use `hexToBytes(...)` or `hexToBigint(...)`from viem, but it would be more consuming in term of memory and cpu)