### PR TITLE
feat: add indexingEnv to distinguish between historical and realtime events in indexing handlers

### DIFF
--- a/.changeset/metal-hairs-grin.md
+++ b/.changeset/metal-hairs-grin.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": minor
+---
+
+Added indexingEnv feature to distinguish between historical and realtime events

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -103,7 +103,7 @@ export async function run({
       switch (event.type) {
         case "block": {
           const result = await handleEvents(
-            decodeEvents(common, sources, event.events),
+            decodeEvents(common, sources, event.events, "realtime"),
             event.checkpoint,
           );
 
@@ -180,7 +180,7 @@ export async function run({
       end = checkpoint;
 
       const result = await handleEvents(
-        decodeEvents(common, sources, events),
+        decodeEvents(common, sources, events, "historical"),
         checkpoint,
       );
       await metadataStore.setStatus(sync.getStatus());

--- a/packages/core/src/indexing/service.test.ts
+++ b/packages/core/src/indexing/service.test.ts
@@ -213,7 +213,7 @@ test("processEvent() log events", async (context) => {
   });
 
   const rawEvents = await getEventsLog(sources);
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const result = await processEvents(indexingService, {
     events,
   });
@@ -301,7 +301,7 @@ test("processEvents() block events", async (context) => {
   });
 
   const rawEvents = await getEventsBlock(sources);
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const result = await processEvents(indexingService, {
     events,
   });
@@ -376,7 +376,7 @@ test("processEvents() call trace events", async (context) => {
   });
 
   const rawEvents = await getEventsTrace(sources);
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const result = await processEvents(indexingService, {
     events,
   });
@@ -459,7 +459,7 @@ test("processEvents killed", async (context) => {
   kill(indexingService);
 
   const rawEvents = await getEventsLog(sources);
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const result = await processEvents(indexingService, {
     events,
   });
@@ -508,7 +508,7 @@ test("processEvents eventCount", async (context) => {
   });
 
   const rawEvents = await getEventsLog(sources);
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const result = await processEvents(indexingService, {
     events,
   });
@@ -779,7 +779,7 @@ test("processEvents() context.client", async (context) => {
     ...(await getEventsBlock(sources)),
     ...(await getEventsTrace(sources)),
   ];
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const result = await processEvents(indexingService, {
     events,
   });
@@ -848,7 +848,7 @@ test("processEvents() context.db", async (context) => {
     ...(await getEventsBlock(sources)),
     ...(await getEventsTrace(sources)),
   ];
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const result = await processEvents(indexingService, {
     events,
   });
@@ -903,7 +903,7 @@ test("processEvents() metrics", async (context) => {
     ...(await getEventsBlock(sources)),
     ...(await getEventsTrace(sources)),
   ];
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   await processEvents(indexingService, {
     events,
   });
@@ -958,7 +958,7 @@ test("processEvents() error", async (context) => {
     ...(await getEventsBlock(sources)),
     ...(await getEventsTrace(sources)),
   ];
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const result = await processEvents(indexingService, {
     events,
   });
@@ -1013,7 +1013,7 @@ test("execute() error after killed", async (context) => {
   });
 
   const rawEvents = await getEventsLog(sources);
-  const events = decodeEvents(common, sources, rawEvents);
+  const events = decodeEvents(common, sources, rawEvents, "historical");
   const resultPromise = processEvents(indexingService, { events });
   kill(indexingService);
 

--- a/packages/core/src/indexing/service.ts
+++ b/packages/core/src/indexing/service.ts
@@ -26,6 +26,7 @@ import type {
   BlockEvent,
   CallTraceEvent,
   Event,
+  IndexingEnv,
   LogEvent,
   SetupEvent,
 } from "../sync/events.js";
@@ -73,6 +74,7 @@ export type Service = {
     contextState: {
       encodedCheckpoint: string;
       blockNumber: bigint;
+      indexingEnv: IndexingEnv;
     };
     context: Context;
   };
@@ -103,6 +105,7 @@ export const create = ({
   const contextState: Service["currentEvent"]["contextState"] = {
     encodedCheckpoint: undefined!,
     blockNumber: undefined!,
+    indexingEnv: undefined!,
   };
   const clientByChainId: Service["clientByChainId"] = {};
   const contractsByChainId: Service["contractsByChainId"] = {};
@@ -251,6 +254,7 @@ export const processSetupEvents = async (
             chainId: BigInt(network.chainId),
             blockNumber: BigInt(source.filter.fromBlock),
           }),
+          indexingEnv: "historical",
 
           name: eventName,
 
@@ -443,6 +447,7 @@ const executeSetup = async (
     currentEvent.context.contracts = contractsByChainId[event.chainId]!;
     currentEvent.contextState.encodedCheckpoint = event.checkpoint;
     currentEvent.contextState.blockNumber = event.block;
+    currentEvent.contextState.indexingEnv = event.indexingEnv;
 
     const endClock = startClock();
 
@@ -503,7 +508,7 @@ const executeLog = async (
     currentEvent.context.contracts = contractsByChainId[event.chainId]!;
     currentEvent.contextState.encodedCheckpoint = event.checkpoint;
     currentEvent.contextState.blockNumber = event.event.block.number;
-
+    currentEvent.contextState.indexingEnv = event.indexingEnv;
     const endClock = startClock();
 
     await indexingFunction!({
@@ -567,6 +572,7 @@ const executeBlock = async (
     currentEvent.context.contracts = contractsByChainId[event.chainId]!;
     currentEvent.contextState.encodedCheckpoint = event.checkpoint;
     currentEvent.contextState.blockNumber = event.event.block.number;
+    currentEvent.contextState.indexingEnv = event.indexingEnv;
 
     const endClock = startClock();
 
@@ -637,7 +643,7 @@ const executeCallTrace = async (
     currentEvent.context.contracts = contractsByChainId[event.chainId]!;
     currentEvent.contextState.encodedCheckpoint = event.checkpoint;
     currentEvent.contextState.blockNumber = event.event.block.number;
-
+    currentEvent.contextState.indexingEnv = event.indexingEnv;
     const endClock = startClock();
 
     await indexingFunction!({

--- a/packages/core/src/sync/events.test.ts
+++ b/packages/core/src/sync/events.test.ts
@@ -35,7 +35,7 @@ test("decodeEvents() log", async (context) => {
 
   const rawEvents = await getEventsLog(sources);
 
-  const events = decodeEvents(common, sources, rawEvents) as [
+  const events = decodeEvents(common, sources, rawEvents, "historical") as [
     LogEvent,
     LogEvent,
     LogEvent,
@@ -74,7 +74,7 @@ test("decodeEvents() log error", async (context) => {
 
   // remove data from log, causing an error when decoding
   rawEvents[0]!.log!.data = "0x0";
-  const events = decodeEvents(common, sources, rawEvents) as [
+  const events = decodeEvents(common, sources, rawEvents, "historical") as [
     LogEvent,
     LogEvent,
   ];
@@ -99,7 +99,9 @@ test("decodeEvents() block", async (context) => {
 
   const rawEvents = await getEventsBlock(sources);
 
-  const events = decodeEvents(common, sources, rawEvents) as [BlockEvent];
+  const events = decodeEvents(common, sources, rawEvents, "historical") as [
+    BlockEvent,
+  ];
 
   expect(events).toHaveLength(1);
   expect(events[0].event.block).toMatchObject({
@@ -112,7 +114,9 @@ test("decodeEvents() trace", async (context) => {
 
   const rawEvents = await getEventsTrace(sources);
 
-  const events = decodeEvents(common, sources, rawEvents) as [CallTraceEvent];
+  const events = decodeEvents(common, sources, rawEvents, "historical") as [
+    CallTraceEvent,
+  ];
 
   expect(events).toHaveLength(1);
   expect(events[0].event.args).toBeUndefined();
@@ -127,7 +131,9 @@ test("decodeEvents() trace error", async (context) => {
 
   // change function selector, causing an error when decoding
   rawEvents[0]!.trace!.input = "0x0";
-  const events = decodeEvents(common, sources, rawEvents) as [CallTraceEvent];
+  const events = decodeEvents(common, sources, rawEvents, "historical") as [
+    CallTraceEvent,
+  ];
 
   expect(events).toHaveLength(0);
 });

--- a/packages/core/src/sync/events.ts
+++ b/packages/core/src/sync/events.ts
@@ -56,10 +56,13 @@ export type RawEvent = {
 
 export type Event = LogEvent | BlockEvent | CallTraceEvent;
 
+export type IndexingEnv = "realtime" | "historical";
+
 export type SetupEvent = {
   type: "setup";
   chainId: number;
   checkpoint: string;
+  indexingEnv: IndexingEnv;
 
   /** `${source.name}:setup` */
   name: string;
@@ -71,6 +74,7 @@ export type LogEvent = {
   type: "log";
   chainId: number;
   checkpoint: string;
+  indexingEnv: IndexingEnv;
 
   /** `${source.name}:${safeName}` */
   name: string;
@@ -89,6 +93,7 @@ export type BlockEvent = {
   type: "block";
   chainId: number;
   checkpoint: string;
+  indexingEnv: IndexingEnv;
 
   /** `${source.name}:block` */
   name: string;
@@ -102,7 +107,7 @@ export type CallTraceEvent = {
   type: "callTrace";
   chainId: number;
   checkpoint: string;
-
+  indexingEnv: IndexingEnv;
   /** `${source.name}.${safeName}()` */
   name: string;
 
@@ -288,6 +293,7 @@ export const decodeEvents = (
   common: Common,
   sources: Source[],
   rawEvents: RawEvent[],
+  indexingEnv: IndexingEnv,
 ): Event[] => {
   const events: Event[] = [];
 
@@ -302,7 +308,10 @@ export const decodeEvents = (
           type: "block",
           chainId: event.chainId,
           checkpoint: event.checkpoint,
+          indexingEnv,
+
           name: `${source.name}:block`,
+
           event: {
             block: event.block,
           },
@@ -333,6 +342,7 @@ export const decodeEvents = (
                 type: "log",
                 chainId: event.chainId,
                 checkpoint: event.checkpoint,
+                indexingEnv,
 
                 name: `${source.name}:${safeName}`,
 
@@ -389,6 +399,7 @@ export const decodeEvents = (
                 type: "callTrace",
                 chainId: event.chainId,
                 checkpoint: event.checkpoint,
+                indexingEnv,
 
                 name: `${source.name}.${safeName}`,
 


### PR DESCRIPTION
This PR adds an `indexingEnv` field to the indexing context to allow indexing functions to distinguish between historical and realtime events. This enables developers to implement different logic based on whether an event is being processed during historical backfilling or realtime indexing.

Example usage in an indexing function, with my use case

```ts
ponder.on(
	"ConditionalTokens:ConditionResolution",
	async ({ event, context }) => {
		// Skip processing for historical events since conditions are already
		// backfilled during setup
		if (context.indexingEnv === "historical") {
			return;
		}

		const conditionId = event.args.conditionId;

		// Fetch current market data from Polymarket API
		// Note: While we could derive this from on-chain events, that would require
		// indexing all Polygon events. Since we're only monitoring specific traders
		// in a recent block range, the API call is more cost-effective
		const market = await getMarketByIdFromPolymarketAPI(conditionId);

		if (!market) {
			logger.error("ConditionResolution: market not found in Polymarket API", {
				conditionId,
				event,
			});
			return;
		}

		await context.db.Condition.upsert({
			id: conditionId,
		});

		await Promise.all(
			market.tokens.map((token, index) =>
				context.db.Token.upsert({
					id: BigInt(token.token_id),
					create: {
						conditionId,
						index,
						price: token.price,
					},
					update: {
						price: token.price,
					},
				}),
			),
		);
	},
);
```