### PR TITLE
fix: `schema.graphql` codegen

### DIFF
--- a/.changeset/proud-pigs-sniff.md
+++ b/.changeset/proud-pigs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where the `codegen` command did not generate `generated/schema.graphql`.

--- a/packages/core/src/bin/commands/codegen.ts
+++ b/packages/core/src/bin/commands/codegen.ts
@@ -57,7 +57,8 @@ export async function codegen({ cliOptions }: { cliOptions: CliOptions }) {
     properties: { cli_command: "codegen" },
   });
 
-  runCodegen({ common });
+  const graphqlSchema = buildResult.indexingBuild.graphqlSchema;
+  runCodegen({ common, graphqlSchema });
 
   logger.info({ service: "codegen", msg: "Wrote ponder-env.d.ts" });
   logger.info({ service: "codegen", msg: "Wrote schema.graphql" });

--- a/packages/core/src/bin/commands/serve.ts
+++ b/packages/core/src/bin/commands/serve.ts
@@ -89,10 +89,10 @@ export async function serve({ cliOptions }: { cliOptions: CliOptions }) {
   });
 
   const server = await createServer({
+    common,
     app: buildResult.apiBuild.app,
     routes: buildResult.apiBuild.routes,
-    common,
-    schema,
+    graphqlSchema: buildResult.indexingBuild.graphqlSchema,
     database,
     instanceId:
       process.env.PONDER_EXPERIMENTAL_INSTANCE_ID === undefined

--- a/packages/core/src/bin/utils/run.test.ts
+++ b/packages/core/src/bin/utils/run.test.ts
@@ -7,6 +7,7 @@ import type { IndexingBuild } from "@/build/index.js";
 import { buildSchema } from "@/build/schema.js";
 import { createDatabase } from "@/database/index.js";
 import { onchainTable } from "@/drizzle/index.js";
+import { buildGraphQLSchema } from "@/graphql/index.js";
 import { promiseWithResolvers } from "@ponder/common";
 import { beforeEach, expect, test, vi } from "vitest";
 import { run } from "./run.js";
@@ -20,7 +21,8 @@ const account = onchainTable("account", (p) => ({
   balance: p.bigint().notNull(),
 }));
 
-// const graphqlSchema = buildGraphQLSchema({ schema: { account } });
+const schema = { account };
+const graphqlSchema = buildGraphQLSchema(schema);
 
 test("run() setup", async (context) => {
   const indexingFunctions = {
@@ -28,14 +30,15 @@ test("run() setup", async (context) => {
   };
 
   const { statements, namespace } = buildSchema({
-    schema: { account },
+    schema,
     instanceId: "1234",
   });
 
   const build: IndexingBuild = {
     buildId: "buildId",
     instanceId: "1234",
-    schema: { account },
+    schema,
+    graphqlSchema,
     databaseConfig: context.databaseConfig,
     networks: context.networks,
     sources: context.sources,
@@ -46,7 +49,7 @@ test("run() setup", async (context) => {
 
   const database = createDatabase({
     common: context.common,
-    schema: { account },
+    schema,
     databaseConfig: context.databaseConfig,
     instanceId: "1234",
     buildId: "buildId",
@@ -76,14 +79,15 @@ test("run() setup error", async (context) => {
   const onReloadableErrorPromiseResolver = promiseWithResolvers<void>();
 
   const { statements, namespace } = buildSchema({
-    schema: { account },
+    schema,
     instanceId: "1234",
   });
 
   const build: IndexingBuild = {
     buildId: "buildId",
     instanceId: "1234",
-    schema: { account },
+    schema,
+    graphqlSchema,
     databaseConfig: context.databaseConfig,
     networks: context.networks,
     sources: context.sources,
@@ -94,7 +98,7 @@ test("run() setup error", async (context) => {
 
   const database = createDatabase({
     common: context.common,
-    schema: { account },
+    schema,
     databaseConfig: context.databaseConfig,
     instanceId: "1234",
     buildId: "buildId",

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -32,7 +32,14 @@ export async function run({
   onFatalError: (error: Error) => void;
   onReloadableError: (error: Error) => void;
 }) {
-  const { instanceId, networks, sources, schema, indexingFunctions } = build;
+  const {
+    instanceId,
+    networks,
+    sources,
+    schema,
+    indexingFunctions,
+    graphqlSchema,
+  } = build;
 
   let isKilled = false;
 
@@ -52,7 +59,7 @@ export async function run({
   // starting the server so the app can become responsive more quickly.
   await database.migrateSync();
 
-  runCodegen({ common });
+  runCodegen({ common, graphqlSchema });
 
   // Note: can throw
   const sync = await createSync({

--- a/packages/core/src/bin/utils/runServer.ts
+++ b/packages/core/src/bin/utils/runServer.ts
@@ -15,13 +15,13 @@ export async function runServer({
   build: ApiBuild;
   database: Database;
 }) {
-  const { schema, instanceId } = build;
+  const { instanceId, graphqlSchema } = build;
 
   const server = await createServer({
     app: build.app,
     routes: build.routes,
     common,
-    schema,
+    graphqlSchema,
     database,
     instanceId,
   });

--- a/packages/core/src/build/schema.ts
+++ b/packages/core/src/build/schema.ts
@@ -1,6 +1,7 @@
 import { BuildError } from "@/common/errors.js";
 import { type Schema, isPgEnumSym } from "@/drizzle/index.js";
 import { getSql } from "@/drizzle/kit/index.js";
+import { buildGraphQLSchema } from "@/graphql/index.js";
 import { SQL, getTableColumns, is } from "drizzle-orm";
 import {
   PgBigSerial53,
@@ -192,10 +193,12 @@ export const safeBuildSchema = ({
 }: { schema: Schema; instanceId: string }) => {
   try {
     const result = buildSchema({ schema, instanceId });
+    const graphqlSchema = buildGraphQLSchema(schema);
 
     return {
       status: "success",
       ...result,
+      graphqlSchema,
     } as const;
   } catch (_error) {
     const buildError = new BuildError((_error as Error).message);

--- a/packages/core/src/build/service.ts
+++ b/packages/core/src/build/service.ts
@@ -13,6 +13,7 @@ import type { PonderRoutes } from "@/hono/index.js";
 import type { Source } from "@/sync/source.js";
 import { serialize } from "@/utils/serialize.js";
 import { glob } from "glob";
+import type { GraphQLSchema } from "graphql";
 import type { Hono } from "hono";
 import { type ViteDevServer, createServer } from "vite";
 import { ViteNodeRunner } from "vite-node/client";
@@ -57,6 +58,7 @@ type BaseBuild = {
   schema: Schema;
   statements: SqlStatements;
   namespace: string;
+  graphqlSchema: GraphQLSchema;
 };
 
 export type IndexingBuild = BaseBuild & {
@@ -748,6 +750,7 @@ const validateAndBuild = async (
       schema: schema.schema,
       statements: buildSchemaResult.statements,
       namespace: buildSchemaResult.namespace,
+      graphqlSchema: buildSchemaResult.graphqlSchema,
     },
   };
 };

--- a/packages/core/src/common/codegen.ts
+++ b/packages/core/src/common/codegen.ts
@@ -1,6 +1,7 @@
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { Common } from "@/common/common.js";
+import { type GraphQLSchema, printSchema } from "graphql";
 
 export const ponderEnv = `// This file enables type checking and editor autocomplete for this Ponder project.
 // After upgrading, you may find that changes have been made to this file.
@@ -31,7 +32,10 @@ declare module "@/generated" {
 }
 `;
 
-export function runCodegen({ common }: { common: Common }) {
+export function runCodegen({
+  common,
+  graphqlSchema,
+}: { common: Common; graphqlSchema: GraphQLSchema }) {
   writeFileSync(
     path.join(common.options.rootDir, "ponder-env.d.ts"),
     ponderEnv,
@@ -41,5 +45,17 @@ export function runCodegen({ common }: { common: Common }) {
   common.logger.debug({
     service: "codegen",
     msg: "Wrote new file at ponder-env.d.ts",
+  });
+
+  mkdirSync(common.options.generatedDir, { recursive: true });
+  writeFileSync(
+    path.join(common.options.generatedDir, "schema.graphql"),
+    printSchema(graphqlSchema),
+    "utf-8",
+  );
+
+  common.logger.debug({
+    service: "codegen",
+    msg: "Wrote new file at generated/schema.graphql",
   });
 }

--- a/packages/core/src/graphql/middleware.test.ts
+++ b/packages/core/src/graphql/middleware.test.ts
@@ -7,6 +7,7 @@ import { onchainTable } from "@/drizzle/index.js";
 import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
 import { beforeEach, expect, test } from "vitest";
+import { buildGraphQLSchema } from "./index.js";
 import { graphql } from "./middleware.js";
 
 beforeEach(setupCommon);
@@ -25,13 +26,15 @@ test("middleware serves request", async (context) => {
     })),
   };
 
+  const graphqlSchema = buildGraphQLSchema(schema);
+
   const { database, indexingStore, metadataStore, cleanup } =
     await setupDatabaseServices(context, { schema });
 
   const contextMiddleware = createMiddleware(async (c, next) => {
-    c.set("common", context.common);
-    c.set("db", database.drizzle);
     c.set("metadataStore", metadataStore);
+    c.set("graphqlSchema", graphqlSchema);
+    c.set("db", database.drizzle);
     await next();
   });
 
@@ -101,15 +104,17 @@ test("middleware throws error when extra filter is applied", async (context) => 
     })),
   };
 
+  const graphqlSchema = buildGraphQLSchema(schema);
+
   const { database, metadataStore, cleanup } = await setupDatabaseServices(
     context,
     { schema },
   );
 
   const contextMiddleware = createMiddleware(async (c, next) => {
-    c.set("common", context.common);
-    c.set("db", database.drizzle);
     c.set("metadataStore", metadataStore);
+    c.set("graphqlSchema", graphqlSchema);
+    c.set("db", database.drizzle);
     await next();
   });
 
@@ -151,15 +156,17 @@ test("graphQLMiddleware throws error for token limit", async (context) => {
     })),
   };
 
+  const graphqlSchema = buildGraphQLSchema(schema);
+
   const { database, metadataStore, cleanup } = await setupDatabaseServices(
     context,
     { schema },
   );
 
   const contextMiddleware = createMiddleware(async (c, next) => {
-    c.set("common", context.common);
-    c.set("db", database.drizzle);
     c.set("metadataStore", metadataStore);
+    c.set("graphqlSchema", graphqlSchema);
+    c.set("db", database.drizzle);
     await next();
   });
 
@@ -207,15 +214,17 @@ test("graphQLMiddleware throws error for depth limit", async (context) => {
     })),
   };
 
+  const graphqlSchema = buildGraphQLSchema(schema);
+
   const { database, metadataStore, cleanup } = await setupDatabaseServices(
     context,
     { schema },
   );
 
   const contextMiddleware = createMiddleware(async (c, next) => {
-    c.set("common", context.common);
-    c.set("db", database.drizzle);
     c.set("metadataStore", metadataStore);
+    c.set("graphqlSchema", graphqlSchema);
+    c.set("db", database.drizzle);
     await next();
   });
 
@@ -263,15 +272,17 @@ test("graphQLMiddleware throws error for max aliases", async (context) => {
     })),
   };
 
+  const graphqlSchema = buildGraphQLSchema(schema);
+
   const { database, metadataStore, cleanup } = await setupDatabaseServices(
     context,
     { schema },
   );
 
   const contextMiddleware = createMiddleware(async (c, next) => {
-    c.set("common", context.common);
-    c.set("db", database.drizzle);
     c.set("metadataStore", metadataStore);
+    c.set("graphqlSchema", graphqlSchema);
+    c.set("db", database.drizzle);
     await next();
   });
 
@@ -323,15 +334,18 @@ test("graphQLMiddleware throws error for max aliases", async (context) => {
 });
 
 test("graphQLMiddleware interactive", async (context) => {
+  const schema = {};
+  const graphqlSchema = buildGraphQLSchema(schema);
+
   const { database, metadataStore, cleanup } = await setupDatabaseServices(
     context,
-    { schema: {} },
+    { schema },
   );
 
   const contextMiddleware = createMiddleware(async (c, next) => {
-    c.set("common", context.common);
-    c.set("db", database.drizzle);
     c.set("metadataStore", metadataStore);
+    c.set("graphqlSchema", graphqlSchema);
+    c.set("db", database.drizzle);
     await next();
   });
 

--- a/packages/core/src/graphql/middleware.ts
+++ b/packages/core/src/graphql/middleware.ts
@@ -1,13 +1,10 @@
-import { mkdirSync, writeFileSync } from "node:fs";
-import path from "node:path";
 import { graphiQLHtml } from "@/ui/graphiql.html.js";
 import { maxAliasesPlugin } from "@escape.tech/graphql-armor-max-aliases";
 import { maxDepthPlugin } from "@escape.tech/graphql-armor-max-depth";
 import { maxTokensPlugin } from "@escape.tech/graphql-armor-max-tokens";
-import { printSchema } from "graphql";
 import { type YogaServerInstance, createYoga } from "graphql-yoga";
 import { createMiddleware } from "hono/factory";
-import { buildDataLoaderCache, buildGraphQLSchema } from "./index.js";
+import { buildDataLoaderCache } from "./index.js";
 
 /**
  * Middleware for GraphQL with an interactive web view.
@@ -47,29 +44,14 @@ export const graphql = (
 
     if (yoga === undefined) {
       const metadataStore = c.get("metadataStore");
-      const common = c.get("common");
+      const graphqlSchema = c.get("graphqlSchema");
       const drizzle = c.get("db");
-
-      const graphqlSchema = buildGraphQLSchema(drizzle);
-
-      // Write schema.graphql once on startup
-      mkdirSync(common.options.generatedDir, { recursive: true });
-      writeFileSync(
-        path.join(common.options.generatedDir, "schema.graphql"),
-        printSchema(graphqlSchema),
-        "utf-8",
-      );
-
-      common.logger.debug({
-        service: "codegen",
-        msg: "Wrote new file at generated/schema.graphql",
-      });
 
       yoga = createYoga({
         schema: graphqlSchema,
         context: () => {
           const getDataLoader = buildDataLoaderCache({ drizzle });
-          return { metadataStore, getDataLoader };
+          return { drizzle, metadataStore, getDataLoader };
         },
         graphqlEndpoint: c.req.path,
         maskedErrors: process.env.NODE_ENV === "production",

--- a/packages/core/src/server/index.test.ts
+++ b/packages/core/src/server/index.test.ts
@@ -3,6 +3,7 @@ import {
   setupDatabaseServices,
   setupIsolatedDatabase,
 } from "@/_test/setup.js";
+import { buildGraphQLSchema } from "@/graphql/index.js";
 import type { Context } from "@/hono/context.js";
 import { getMetadataStore } from "@/indexing-store/metadata.js";
 import { Hono } from "hono";
@@ -19,7 +20,7 @@ test("port", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -27,7 +28,7 @@ test("port", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -45,7 +46,7 @@ test("listens on ipv4", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -63,7 +64,7 @@ test("listens on ipv6", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -81,7 +82,7 @@ test("not ready", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -100,7 +101,7 @@ test("ready", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -124,7 +125,7 @@ test("health", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -143,7 +144,7 @@ test("healthy PUT", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -164,7 +165,7 @@ test("metrics", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -183,7 +184,7 @@ test("metrics error", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -205,7 +206,7 @@ test("metrics PUT", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -226,7 +227,7 @@ test("metrics unmatched route", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -251,7 +252,7 @@ test("missing route", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -272,7 +273,7 @@ test("custom api route", async (context) => {
     routes: [
       { method: "GET", pathOrHandlers: ["/hi", (c: Context) => c.text("hi")] },
     ],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -294,7 +295,7 @@ test("custom hono route", async (context) => {
     common: context.common,
     app,
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 
@@ -316,7 +317,7 @@ test.skip("kill", async (context) => {
     common: context.common,
     app: new Hono(),
     routes: [],
-    schema: {},
+    graphqlSchema: buildGraphQLSchema({}),
     database,
   });
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,7 +1,6 @@
 import http from "node:http";
 import type { Common } from "@/common/common.js";
 import type { Database } from "@/database/index.js";
-import type { Schema } from "@/drizzle/index.js";
 import { graphql } from "@/graphql/middleware.js";
 import { type PonderRoutes, applyHonoRoutes } from "@/hono/index.js";
 import {
@@ -10,6 +9,7 @@ import {
 } from "@/indexing-store/metadata.js";
 import { startClock } from "@/utils/timer.js";
 import { serve } from "@hono/node-server";
+import type { GraphQLSchema } from "graphql";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createMiddleware } from "hono/factory";
@@ -26,14 +26,14 @@ export async function createServer({
   app: userApp,
   routes: userRoutes,
   common,
-  schema,
+  graphqlSchema,
   database,
   instanceId,
 }: {
   app: Hono;
   routes: PonderRoutes;
   common: Common;
-  schema: Schema;
+  graphqlSchema: GraphQLSchema;
   database: Database;
   instanceId?: string;
 }): Promise<Server> {
@@ -93,10 +93,9 @@ export async function createServer({
 
   // context required for graphql middleware and hono middleware
   const contextMiddleware = createMiddleware(async (c, next) => {
-    c.set("common", common);
     c.set("db", database.drizzle);
     c.set("metadataStore", metadataStore);
-    c.set("schema", schema);
+    c.set("graphqlSchema", graphqlSchema);
     await next();
   });
 


### PR DESCRIPTION
Before, `buildGraphqlSchema` needed the built `drizzle` object to access the relational config, which was created by `createDatabase`. Now, it only needs the raw `schema` object and builds the relational config manually using helper functions from Drizzle. This decouples the GraphQL schema build from the database build. With that done, it was easy to move the GraphQL schema build from the server/middleware back to the build step.