### PR TITLE
Feature: Accounts API for specifying event, transaction and native transfer filters

### DIFF
--- a/packages/core/src/build/factory.ts
+++ b/packages/core/src/build/factory.ts
@@ -4,17 +4,26 @@ import { getBytesConsumedByParam } from "@/utils/offset.js";
 import type { AbiEvent } from "abitype";
 import { type Address, getEventSelector } from "viem";
 
-export function buildLogFactory({
-  address: _address,
-  event,
-  parameter,
-  chainId,
-}: {
-  address: Address | readonly Address[];
-  event: AbiEvent;
-  parameter: string;
-  chainId: number;
-}): LogFactory {
+export function buildLogFactory(
+  chainId: number,
+  factory:
+    | {
+        address: Address | readonly Address[];
+        event: AbiEvent;
+        parameter: string;
+      }
+    | Address
+    | Address[]
+    | undefined,
+): LogFactory | Address | Address[] | undefined {
+  if (Array.isArray(factory)) {
+    return factory.map(toLowerCase);
+  } else if (typeof factory === "string" || factory === undefined) {
+    return factory;
+  }
+
+  const { address: _address, event, parameter } = factory;
+
   const address = Array.isArray(_address)
     ? _address.map(toLowerCase)
     : toLowerCase(_address);

--- a/packages/core/src/config/address.ts
+++ b/packages/core/src/config/address.ts
@@ -47,3 +47,130 @@ export type GetAddress<contract> = contract extends {
           parameter: string;
         };
       };
+
+export type GetAccountAddress<filter> = filter extends {
+  fromAddress: unknown;
+  toAddress: unknown;
+}
+  ? filter extends {
+      fromAddress: {
+        event: infer fromEvent extends AbiEvent;
+      };
+      toAddress: {
+        event: infer toEvent extends AbiEvent;
+      };
+    }
+    ? {
+        fromAddress?: {
+          /** Address of the factory contract that creates this contract. */
+          address: `0x${string}` | readonly `0x${string}`[];
+          /** ABI event that announces the creation of a new instance of this contract. */
+          event: AbiEvent;
+          /** Name of the factory event parameter that contains the new child contract address. */
+          parameter: Exclude<fromEvent["inputs"][number]["name"], undefined>;
+        };
+        toAddress?: {
+          /** Address of the factory contract that creates this contract. */
+          address: `0x${string}` | readonly `0x${string}`[];
+          /** ABI event that announces the creation of a new instance of this contract. */
+          event: AbiEvent;
+          /** Name of the factory event parameter that contains the new child contract address. */
+          parameter: Exclude<toEvent["inputs"][number]["name"], undefined>;
+        };
+      }
+    : filter extends {
+          fromAddress: {
+            event: infer fromEvent extends AbiEvent;
+          };
+        }
+      ? {
+          fromAddress?: {
+            /** Address of the factory contract that creates this contract. */
+            address: `0x${string}` | readonly `0x${string}`[];
+            /** ABI event that announces the creation of a new instance of this contract. */
+            event: AbiEvent;
+            /** Name of the factory event parameter that contains the new child contract address. */
+            parameter: Exclude<fromEvent["inputs"][number]["name"], undefined>;
+          };
+          toAddress?: {
+            /** Address of the factory contract that creates this contract. */
+            address: `0x${string}` | readonly `0x${string}`[];
+            /** ABI event that announces the creation of a new instance of this contract. */
+            event: AbiEvent;
+            /** Name of the factory event parameter that contains the new child contract address. */
+            parameter: string;
+          };
+        }
+      : filter extends {
+            toAddress: {
+              event: infer toEvent extends AbiEvent;
+            };
+          }
+        ? {
+            fromAddress?: {
+              /** Address of the factory contract that creates this contract. */
+              address: `0x${string}` | readonly `0x${string}`[];
+              /** ABI event that announces the creation of a new instance of this contract. */
+              event: AbiEvent;
+              /** Name of the factory event parameter that contains the new child contract address. */
+              parameter: string;
+            };
+            toAddress?: {
+              /** Address of the factory contract that creates this contract. */
+              address: `0x${string}` | readonly `0x${string}`[];
+              /** ABI event that announces the creation of a new instance of this contract. */
+              event: AbiEvent;
+              /** Name of the factory event parameter that contains the new child contract address. */
+              parameter: Exclude<toEvent["inputs"][number]["name"], undefined>;
+            };
+          }
+        : {
+            fromAddress?: {
+              /** Address of the factory contract that creates this contract. */
+              address: `0x${string}` | readonly `0x${string}`[];
+              /** ABI event that announces the creation of a new instance of this contract. */
+              event: AbiEvent;
+              /** Name of the factory event parameter that contains the new child contract address. */
+              parameter: string;
+            };
+            toAddress?: {
+              /** Address of the factory contract that creates this contract. */
+              address: `0x${string}` | readonly `0x${string}`[];
+              /** ABI event that announces the creation of a new instance of this contract. */
+              event: AbiEvent;
+              /** Name of the factory event parameter that contains the new child contract address. */
+              parameter: string;
+            };
+          }
+  : filter extends {
+        fromAddress: `0x${string}` | `0x${string}`[];
+        toAddress: `0x${string}` | `0x${string}`[];
+      }
+    ? {
+        fromAddress?: `0x${string}` | `0x${string}`[];
+        toAddress?: `0x${string}` | `0x${string}`[];
+      }
+    : {
+        fromAddress?:
+          | `0x${string}`
+          | `0x${string}`[]
+          | {
+              /** Address of the factory contract that creates this contract. */
+              address: `0x${string}` | readonly `0x${string}`[];
+              /** ABI event that announces the creation of a new instance of this contract. */
+              event: AbiEvent;
+              /** Name of the factory event parameter that contains the new child contract address. */
+              parameter: string;
+            };
+        toAddress?:
+          | `0x${string}`
+          | `0x${string}`[]
+          | {
+              /** Address of the factory contract that creates this contract. */
+              address: `0x${string}` | readonly `0x${string}`[];
+              /** ABI event that announces the creation of a new instance of this contract. */
+              event: AbiEvent;
+              /** Name of the factory event parameter that contains the new child contract address. */
+              parameter: string;
+            };
+      };

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -257,10 +257,10 @@ export const createConfig = <
 >(config: {
   // TODO: add jsdoc to these properties.
   networks: NetworksConfig<Narrow<networks>>;
-  contracts: ContractsConfig<networks, Narrow<contracts>>;
+  contracts?: ContractsConfig<networks, Narrow<contracts>>;
   database?: DatabaseConfig;
   blocks?: BlockFiltersConfig<networks, blocks>;
-  accounts: AccountsConfig<networks, Narrow<accounts>>;
+  accounts?: AccountsConfig<networks, Narrow<accounts>>;
 }): CreateConfigReturnType<networks, contracts, accounts, blocks> =>
   config as Prettify<
     CreateConfigReturnType<networks, contracts, accounts, blocks>

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,8 +1,7 @@
-import type { TransactionFilter, TransferFilter } from "@/sync/source.js";
 import type { Prettify } from "@/types/utils.js";
 import type { Abi } from "abitype";
 import type { Narrow, Transport } from "viem";
-import type { GetAddress } from "./address.js";
+import type { GetAccountAddress, GetAddress } from "./address.js";
 import type { GetEventFilter } from "./eventFilter.js";
 import type { NonStrictPick } from "./utilityTypes.js";
 
@@ -168,8 +167,8 @@ type GetAccountNetwork<
     | {
         [name in allNetworkNames]?: Prettify<
           GetEventFilter<abi, NonStrictPick<account, "filter">> &
-            GetTransactionConfig &
-            GetTransferConfig &
+            GetTransactionFilter<account> &
+            GetTransferFilter<account> &
             TransactionReceiptConfig &
             BlockConfig
         >;
@@ -186,20 +185,44 @@ type ContractConfig<networks, contract, abi extends Abi> = Prettify<
     BlockConfig
 >;
 
-type GetTransactionConfig = {
-  transaction?: TransactionFilter | readonly TransactionFilter[];
+export type GetTransferFilter<account> = {
+  transfer?:
+    | ({
+        chainId: number;
+        fromBlock: number;
+        toBlock: number | undefined;
+        includeTransactionReceipts: boolean;
+      } & GetAccountAddress<NonStrictPick<account, "transfer">>)
+    | ({
+        chainId: number;
+        fromBlock: number;
+        toBlock: number | undefined;
+        includeTransactionReceipts: boolean;
+      } & GetAccountAddress<NonStrictPick<account, "transfer">>)[];
 };
 
-type GetTransferConfig = {
-  transfer?: TransferFilter | readonly TransferFilter[];
+export type GetTransactionFilter<account> = {
+  transaction?:
+    | ({
+        chainId: number;
+        fromBlock: number;
+        toBlock: number | undefined;
+        includeTransactionReceipts: boolean;
+      } & GetAccountAddress<NonStrictPick<account, "transaction">>)
+    | ({
+        chainId: number;
+        fromBlock: number;
+        toBlock: number | undefined;
+        includeTransactionReceipts: boolean;
+      } & GetAccountAddress<NonStrictPick<account, "transaction">>)[];
 };
 
 type AccountConfig<networks, account, abi extends Abi> = Prettify<
   AbiConfig<abi> &
     GetAccountNetwork<networks, NonStrictPick<account, "network">, abi> &
     GetEventFilter<abi, NonStrictPick<account, "filter">> &
-    GetTransactionConfig &
-    GetTransferConfig &
+    GetTransactionFilter<account> &
+    GetTransferFilter<account> &
     TransactionReceiptConfig &
     BlockConfig
 >;

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -365,12 +365,12 @@ export const createHistoricalSync = async (
     transactions = transactions.filter((t) =>
       fromAddress !== undefined
         ? toAddress !== undefined
-          ? fromAddress.includes(t.from.toLowerCase() as Address) &&
+          ? fromAddress.includes(t.from) &&
             t.to !== null &&
-            toAddress.includes(t.to.toLowerCase() as Address)
-          : fromAddress.includes(t.from.toLowerCase() as Address)
+            toAddress.includes(t.to)
+          : fromAddress.includes(t.from)
         : toAddress !== undefined
-          ? t.to !== null && toAddress.includes(t.to.toLowerCase() as Address)
+          ? t.to !== null && toAddress.includes(t.to)
           : true,
     );
 
@@ -409,9 +409,7 @@ export const createHistoricalSync = async (
     await args.syncStore.insertTransactions({
       transactions: transactions.map((transaction) => ({
         transaction,
-        block: blocks.find((block) => {
-          block.hash === transaction.blockHash;
-        })!,
+        block: blocks.find((block) => block.hash === transaction.blockHash)!,
       })),
       chainId: args.network.chainId,
     });

--- a/packages/core/src/sync-realtime/filter.ts
+++ b/packages/core/src/sync-realtime/filter.ts
@@ -1,16 +1,27 @@
 import {
   type TraceFilterFragment,
+  type TransactionFilterFragment,
+  type TransferFilterFragment,
   buildLogFilterFragments,
   buildTraceFilterFragments,
+  buildTransactionFilterFragments,
+  buildTransferFilterFragments,
 } from "@/sync/fragments.js";
 import {
   type BlockFilter,
   type CallTraceFilter,
   type LogFactory,
   type LogFilter,
+  type TransactionFilter,
+  type TransferFilter,
   isAddressFactory,
 } from "@/sync/source.js";
-import type { SyncBlock, SyncCallTrace, SyncLog } from "@/types/sync.js";
+import type {
+  SyncBlock,
+  SyncCallTrace,
+  SyncLog,
+  SyncTransaction,
+} from "@/types/sync.js";
 import { toLowerCase } from "@/utils/lowercase.js";
 import { hexToNumber } from "viem";
 
@@ -114,6 +125,98 @@ export const isCallTraceFilterMatched = ({
       (fragment as TraceFilterFragment<undefined>).toAddress !== null &&
       (fragment as TraceFilterFragment<undefined>).toAddress !==
         callTrace.action.to.toLowerCase()
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+/**
+ * Returns `true` if `callTrace` matches `transferFilter`
+ */
+export const isTransferFilterMatched = ({
+  filter,
+  block,
+  callTrace,
+}: {
+  filter: TransferFilter;
+  block: SyncBlock;
+  callTrace: SyncCallTrace;
+}): boolean => {
+  // Return `false` for out of range blocks
+  if (
+    hexToNumber(block.number) < filter.fromBlock ||
+    hexToNumber(block.number) > (filter.toBlock ?? Number.POSITIVE_INFINITY)
+  ) {
+    return false;
+  }
+
+  return buildTransferFilterFragments(filter).some((fragment) => {
+    if (
+      isAddressFactory(filter.toAddress) === false &&
+      (fragment as TransferFilterFragment<undefined>).fromAddress !== null &&
+      (fragment as TransferFilterFragment<undefined>).fromAddress !==
+        callTrace.action.from.toLowerCase()
+    ) {
+      return false;
+    }
+
+    if (
+      isAddressFactory(filter.toAddress) === false &&
+      (fragment as TransferFilterFragment<undefined>).toAddress !== null &&
+      (fragment as TransferFilterFragment<undefined>).toAddress !==
+        callTrace.action.to.toLowerCase()
+    ) {
+      return false;
+    }
+
+    // Check if call trace corresponds to native transfer
+    if (callTrace.action.input !== "0x") {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+/**
+ * Returns `true` if `transaction` matches `filter`
+ */
+export const isTransactionFilterMatched = ({
+  filter,
+  block,
+  transaction,
+}: {
+  filter: TransactionFilter;
+  block: SyncBlock;
+  transaction: SyncTransaction;
+}): boolean => {
+  // Return `false` for out of range blocks
+  if (
+    hexToNumber(block.number) < filter.fromBlock ||
+    hexToNumber(block.number) > (filter.toBlock ?? Number.POSITIVE_INFINITY)
+  ) {
+    return false;
+  }
+
+  return buildTransactionFilterFragments(filter).some((fragment) => {
+    if (
+      isAddressFactory(filter.toAddress) === false &&
+      (fragment as TransactionFilterFragment<undefined>).fromAddress !== null &&
+      (fragment as TransactionFilterFragment<undefined>).fromAddress !==
+        transaction.from.toLowerCase()
+    ) {
+      return false;
+    }
+
+    if (
+      isAddressFactory(filter.toAddress) === false &&
+      (fragment as TransactionFilterFragment<undefined>).toAddress !== null &&
+      (transaction.to === null ||
+        (fragment as TransactionFilterFragment<undefined>).toAddress !==
+          transaction.to.toLowerCase())
     ) {
       return false;
     }

--- a/packages/core/src/sync-store/encoding.ts
+++ b/packages/core/src/sync-store/encoding.ts
@@ -193,21 +193,18 @@ export const encodeTransaction = ({
 }: {
   transaction: SyncTransaction;
   chainId: number;
-  block?: SyncBlock;
+  block: SyncBlock;
   dialect: "sqlite" | "postgres";
 }): Insertable<TransactionsTable> => {
   return {
-    checkpoint:
-      block === undefined
-        ? null
-        : encodeCheckpoint({
-            blockTimestamp: hexToNumber(block.timestamp),
-            chainId: BigInt(chainId),
-            blockNumber: hexToBigInt(transaction.blockNumber),
-            transactionIndex: hexToBigInt(transaction.transactionIndex),
-            eventType: EVENT_TYPES.transactions,
-            eventIndex: hexToBigInt(transaction.transactionIndex),
-          }),
+    checkpoint: encodeCheckpoint({
+      blockTimestamp: hexToNumber(block.timestamp),
+      chainId: BigInt(chainId),
+      blockNumber: hexToBigInt(transaction.blockNumber),
+      transactionIndex: hexToBigInt(transaction.transactionIndex),
+      eventType: EVENT_TYPES.transactions,
+      eventIndex: hexToBigInt(transaction.transactionIndex),
+    }),
     hash: transaction.hash,
     chainId,
     blockHash: transaction.blockHash,

--- a/packages/core/src/sync-store/encoding.ts
+++ b/packages/core/src/sync-store/encoding.ts
@@ -162,6 +162,7 @@ export const encodeLog = ({
 };
 
 type TransactionsTable = {
+  checkpoint: string | null;
   hash: Hash;
   blockHash: Hash;
   blockNumber: string | bigint;
@@ -186,14 +187,27 @@ type TransactionsTable = {
 
 export const encodeTransaction = ({
   transaction,
+  block,
   chainId,
   dialect,
 }: {
   transaction: SyncTransaction;
   chainId: number;
+  block?: SyncBlock;
   dialect: "sqlite" | "postgres";
 }): Insertable<TransactionsTable> => {
   return {
+    checkpoint:
+      block === undefined
+        ? null
+        : encodeCheckpoint({
+            blockTimestamp: hexToNumber(block.timestamp),
+            chainId: BigInt(chainId),
+            blockNumber: hexToBigInt(transaction.blockNumber),
+            transactionIndex: hexToBigInt(transaction.transactionIndex),
+            eventType: EVENT_TYPES.transactions,
+            eventIndex: hexToBigInt(transaction.transactionIndex),
+          }),
     hash: transaction.hash,
     chainId,
     blockHash: transaction.blockHash,
@@ -400,6 +414,74 @@ type FactoryTraceFilterIntervalsTable = {
   endBlock: string | bigint;
 };
 
+type TransferFiltersTable = {
+  id: string;
+  chainId: number;
+  fromAddress: Address | null;
+  toAddress: Address | null;
+  includeTransactionReceipts: 0 | 1;
+};
+
+type TransferIntervalsTable = {
+  id: Generated<number>;
+  transferFilterId: string;
+  startBlock: string | bigint;
+  endBlock: string | bigint;
+};
+
+type FactoryTransferFiltersTable = {
+  id: string;
+  chainId: number;
+  fromAddress: Address | null;
+  fromEventSelector: Hex | null;
+  fromChildAddressLocation: `topic${1 | 2 | 3}` | `offset${number}` | null;
+  toAddress: Address | null;
+  toEventSelector: Hex | null;
+  toChildAddressLocation: `topic${1 | 2 | 3}` | `offset${number}` | null;
+  includeTransactionReceipts: 0 | 1;
+};
+
+type FactoryTransferIntervalsTable = {
+  id: Generated<number>;
+  factoryId: string;
+  startBlock: string | bigint;
+  endBlock: string | bigint;
+};
+
+type TransactionFiltersTable = {
+  id: string;
+  chainId: number;
+  fromAddress: Address | null;
+  toAddress: Address | null;
+  includeTransactionReceipts: 0 | 1;
+};
+
+type TransactionIntervalsTable = {
+  id: Generated<number>;
+  transactionFilterId: string;
+  startBlock: string | bigint;
+  endBlock: string | bigint;
+};
+
+type FactoryTransactionFiltersTable = {
+  id: string;
+  chainId: number;
+  fromAddress: Address | null;
+  fromEventSelector: Hex | null;
+  fromChildAddressLocation: `topic${1 | 2 | 3}` | `offset${number}` | null;
+  toAddress: Address | null;
+  toEventSelector: Hex | null;
+  toChildAddressLocation: `topic${1 | 2 | 3}` | `offset${number}` | null;
+  includeTransactionReceipts: 0 | 1;
+};
+
+type FactoryTransactionIntervalsTable = {
+  id: Generated<number>;
+  factoryId: string;
+  startBlock: string | bigint;
+  endBlock: string | bigint;
+};
+
 type BlockFiltersTable = {
   id: string;
   chainId: number;
@@ -431,6 +513,14 @@ export type PonderSyncSchema = {
   traceFilterIntervals: TraceFilterIntervalsTable;
   factoryTraceFilters: FactoryTraceFiltersTable;
   factoryTraceFilterIntervals: FactoryTraceFilterIntervalsTable;
+  transferFilters: TransferFiltersTable;
+  transferFilterIntervals: TransferIntervalsTable;
+  factoryTransferFilters: FactoryTransferFiltersTable;
+  factoryTransferFilterIntervals: FactoryTransferIntervalsTable;
+  transactionFilters: TransactionFiltersTable;
+  transactionFilterIntervals: TransactionIntervalsTable;
+  factoryTransactionFilters: FactoryTransactionFiltersTable;
+  factoryTransactionFilterIntervals: FactoryTransactionIntervalsTable;
   blockFilters: BlockFiltersTable;
   blockFilterIntervals: BlockFilterIntervalsTable;
 };

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -1297,17 +1297,6 @@ export const createSyncStore = ({
           query = query === undefined ? _query : query.unionAll(_query);
         }
 
-        const fake_rows = await db
-          .with("event", () => query!)
-          .selectFrom("event")
-          .select(["event.transactionHash"])
-          .limit(limit)
-          .execute();
-
-        console.log(
-          `fake_rows ${fake_rows.map((f) => `${f.transactionHash}`).join(", ")}`,
-        );
-
         return await db
           .with("event", () => query!)
           .selectFrom("event")
@@ -1315,7 +1304,7 @@ export const createSyncStore = ({
             "event.filterIndex as event_filterIndex",
             "event.checkpoint as event_checkpoint",
           ])
-          .leftJoin("blocks", "blocks.hash", "event.blockHash")
+          .innerJoin("blocks", "blocks.hash", "event.blockHash")
           .select([
             "blocks.baseFeePerGas as block_baseFeePerGas",
             "blocks.difficulty as block_difficulty",
@@ -1424,23 +1413,6 @@ export const createSyncStore = ({
           .limit(limit)
           .execute();
       },
-    );
-
-    const tx_rows = await db
-      .selectFrom("transactions")
-      .select([
-        "transactions.hash",
-        "transactions.blockHash",
-        "transactions.from",
-      ])
-      .execute();
-    const block_rows = await db
-      .selectFrom("blocks")
-      .select(["blocks.hash"])
-      .execute();
-
-    console.log(
-      `tx_rows ${tx_rows.map((t) => `${t.hash}-${t.blockHash}-${t.from}`).join(", ")}, block_rows ${block_rows.map((t) => t.hash).join(", ")}, from ${from}`,
     );
 
     const events = rows.map((_row) => {

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -736,7 +736,8 @@ export const createSync = async (args: CreateSyncParameters): Promise<Sync> => {
           }),
           args.syncStore.insertTransactions({
             transactions: finalizedEventData.flatMap(
-              ({ transactions }) => transactions,
+              ({ transactions, block }) =>
+                transactions.map((transaction) => ({ transaction, block })),
             ),
             chainId: network.chainId,
           }),
@@ -854,16 +855,36 @@ export const createSync = async (args: CreateSyncParameters): Promise<Sync> => {
           const initialChildAddresses = new Map<Factory, Set<Address>>();
 
           for (const { filter } of args.sources) {
-            if (
-              filter.chainId === network.chainId &&
-              "address" in filter &&
-              isAddressFactory(filter.address)
-            ) {
-              const addresses = await args.syncStore.getChildAddresses({
-                filter: filter.address,
-              });
+            if (filter.chainId === network.chainId) {
+              if ("address" in filter && isAddressFactory(filter.address)) {
+                const addresses = await args.syncStore.getChildAddresses({
+                  filter: filter.address,
+                });
 
-              initialChildAddresses.set(filter.address, new Set(addresses));
+                initialChildAddresses.set(filter.address, new Set(addresses));
+              }
+
+              if (
+                "fromAddress" in filter &&
+                isAddressFactory(filter.fromAddress)
+              ) {
+                const addresses = await args.syncStore.getChildAddresses({
+                  filter: filter.fromAddress,
+                });
+
+                initialChildAddresses.set(
+                  filter.fromAddress,
+                  new Set(addresses),
+                );
+              }
+
+              if ("toAddress" in filter && isAddressFactory(filter.toAddress)) {
+                const addresses = await args.syncStore.getChildAddresses({
+                  filter: filter.toAddress,
+                });
+
+                initialChildAddresses.set(filter.toAddress, new Set(addresses));
+              }
             }
           }
 

--- a/packages/core/src/sync/source.ts
+++ b/packages/core/src/sync/source.ts
@@ -2,16 +2,36 @@ import type { AbiEvents, AbiFunctions } from "@/sync/abi.js";
 import type { SyncLog } from "@/types/sync.js";
 import type { Abi, Address, Hex, LogTopic } from "viem";
 
-export type Source = ContractSource | BlockSource;
+export type Source = ContractSource | BlockSource | AccountSource;
 export type ContractSource<
   filter extends "log" | "trace" = "log" | "trace",
   factory extends Factory | undefined = Factory | undefined,
 > = {
   filter: filter extends "log" ? LogFilter<factory> : CallTraceFilter<factory>;
 } & ContractMetadata;
+export type AccountSource<
+  filter extends "log" | "transaction" | "transfer" =
+    | "log"
+    | "transaction"
+    | "transfer",
+  factory extends Factory | undefined = Factory | undefined,
+  fromFactory extends Factory | undefined = Factory | undefined,
+  toFactory extends Factory | undefined = Factory | undefined,
+> = {
+  filter: filter extends "log"
+    ? LogFilter<factory>
+    : filter extends "transaction"
+      ? TransactionFilter<fromFactory, toFactory>
+      : TransferFilter<fromFactory, toFactory>;
+} & AccountMetadata;
 export type BlockSource = { filter: BlockFilter } & BlockMetadata;
 
-export type Filter = LogFilter | BlockFilter | CallTraceFilter;
+export type Filter =
+  | LogFilter
+  | BlockFilter
+  | CallTraceFilter
+  | TransactionFilter
+  | TransferFilter;
 export type Factory = LogFactory;
 
 export type ContractMetadata = {
@@ -19,6 +39,13 @@ export type ContractMetadata = {
   abi: Abi;
   abiEvents: AbiEvents;
   abiFunctions: AbiFunctions;
+  name: string;
+  networkName: string;
+};
+export type AccountMetadata = {
+  type: "account";
+  abi: Abi;
+  abiEvents: AbiEvents;
   name: string;
   networkName: string;
 };
@@ -60,6 +87,40 @@ export type CallTraceFilter<
   includeTransactionReceipts: boolean;
   fromBlock: number;
   toBlock: number | undefined;
+};
+
+export type TransferFilter<
+  fromFactory extends Factory | undefined = Factory | undefined,
+  toFactory extends Factory | undefined = Factory | undefined,
+> = {
+  type: "transfer";
+  chainId: number;
+  fromAddress: fromFactory extends Factory
+    ? fromFactory
+    : Address | Address[] | undefined;
+  toAddress: toFactory extends Factory
+    ? fromFactory
+    : Address | Address[] | undefined;
+  fromBlock: number;
+  toBlock: number | undefined;
+  includeTransactionReceipts: boolean;
+};
+
+export type TransactionFilter<
+  fromFactory extends Factory | undefined = Factory | undefined,
+  toFactory extends Factory | undefined = Factory | undefined,
+> = {
+  type: "transaction";
+  chainId: number;
+  fromAddress: fromFactory extends Factory
+    ? fromFactory
+    : Address | Address[] | undefined;
+  toAddress: toFactory extends Factory
+    ? fromFactory
+    : Address | Address[] | undefined;
+  fromBlock: number;
+  toBlock: number | undefined;
+  includeTransactionReceipts: boolean;
 };
 
 export type LogFactory = {

--- a/packages/core/src/utils/checkpoint.ts
+++ b/packages/core/src/utils/checkpoint.ts
@@ -33,6 +33,8 @@ export const EVENT_TYPES = {
   blocks: 5,
   logs: 5,
   callTraces: 7,
+  transactions: 7,
+  transfers: 7,
 } as const;
 
 export const encodeCheckpoint = (checkpoint: Checkpoint) => {

--- a/packages/core/src/utils/rpc.ts
+++ b/packages/core/src/utils/rpc.ts
@@ -34,7 +34,7 @@ export const _eth_getBlockByNumber = (
       params: [
         typeof blockNumber === "number"
           ? numberToHex(blockNumber)
-          : blockNumber ?? blockTag,
+          : (blockNumber ?? blockTag),
         true,
       ],
     })


### PR DESCRIPTION
I have currently added an accounts api for specifying transaction and native transfer filters alongside event logs. This included changes in the sync engine/ db and build parts of the project. I have tested the API on simple cases for transaction filters, but there are still a lot of things to test and validate. That is why I am adding this pull request to see if I am on the right track, and get feedback on the changes I have currently made. This relates to #1157 issue. @0xOlias @kyscott18 