### PR TITLE
Feature: network option to disable rpc request validation

### DIFF
--- a/packages/core/src/build/configAndIndexingFunctions.ts
+++ b/packages/core/src/build/configAndIndexingFunctions.ts
@@ -213,6 +213,7 @@ export async function buildConfigAndIndexingFunctions({
         pollingInterval: network.pollingInterval ?? 1_000,
         finalityBlockCount: getFinalityBlockCount({ chainId }),
         disableCache: network.disableCache ?? false,
+        disableValidation: network.disableValidation ?? false,
       } satisfies Network;
     }),
   );

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -59,6 +59,8 @@ export type NetworkConfig<network> = {
   maxRequestsPerSecond?: number;
   /** Disable RPC request caching. Default: `false`. */
   disableCache?: boolean;
+  /** Disable RPC request validation. Default: `false`. */
+  disableValidation?: boolean;
 };
 
 export type BlockFilterConfig = {

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -10,6 +10,7 @@ export type Network = {
   maxRequestsPerSecond: number;
   finalityBlockCount: number;
   disableCache: boolean;
+  disableValidation: boolean;
 };
 
 /**

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -489,12 +489,14 @@ export const createRealtimeSync = (
         );
       }
 
-      // Check that logs refer to the correct block
-      for (const log of logs) {
-        if (log.blockHash !== block.hash) {
-          throw new Error(
-            "Detected invalid eth_getLogs response. `log.blockHash` does not match requested block hash.",
-          );
+      // Check that logs refer to the correct block (only if validation isn't disabled)
+      if (!args.network.disableValidation) {
+        for (const log of logs) {
+          if (log.blockHash !== block.hash) {
+            throw new Error(
+              "Detected invalid eth_getLogs response. `log.blockHash` does not match requested block hash.",
+            );
+          }
         }
       }
     }
@@ -534,12 +536,14 @@ export const createRealtimeSync = (
       ) as SyncCallTrace[];
     }
 
-    // Check that traces refer to the correct block
-    for (const trace of callTraces) {
-      if (trace.blockHash !== block.hash) {
-        throw new Error(
-          "Detected invalid trace_block response. `trace.blockHash` does not match requested block hash.",
-        );
+    // Check that traces refer to the correct block (if validation isn't disabled)
+    if (!args.network.disableValidation) {
+      for (const trace of callTraces) {
+        if (trace.blockHash !== block.hash) {
+          throw new Error(
+            "Detected invalid trace_block response. `trace.blockHash` does not match requested block hash.",
+          );
+        }
       }
     }
 


### PR DESCRIPTION
Related to #1173  

Add a network option to disable rpc request validation for the comparaison between block hash of logs and traces results 