### PR TITLE
fix: graphql snake case bugs

### DIFF
--- a/.changeset/tasty-otters-flow.md
+++ b/.changeset/tasty-otters-flow.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed several GraphQL bugs introduced in `0.7.0` that affected tables and columns using snake_case.


### PR DESCRIPTION
See changeset. Note that there are still some cases of ambiguous parsing that we should consider validating against, e.g. if the column names themselves end with any of the where suffixes like `_not`, `_not_in`.