### PR TITLE
chore: compact checkpoint

### DIFF
--- a/packages/core/src/utils/checkpoint.test.ts
+++ b/packages/core/src/utils/checkpoint.test.ts
@@ -310,12 +310,3 @@ test("checkpointMin compares properly on blockNumber", () => {
   const max = checkpointMin(checkpointOne, checkpointTwo, checkpointThree);
   expect(max).toMatchObject(checkpointOne);
 });
-
-/*
-checkpoint/base64: (24 characters)
-Zztd5AAAAAAAHoUfAcUBAAw=
-checkpoint/hex: (34 characters)
-673b5de400000000001e851f01c501000c
-checkpoint/stringified: (75 characters)
-173194390800000000000000010000000002000159000000000000045310000000000000012
-*/


### PR DESCRIPTION
use more compact checkpoint by:
- removing chainId
- use binary encoding of number
- export as base64

example checkpoint:
```
{
    blockTimestamp: 1731943908,
    chainId: 1n,
    blockNumber: 2000159n,
    transactionIndex: 453n,
    eventType: 1,
    eventIndex: 12n,
  } 
```

previous encoding: 75 characters
`173194390800000000000000010000000002000159000000000000045310000000000000012`

new encoding (`base64`): 24 characters
`Zztd5AAAAAAAHoUfAcUBAAw=`

alternative encoding (`hex`): 34 characters
`673b5de400000000001e851f01c501000c`
