### PR TITLE
fix: Correction of Twitter link and typo in documentation

### DIFF
--- a/docs/components/Footer.tsx
+++ b/docs/components/Footer.tsx
@@ -30,7 +30,7 @@ export function Footer() {
 
               <div className="min-h-full w-[1px] bg-neutral-300 dark:bg-neutral-600" />
 
-              <Link href="https://github.com/ponder-sh/ponder" target="_blank">
+              <Link href="https://twitter.com/ponder_sh" target="_blank">
                 <TwitterIcon className="text-neutral-700 dark:text-neutral-200 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors h-5 w-5" />
                 <span className="_sr-only">Twitter</span>
               </Link>

--- a/docs/pages/blog/0.2.0.mdx
+++ b/docs/pages/blog/0.2.0.mdx
@@ -64,7 +64,7 @@ ponder.on("ERC20:Transfer", async ({ event, context }) => {
 
 </div>
 
-In this example, the indexing funtion only writes to the `TransferEvent` table. It doesn't read from any tables.
+In this example, the indexing function only writes to the `TransferEvent` table. It doesn't read from any tables.
 
 <Callout type="info">
   Technically, the indexing engine still uses a finite concurrency factor that's


### PR DESCRIPTION
- Corrected the Twitter link in `Footer.tsx` to point to the official Twitter page instead of GitHub.
- Fixed a typo in the documentation (`funtion` -> `function`) in `blog/0.2.0.mdx`.

https://ponder.sh/
![image](https://github.com/user-attachments/assets/93044126-0a2a-430e-b630-9f63c494e13f)