### PR TITLE
fix: reorg bug

### DIFF
--- a/.changeset/nine-dolls-run.md
+++ b/.changeset/nine-dolls-run.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug in reorg reconciliation logic.

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -103,7 +103,9 @@ export async function run({
           break;
         }
         case "reorg":
+          await database.removeTriggers();
           await database.revert({ checkpoint: event.checkpoint });
+          await database.createTriggers();
 
           break;
 


### PR DESCRIPTION
### Description
Fixes a reorg related bug that was reported in the telegram. Based on these logs:
1. Reorg detected on chain A at timestamp 10
2. Reorg detected on chain B at timestamp 8

The issue is that the reorg reconciliation was adding rows to the reorg tables. When the second reorg was reconciled, the rows resulting from chain A were duplicated, causing a primary key constraint violation.

Removing the triggers and therefore avoiding adding to the reorg table when reconciling a reorg fixes this.

![telegram-cloud-photo-size-4-5888535154094360606-w](https://github.com/user-attachments/assets/0a864f54-fa98-4453-aefd-2d2749d0ba5c)
