### PR TITLE
add `include` property to filters

### DIFF
--- a/packages/core/src/build/configAndIndexingFunctions.ts
+++ b/packages/core/src/build/configAndIndexingFunctions.ts
@@ -10,11 +10,17 @@ import {
   isRpcUrlPublic,
 } from "@/config/networks.js";
 import { buildAbiEvents, buildAbiFunctions, buildTopics } from "@/sync/abi.js";
-import type {
-  AccountSource,
-  BlockSource,
-  ContractSource,
-  Source,
+import {
+  type AccountSource,
+  type BlockSource,
+  type ContractSource,
+  type Source,
+  defaultBlockFilterInclude,
+  defaultLogFilterInclude,
+  defaultTraceFilterInclude,
+  defaultTransactionFilterInclude,
+  defaultTransactionReceiptInclude,
+  defaultTransferFilterInclude,
 } from "@/sync/source.js";
 import { chains } from "@/utils/chains.js";
 import { toLowerCase } from "@/utils/lowercase.js";
@@ -530,9 +536,13 @@ export async function buildConfigAndIndexingFunctions({
             topic1,
             topic2,
             topic3,
-            // includeTransactionReceipts: source.includeTransactionReceipts,
             fromBlock,
             toBlock,
+            include: defaultLogFilterInclude!.concat(
+              source.includeTransactionReceipts
+                ? defaultTransactionReceiptInclude
+                : [],
+            ),
           },
         } satisfies ContractSource;
 
@@ -549,10 +559,13 @@ export async function buildConfigAndIndexingFunctions({
                 callType: "CALL",
                 functionSelector: registeredFunctionSelectors,
                 includeReverted: false,
-                // includeTransactionReceipts:
-                //   rawContract.includeTransactionReceipts,
                 fromBlock,
                 toBlock,
+                include: defaultTraceFilterInclude!.concat(
+                  source.includeTransactionReceipts
+                    ? defaultTransactionReceiptInclude
+                    : [],
+                ),
               },
             } satisfies ContractSource,
           ];
@@ -593,9 +606,13 @@ export async function buildConfigAndIndexingFunctions({
           topic1,
           topic2,
           topic3,
-          // includeTransactionReceipts: rawContract.includeTransactionReceipts,
           fromBlock,
           toBlock,
+          include: defaultLogFilterInclude!.concat(
+            source.includeTransactionReceipts
+              ? defaultTransactionReceiptInclude
+              : [],
+          ),
         },
       } satisfies ContractSource;
 
@@ -616,10 +633,13 @@ export async function buildConfigAndIndexingFunctions({
               callType: "CALL",
               functionSelector: registeredFunctionSelectors,
               includeReverted: false,
-              // includeTransactionReceipts:
-              //   rawContract.includeTransactionReceipts,
               fromBlock,
               toBlock,
+              include: defaultTraceFilterInclude!.concat(
+                source.includeTransactionReceipts
+                  ? defaultTransactionReceiptInclude
+                  : [],
+              ),
             },
           } satisfies ContractSource,
         ];
@@ -685,6 +705,7 @@ export async function buildConfigAndIndexingFunctions({
               includeReverted: false,
               fromBlock,
               toBlock,
+              include: defaultTransactionFilterInclude,
             },
           } satisfies AccountSource,
           {
@@ -699,6 +720,7 @@ export async function buildConfigAndIndexingFunctions({
               includeReverted: false,
               fromBlock,
               toBlock,
+              include: defaultTransactionFilterInclude,
             },
           } satisfies AccountSource,
           {
@@ -713,6 +735,11 @@ export async function buildConfigAndIndexingFunctions({
               includeReverted: false,
               fromBlock,
               toBlock,
+              include: defaultTransferFilterInclude!.concat(
+                source.includeTransactionReceipts
+                  ? defaultTransactionReceiptInclude
+                  : [],
+              ),
             },
           } satisfies AccountSource,
           {
@@ -727,6 +754,11 @@ export async function buildConfigAndIndexingFunctions({
               includeReverted: false,
               fromBlock,
               toBlock,
+              include: defaultTransferFilterInclude!.concat(
+                source.includeTransactionReceipts
+                  ? defaultTransactionReceiptInclude
+                  : [],
+              ),
             },
           } satisfies AccountSource,
         ];
@@ -768,6 +800,7 @@ export async function buildConfigAndIndexingFunctions({
             includeReverted: false,
             fromBlock,
             toBlock,
+            include: defaultTransactionFilterInclude,
           },
         } satisfies AccountSource,
         {
@@ -782,6 +815,7 @@ export async function buildConfigAndIndexingFunctions({
             includeReverted: false,
             fromBlock,
             toBlock,
+            include: defaultTransactionFilterInclude,
           },
         } satisfies AccountSource,
         {
@@ -796,6 +830,11 @@ export async function buildConfigAndIndexingFunctions({
             includeReverted: false,
             fromBlock,
             toBlock,
+            include: defaultTransferFilterInclude!.concat(
+              source.includeTransactionReceipts
+                ? defaultTransactionReceiptInclude
+                : [],
+            ),
           },
         } satisfies AccountSource,
         {
@@ -810,6 +849,11 @@ export async function buildConfigAndIndexingFunctions({
             includeReverted: false,
             fromBlock,
             toBlock,
+            include: defaultTransferFilterInclude!.concat(
+              source.includeTransactionReceipts
+                ? defaultTransactionReceiptInclude
+                : [],
+            ),
           },
         } satisfies AccountSource,
       ];
@@ -868,6 +912,7 @@ export async function buildConfigAndIndexingFunctions({
           offset: (fromBlock ?? 0) % interval,
           fromBlock,
           toBlock,
+          include: defaultBlockFilterInclude,
         },
       } satisfies BlockSource;
     })

--- a/packages/core/src/sync-historical/index.test.ts
+++ b/packages/core/src/sync-historical/index.test.ts
@@ -123,7 +123,7 @@ test("sync() with log filter", async (context) => {
   await cleanup();
 });
 
-test.skip("sync() with log filter and transaction receipts", async (context) => {
+test("sync() with log filter and transaction receipts", async (context) => {
   const { cleanup, syncStore, database } = await setupDatabaseServices(context);
 
   const network = getNetwork();
@@ -162,14 +162,14 @@ test.skip("sync() with log filter and transaction receipts", async (context) => 
     onFatalError: () => {},
   });
 
-  await historicalSync.sync([1, 3]);
+  await historicalSync.sync([1, 2]);
 
   const transactionReceipts = await database.qb.sync
     .selectFrom("transactionReceipts")
     .selectAll()
     .execute();
 
-  expect(transactionReceipts).toHaveLength(2);
+  expect(transactionReceipts).toHaveLength(1);
 
   const intervals = await database.qb.sync
     .selectFrom("intervals")

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -12,6 +12,7 @@ import {
   type TransferFilter,
   getChildAddress,
   isAddressFactory,
+  shouldGetTransactionReceipt,
 } from "@/sync/source.js";
 import type {
   LightBlock,
@@ -674,10 +675,13 @@ export const createRealtimeSync = (
 
       for (const filter of logFilters) {
         if (isLogFilterMatched({ filter, block, log })) {
-          // TODO: includeTransactionReceipt
-          // return early if includeTransactionReceipt, otherwise continue checking filters
           requiredTransactions.add(log.transactionHash);
           isMatched = true;
+          if (shouldGetTransactionReceipt(filter)) {
+            requiredTransactionReceipts.add(log.transactionHash);
+            // skip to next log
+            break;
+          }
         }
       }
 
@@ -695,10 +699,13 @@ export const createRealtimeSync = (
             trace: trace.trace,
           })
         ) {
-          // TODO: includeTransactionReceipt
-          // return early if includeTransactionReceipt, otherwise continue checking filters
           requiredTransactions.add(trace.transactionHash);
           isMatched = true;
+          if (shouldGetTransactionReceipt(filter)) {
+            requiredTransactionReceipts.add(trace.transactionHash);
+            // skip to next trace
+            break;
+          }
         }
       }
 
@@ -710,10 +717,13 @@ export const createRealtimeSync = (
             trace: trace.trace,
           })
         ) {
-          // TODO: includeTransactionReceipt
-          // return early if includeTransactionReceipt, otherwise continue checking filters
           requiredTransactions.add(trace.transactionHash);
           isMatched = true;
+          if (shouldGetTransactionReceipt(filter)) {
+            requiredTransactionReceipts.add(trace.transactionHash);
+            // skip to next trace
+            break;
+          }
         }
       }
 

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -82,6 +82,7 @@ test("getIntervals() empty", async (context) => {
     offset: 0,
     fromBlock: undefined,
     toBlock: undefined,
+    include: [],
   } satisfies BlockFilter;
 
   const intervals = await syncStore.getIntervals({
@@ -103,6 +104,7 @@ test("getIntervals() returns intervals", async (context) => {
     offset: 0,
     fromBlock: undefined,
     toBlock: undefined,
+    include: [],
   } satisfies BlockFilter;
 
   await syncStore.insertIntervals({
@@ -134,6 +136,7 @@ test("getIntervals() merges intervals", async (context) => {
     offset: 0,
     fromBlock: undefined,
     toBlock: undefined,
+    include: [],
   } satisfies BlockFilter;
 
   await syncStore.insertIntervals({
@@ -176,6 +179,7 @@ test("getIntervals() adjacent intervals", async (context) => {
     address: [zeroAddress],
     fromBlock: undefined,
     toBlock: undefined,
+    include: [],
   } satisfies LogFilter;
 
   await syncStore.insertIntervals({
@@ -1089,7 +1093,7 @@ test("getEvents() returns events", async (context) => {
     topic3: null,
     fromBlock: undefined,
     toBlock: undefined,
-    // includeTransactionReceipts: false,
+    include: [],
   } satisfies LogFilter;
 
   const { events } = await syncStore.getEvents({

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -12,6 +12,7 @@ import {
   type TransactionFilter,
   type TransferFilter,
   isAddressFactory,
+  shouldGetTransactionReceipt,
 } from "@/sync/source.js";
 import type { Log, Trace } from "@/types/eth.js";
 import type {
@@ -30,8 +31,10 @@ import {
   type Address,
   type Hash,
   type Hex,
+  type TransactionReceipt,
   checksumAddress,
   hexToBigInt,
+  hexToNumber,
 } from "viem";
 import {
   type PonderSyncSchema,
@@ -845,6 +848,7 @@ export const createSyncStore = ({
       const hasLog = row.log_id !== null;
       const hasTransaction = row.tx_hash !== null;
       const hasTrace = row.trace_id !== null;
+      const hasTransactionReceipt = shouldGetTransactionReceipt(filter);
 
       return {
         chainId: filter.chainId,
@@ -960,57 +964,56 @@ export const createSyncStore = ({
               value: BigInt(row.trace_value),
             }
           : undefined,
-        transactionReceipt: undefined,
-        // hasTransactionReceipt
-        //   ? {
-        //       blockHash: row.txr_blockHash,
-        //       blockNumber: BigInt(row.txr_blockNumber),
-        //       contractAddress: row.txr_contractAddress
-        //         ? checksumAddress(row.txr_contractAddress)
-        //         : null,
-        //       cumulativeGasUsed: BigInt(row.txr_cumulativeGasUsed),
-        //       effectiveGasPrice: BigInt(row.txr_effectiveGasPrice),
-        //       from: checksumAddress(row.txr_from),
-        //       gasUsed: BigInt(row.txr_gasUsed),
-        //       logs: JSON.parse(row.txr_logs).map((log: SyncLog) => ({
-        //         id: `${log.blockHash}-${log.logIndex}`,
-        //         address: checksumAddress(log.address),
-        //         blockHash: log.blockHash,
-        //         blockNumber: hexToBigInt(log.blockNumber),
-        //         data: log.data,
-        //         logIndex: hexToNumber(log.logIndex),
-        //         removed: false,
-        //         topics: [
-        //           log.topics[0] ?? null,
-        //           log.topics[1] ?? null,
-        //           log.topics[2] ?? null,
-        //           log.topics[3] ?? null,
-        //         ].filter((t): t is Hex => t !== null) as [Hex, ...Hex[]] | [],
-        //         transactionHash: log.transactionHash,
-        //         transactionIndex: hexToNumber(log.transactionIndex),
-        //       })),
-        //       logsBloom: row.txr_logsBloom,
-        //       status:
-        //         row.txr_status === "0x1"
-        //           ? "success"
-        //           : row.txr_status === "0x0"
-        //             ? "reverted"
-        //             : (row.txr_status as TransactionReceipt["status"]),
-        //       to: row.txr_to ? checksumAddress(row.txr_to) : null,
-        //       transactionHash: row.txr_transactionHash,
-        //       transactionIndex: Number(row.txr_transactionIndex),
-        //       type:
-        //         row.txr_type === "0x0"
-        //           ? "legacy"
-        //           : row.txr_type === "0x1"
-        //             ? "eip2930"
-        //             : row.tx_type === "0x2"
-        //               ? "eip1559"
-        //               : row.tx_type === "0x7e"
-        //                 ? "deposit"
-        //                 : row.tx_type,
-        //     }
-        //   : undefined,
+        transactionReceipt: hasTransactionReceipt
+          ? {
+              blockHash: row.txr_blockHash,
+              blockNumber: BigInt(row.txr_blockNumber),
+              contractAddress: row.txr_contractAddress
+                ? checksumAddress(row.txr_contractAddress)
+                : null,
+              cumulativeGasUsed: BigInt(row.txr_cumulativeGasUsed),
+              effectiveGasPrice: BigInt(row.txr_effectiveGasPrice),
+              from: checksumAddress(row.txr_from),
+              gasUsed: BigInt(row.txr_gasUsed),
+              logs: JSON.parse(row.txr_logs).map((log: SyncLog) => ({
+                id: `${log.blockHash}-${log.logIndex}`,
+                address: checksumAddress(log.address),
+                blockHash: log.blockHash,
+                blockNumber: hexToBigInt(log.blockNumber),
+                data: log.data,
+                logIndex: hexToNumber(log.logIndex),
+                removed: false,
+                topics: [
+                  log.topics[0] ?? null,
+                  log.topics[1] ?? null,
+                  log.topics[2] ?? null,
+                  log.topics[3] ?? null,
+                ].filter((t): t is Hex => t !== null) as [Hex, ...Hex[]] | [],
+                transactionHash: log.transactionHash,
+                transactionIndex: hexToNumber(log.transactionIndex),
+              })),
+              logsBloom: row.txr_logsBloom,
+              status:
+                row.txr_status === "0x1"
+                  ? "success"
+                  : row.txr_status === "0x0"
+                    ? "reverted"
+                    : (row.txr_status as TransactionReceipt["status"]),
+              to: row.txr_to ? checksumAddress(row.txr_to) : null,
+              transactionHash: row.txr_transactionHash,
+              transactionIndex: Number(row.txr_transactionIndex),
+              type:
+                row.txr_type === "0x0"
+                  ? "legacy"
+                  : row.txr_type === "0x1"
+                    ? "eip2930"
+                    : row.tx_type === "0x2"
+                      ? "eip1559"
+                      : row.tx_type === "0x7e"
+                        ? "deposit"
+                        : row.tx_type,
+            }
+          : undefined,
       } satisfies RawEvent;
     });
 

--- a/packages/core/src/sync/events.ts
+++ b/packages/core/src/sync/events.ts
@@ -52,6 +52,7 @@ import {
   type TransactionFilter,
   type TransferFilter,
   isAddressFactory,
+  shouldGetTransactionReceipt,
 } from "./source.js";
 
 export type RawEvent = {
@@ -266,7 +267,11 @@ export const buildEvents = ({
                   transaction: convertTransaction(
                     transactionCache.get(log.transactionHash)!,
                   ),
-                  transactionReceipt: undefined,
+                  transactionReceipt: shouldGetTransactionReceipt(filter)
+                    ? convertTransactionReceipt(
+                        transactionReceiptCache.get(log.transactionHash)!,
+                      )
+                    : undefined,
                   trace: undefined,
                 });
               }
@@ -293,6 +298,9 @@ export const buildEvents = ({
                 const transaction = transactionCache.get(
                   trace.transactionHash,
                 )!;
+                const transactionReceipt = transactionReceiptCache.get(
+                  trace.transactionHash,
+                )!;
                 events.push({
                   chainId: filter.chainId,
                   sourceIndex: i,
@@ -308,7 +316,9 @@ export const buildEvents = ({
                   trace: convertTrace(trace),
                   block: convertBlock(block),
                   transaction: convertTransaction(transaction),
-                  transactionReceipt: undefined,
+                  transactionReceipt: shouldGetTransactionReceipt(filter)
+                    ? convertTransactionReceipt(transactionReceipt)
+                    : undefined,
                 });
               }
             }
@@ -352,7 +362,9 @@ export const buildEvents = ({
                   trace: undefined,
                   block: convertBlock(block),
                   transaction: convertTransaction(transaction),
-                  transactionReceipt: undefined,
+                  transactionReceipt: convertTransactionReceipt(
+                    transactionReceiptCache.get(transaction.hash)!,
+                  ),
                 });
               }
             }
@@ -378,6 +390,9 @@ export const buildEvents = ({
                 const transaction = transactionCache.get(
                   trace.transactionHash,
                 )!;
+                const transactionReceipt = transactionReceiptCache.get(
+                  trace.transactionHash,
+                )!;
                 events.push({
                   chainId: filter.chainId,
                   sourceIndex: i,
@@ -393,7 +408,9 @@ export const buildEvents = ({
                   trace: convertTrace(trace),
                   block: convertBlock(block),
                   transaction: convertTransaction(transaction),
-                  transactionReceipt: undefined,
+                  transactionReceipt: shouldGetTransactionReceipt(filter)
+                    ? convertTransactionReceipt(transactionReceipt)
+                    : undefined,
                 });
               }
             }
@@ -796,7 +813,6 @@ const convertTransaction = (transaction: SyncTransaction): Transaction => ({
             }),
 });
 
-// @ts-ignore
 const convertTransactionReceipt = (
   transactionReceipt: SyncTransactionReceipt,
 ): TransactionReceipt => ({

--- a/packages/core/src/sync/fragments.test.ts
+++ b/packages/core/src/sync/fragments.test.ts
@@ -16,7 +16,7 @@ test("getLogFilterFragmentIds generates 1 log filter fragment for null filter", 
     topic1: null,
     topic2: null,
     topic3: null,
-    // includeTransactionReceipts: false,
+    include: [],
   });
 
   expect(logFilterFragments[0]!.id).toBe("log_1_null_null_null_null_null_0");
@@ -31,7 +31,7 @@ test("getLogFilterFragmentIds generates 1 log filter fragment for simple filter"
     topic1: null,
     topic2: null,
     topic3: null,
-    // includeTransactionReceipts: false,
+    include: [],
   });
 
   expect(logFilterFragments[0]!.id).toBe("log_1_0xa_null_null_null_null_0");
@@ -46,7 +46,7 @@ test("getLogFilterFragmentIds generates 4 log filter fragment for 2x2 filter", (
     topic1: null,
     topic2: "0xe",
     topic3: null,
-    // includeTransactionReceipts: false,
+    include: [],
   });
 
   expect(logFilterFragments[0]!.id).toBe("log_115511_0xa_0xc_null_0xe_null_0");
@@ -64,13 +64,13 @@ test("getLogFilterFragmentIds generates 12 log filter fragment for 2x2x3 filter"
     topic1: null,
     topic2: ["0xe", "0xf", "0x1"],
     topic3: null,
-    // includeTransactionReceipts: false,
+    include: [],
   });
 
   expect(logFilterFragments.length).toBe(12);
 });
 
-test.skip("getLogFilterFragmentIds includeTransactionReceipts", () => {
+test("getLogFilterFragmentIds includeTransactionReceipts", () => {
   const logFilterFragments = getLogFilterFragmentIds({
     type: "log",
     chainId: 1,
@@ -79,7 +79,7 @@ test.skip("getLogFilterFragmentIds includeTransactionReceipts", () => {
     topic1: null,
     topic2: null,
     topic3: null,
-    // includeTransactionReceipts: true,
+    include: ["transactionReceipt.transactionHash"],
   });
 
   expect(logFilterFragments[0]!.id).toBe("log_1_null_null_null_null_null_1");
@@ -101,7 +101,7 @@ test("getLogFilterFragmentIds builds id containing factory topic", () => {
     topic2: null,
     topic3: null,
     address: factory,
-    // includeTransactionReceipts: false,
+    include: [],
   });
 
   expect(fragments).toHaveLength(1);
@@ -127,7 +127,7 @@ test("getLogFilterFragmentIds builds id containing factory offset", () => {
     topic2: null,
     topic3: null,
     address: factory,
-    // includeTransactionReceipts: false,
+    include: [],
   });
 
   expect(fragments).toHaveLength(1);
@@ -153,7 +153,7 @@ test("getLogFilterFragmentIds builds id with multiple factories", () => {
     topic2: null,
     topic3: null,
     address: factory,
-    // includeTransactionReceipts: false,
+    include: [],
   });
 
   expect(fragments).toHaveLength(2);

--- a/packages/core/src/sync/fragments.ts
+++ b/packages/core/src/sync/fragments.ts
@@ -9,6 +9,7 @@ import {
   type TransactionFilter,
   type TransferFilter,
   isAddressFactory,
+  shouldGetTransactionReceipt,
 } from "./source.js";
 
 type FragmentAddress =
@@ -18,34 +19,31 @@ type FragmentAddress =
 type FragmentTopic = Hex | null;
 
 export type FragmentId =
-  /** log_{chainId}_{address}_{topic0}_{topic1}_{topic2}_{topic3}_{includeReceipts} */
-  | `log_${number}_${FragmentAddress}_${FragmentTopic}_${FragmentTopic}_${FragmentTopic}_${FragmentTopic}_${0 | 1}`
-  /** transaction_{chainId}_{fromAddress}_{toAddress}_{includeReceipts} */
-  | `transaction_${number}_${FragmentAddress}_${FragmentAddress}_${0 | 1}`
-  /** transfer_{chainId}_{fromAddress}_{toAddress} */
-  | `transfer_${number}_${FragmentAddress}_${FragmentAddress}`
+  /** block_{chainId}_{interval}_{offset} */
+  | `block_${number}_${number}_${number}`
+  /** transaction_{chainId}_{fromAddress}_{toAddress} */
+  | `transaction_${number}_${FragmentAddress}_${FragmentAddress}`
   /** trace_{chainId}_{fromAddress}_{toAddress}_{callType}_{functionSelector}_{includeReceipts} */
   | `trace_${number}_${FragmentAddress}_${FragmentAddress}_${Trace["result"]["type"] | null}_${Hex | null}_${0 | 1}`
-  /** block_{chainId}_{interval}_{offset} */
-  | `block_${number}_${number}_${number}`;
+  /** log_{chainId}_{address}_{topic0}_{topic1}_{topic2}_{topic3}_{includeReceipts} */
+  | `log_${number}_${FragmentAddress}_${FragmentTopic}_${FragmentTopic}_${FragmentTopic}_${FragmentTopic}_${0 | 1}`
+  /** transfer_{chainId}_{fromAddress}_{toAddress}_{includeReceipts} */
+  | `transfer_${number}_${FragmentAddress}_${FragmentAddress}_${0 | 1}`;
 
 export const getFragmentIds = (
   filter: Omit<Filter, "startBlock" | "endBlock">,
 ): FragmentReturnType => {
   switch (filter.type) {
-    case "log":
-      return getLogFilterFragmentIds(filter as LogFilter);
     case "block":
       return getBlockFilterFragmentId(filter as BlockFilter);
-
     case "transaction":
       return getTransactionFilterFragmentIds(filter as TransactionFilter);
-
-    case "transfer":
-      return getTransferFilterFragmentIds(filter as TransferFilter);
-
     case "trace":
       return getTraceFilterFragmentIds(filter as TraceFilter);
+    case "log":
+      return getLogFilterFragmentIds(filter as LogFilter);
+    case "transfer":
+      return getTransferFilterFragmentIds(filter as TransferFilter);
   }
 };
 
@@ -82,82 +80,6 @@ const getAddressFragmentIds = (
   return fragments;
 };
 
-/**
- * Generates log filter fragment IDs from a log filter.
- *
- * @param logFilter Log filter to be decomposed into fragments.
- * @returns A list of log filter fragment IDs.
- */
-export const getLogFilterFragmentIds = ({
-  chainId,
-  address,
-  topic0,
-  topic1,
-  topic2,
-  topic3,
-  // includeTransactionReceipts,
-}: Omit<LogFilter, "fromBlock" | "toBlock">): FragmentReturnType => {
-  // TODO(kyle) handle once column selection
-  const includeTransactionReceipts = false as boolean;
-
-  const fragments: FragmentReturnType = [];
-  const addressFragmentIds = getAddressFragmentIds(address);
-
-  for (const fragmentAddress of addressFragmentIds) {
-    for (const fragmentTopic0 of Array.isArray(topic0) ? topic0 : [topic0]) {
-      for (const fragmentTopic1 of Array.isArray(topic1) ? topic1 : [topic1]) {
-        for (const fragmentTopic2 of Array.isArray(topic2)
-          ? topic2
-          : [topic2]) {
-          for (const fragmentTopic3 of Array.isArray(topic3)
-            ? topic3
-            : [topic3]) {
-            const id =
-              `log_${chainId}_${fragmentAddress.id}_${fragmentTopic0 ?? null}_${fragmentTopic1 ?? null}_${fragmentTopic2 ?? null}_${fragmentTopic3 ?? null}_${
-                includeTransactionReceipts ? 1 : 0
-              }` as const;
-
-            const adjacent: FragmentId[] = [];
-
-            for (const adjacentAddress of fragmentAddress.adjacent) {
-              for (const adjacentTopic0 of fragmentTopic0
-                ? [fragmentTopic0, null]
-                : [null]) {
-                for (const adjacentTopic1 of fragmentTopic1
-                  ? [fragmentTopic1, null]
-                  : [null]) {
-                  for (const adjacentTopic2 of fragmentTopic2
-                    ? [fragmentTopic2, null]
-                    : [null]) {
-                    for (const adjacentTopic3 of fragmentTopic3
-                      ? [fragmentTopic3, null]
-                      : [null]) {
-                      for (const adjacentTxr of includeTransactionReceipts ===
-                      true
-                        ? [1]
-                        : [0, 1]) {
-                        adjacent.push(
-                          `log_${chainId}_${adjacentAddress}_${adjacentTopic0}_${adjacentTopic1}_${adjacentTopic2}_${adjacentTopic3}_${
-                            adjacentTxr as 0 | 1
-                          }`,
-                        );
-                      }
-                    }
-                  }
-                }
-              }
-            }
-
-            fragments.push({ id, adjacent });
-          }
-        }
-      }
-    }
-  }
-
-  return fragments;
-};
-
 export const getBlockFilterFragmentId = ({
   chainId,
   interval,
@@ -185,47 +107,14 @@ export const getTransactionFilterFragmentIds = ({
   for (const fragmentFromAddress of fromAddressFragmentIds) {
     for (const fragmentToAddress of toAddressFragmentIds) {
       const id =
-        `transaction_${chainId}_${fragmentFromAddress.id}_${fragmentToAddress.id}_${0}` as const;
+        `transaction_${chainId}_${fragmentFromAddress.id}_${fragmentToAddress.id}` as const;
 
       const adjacent: FragmentId[] = [];
 
       for (const adjacentFromAddress of fragmentFromAddress.adjacent) {
         for (const adjacentToAddress of fragmentToAddress.adjacent) {
           adjacent.push(
-            `transaction_${chainId}_${adjacentFromAddress}_${adjacentToAddress}_${0}`,
-          );
-        }
-      }
-
-      fragments.push({ id, adjacent });
-    }
-  }
-
-  return fragments;
-};
-
-export const getTransferFilterFragmentIds = ({
-  chainId,
-  fromAddress,
-  toAddress,
-}: Omit<TransferFilter, "fromBlock" | "toBlock"> & {
-  chainId: number;
-}): FragmentReturnType => {
-  const fragments: FragmentReturnType = [];
-  const fromAddressFragmentIds = getAddressFragmentIds(fromAddress);
-  const toAddressFragmentIds = getAddressFragmentIds(toAddress);
-
-  for (const fragmentFromAddress of fromAddressFragmentIds) {
-    for (const fragmentToAddress of toAddressFragmentIds) {
-      const id =
-        `transfer_${chainId}_${fragmentFromAddress.id}_${fragmentToAddress.id}` as const;
-
-      const adjacent: FragmentId[] = [];
-
-      for (const adjacentFromAddress of fragmentFromAddress.adjacent) {
-        for (const adjacentToAddress of fragmentToAddress.adjacent) {
-          adjacent.push(
-            `transfer_${chainId}_${adjacentFromAddress}_${adjacentToAddress}`,
+            `transaction_${chainId}_${adjacentFromAddress}_${adjacentToAddress}`,
           );
         }
       }
@@ -243,12 +132,14 @@ export const getTraceFilterFragmentIds = ({
   toAddress,
   callType,
   functionSelector,
+  ...filter
 }: Omit<TraceFilter, "fromBlock" | "toBlock"> & {
   chainId: number;
 }): FragmentReturnType => {
   const fragments: FragmentReturnType = [];
   const fromAddressFragmentIds = getAddressFragmentIds(fromAddress);
   const toAddressFragmentIds = getAddressFragmentIds(toAddress);
+  const includeTransactionReceipts = shouldGetTransactionReceipt(filter);
 
   for (const fragmentFromAddress of fromAddressFragmentIds) {
     for (const fragmentToAddress of toAddressFragmentIds) {
@@ -256,7 +147,7 @@ export const getTraceFilterFragmentIds = ({
         ? functionSelector
         : [functionSelector]) {
         const id =
-          `trace_${chainId}_${fragmentFromAddress.id}_${fragmentToAddress.id}_${callType ?? null}_${fragmentFunctionSelector ?? null}_${0}` as const;
+          `trace_${chainId}_${fragmentFromAddress.id}_${fragmentToAddress.id}_${callType ?? null}_${fragmentFunctionSelector ?? null}_${includeTransactionReceipts ? 1 : 0}` as const;
 
         const adjacent: FragmentId[] = [];
 
@@ -265,15 +156,119 @@ export const getTraceFilterFragmentIds = ({
             for (const adjacentFunctionSelector of fragmentFunctionSelector
               ? [fragmentFunctionSelector, null]
               : [null]) {
-              adjacent.push(
-                `trace_${chainId}_${adjacentFromAddress}_${adjacentToAddress}_${callType ?? null}_${adjacentFunctionSelector}_${0}`,
-              );
+              for (const adjacentTxr of includeTransactionReceipts
+                ? [1]
+                : [0, 1]) {
+                adjacent.push(
+                  `trace_${chainId}_${adjacentFromAddress}_${adjacentToAddress}_${callType ?? null}_${adjacentFunctionSelector}_${adjacentTxr as 0 | 1}`,
+                );
+              }
             }
           }
         }
 
         fragments.push({ id, adjacent });
       }
+    }
+  }
+
+  return fragments;
+};
+
+export const getLogFilterFragmentIds = ({
+  chainId,
+  address,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  ...filter
+}: Omit<LogFilter, "fromBlock" | "toBlock">): FragmentReturnType => {
+  const fragments: FragmentReturnType = [];
+  const addressFragmentIds = getAddressFragmentIds(address);
+  const includeTransactionReceipts = shouldGetTransactionReceipt(filter);
+
+  for (const fragmentAddress of addressFragmentIds) {
+    for (const fragmentTopic0 of Array.isArray(topic0) ? topic0 : [topic0]) {
+      for (const fragmentTopic1 of Array.isArray(topic1) ? topic1 : [topic1]) {
+        for (const fragmentTopic2 of Array.isArray(topic2)
+          ? topic2
+          : [topic2]) {
+          for (const fragmentTopic3 of Array.isArray(topic3)
+            ? topic3
+            : [topic3]) {
+            const id =
+              `log_${chainId}_${fragmentAddress.id}_${fragmentTopic0 ?? null}_${fragmentTopic1 ?? null}_${fragmentTopic2 ?? null}_${fragmentTopic3 ?? null}_${includeTransactionReceipts ? 1 : 0}` as const;
+
+            const adjacent: FragmentId[] = [];
+
+            for (const adjacentAddress of fragmentAddress.adjacent) {
+              for (const adjacentTopic0 of fragmentTopic0
+                ? [fragmentTopic0, null]
+                : [null]) {
+                for (const adjacentTopic1 of fragmentTopic1
+                  ? [fragmentTopic1, null]
+                  : [null]) {
+                  for (const adjacentTopic2 of fragmentTopic2
+                    ? [fragmentTopic2, null]
+                    : [null]) {
+                    for (const adjacentTopic3 of fragmentTopic3
+                      ? [fragmentTopic3, null]
+                      : [null]) {
+                      for (const adjacentTxr of includeTransactionReceipts
+                        ? [1]
+                        : [0, 1]) {
+                        adjacent.push(
+                          `log_${chainId}_${adjacentAddress}_${adjacentTopic0}_${adjacentTopic1}_${adjacentTopic2}_${adjacentTopic3}_${adjacentTxr as 0 | 1}`,
+                        );
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            fragments.push({ id, adjacent });
+          }
+        }
+      }
+    }
+  }
+
+  return fragments;
+};
+
+export const getTransferFilterFragmentIds = ({
+  chainId,
+  fromAddress,
+  toAddress,
+  ...filter
+}: Omit<TransferFilter, "fromBlock" | "toBlock"> & {
+  chainId: number;
+}): FragmentReturnType => {
+  const fragments: FragmentReturnType = [];
+  const fromAddressFragmentIds = getAddressFragmentIds(fromAddress);
+  const toAddressFragmentIds = getAddressFragmentIds(toAddress);
+  const includeTransactionReceipts = shouldGetTransactionReceipt(filter);
+
+  for (const fragmentFromAddress of fromAddressFragmentIds) {
+    for (const fragmentToAddress of toAddressFragmentIds) {
+      const id =
+        `transfer_${chainId}_${fragmentFromAddress.id}_${fragmentToAddress.id}_${includeTransactionReceipts ? 1 : 0}` as const;
+
+      const adjacent: FragmentId[] = [];
+
+      for (const adjacentFromAddress of fragmentFromAddress.adjacent) {
+        for (const adjacentToAddress of fragmentToAddress.adjacent) {
+          for (const adjacentTxr of includeTransactionReceipts ? [1] : [0, 1]) {
+            adjacent.push(
+              `transfer_${chainId}_${adjacentFromAddress}_${adjacentToAddress}_${adjacentTxr as 0 | 1}`,
+            );
+          }
+        }
+      }
+
+      fragments.push({ id, adjacent });
     }
   }
 

--- a/packages/core/src/sync/source.ts
+++ b/packages/core/src/sync/source.ts
@@ -1,4 +1,11 @@
 import type { AbiEvents, AbiFunctions } from "@/sync/abi.js";
+import type {
+  Block,
+  Log,
+  Transaction,
+  TransactionReceipt,
+  Trace as UserTrace,
+} from "@/types/eth.js";
 import type { SyncLog } from "@/types/sync.js";
 import type { Trace } from "@/utils/debug.js";
 import type { Abi, Address, Hex, LogTopic } from "viem";
@@ -66,6 +73,14 @@ export type LogFilter<
   topic3: LogTopic | undefined;
   fromBlock: number | undefined;
   toBlock: number | undefined;
+  include:
+    | (
+        | `block.${keyof Block}`
+        | `transaction.${keyof Transaction}`
+        | `transactionReceipt.${keyof TransactionReceipt}`
+        | `log.${keyof Log}`
+      )[]
+    | undefined;
 };
 
 export type BlockFilter = {
@@ -75,6 +90,7 @@ export type BlockFilter = {
   offset: number;
   fromBlock: number | undefined;
   toBlock: number | undefined;
+  include: `block.${keyof Block}`[] | undefined;
 };
 
 export type TransferFilter<
@@ -92,6 +108,14 @@ export type TransferFilter<
   includeReverted: boolean;
   fromBlock: number | undefined;
   toBlock: number | undefined;
+  include:
+    | (
+        | `block.${keyof Block}`
+        | `transaction.${keyof Transaction}`
+        | `transactionReceipt.${keyof TransactionReceipt}`
+        | `trace.${keyof UserTrace}`
+      )[]
+    | undefined;
 };
 
 export type TransactionFilter<
@@ -128,6 +152,14 @@ export type TraceFilter<
   includeReverted: boolean;
   fromBlock: number | undefined;
   toBlock: number | undefined;
+  include:
+    | (
+        | `block.${keyof Block}`
+        | `transaction.${keyof Transaction}`
+        | `transactionReceipt.${keyof TransactionReceipt}`
+        | `trace.${keyof UserTrace}`
+      )[]
+    | undefined;
 };
 
 export type LogFactory = {

--- a/packages/core/src/sync/source.ts
+++ b/packages/core/src/sync/source.ts
@@ -248,6 +248,24 @@ const defaultTransactionInclude: `transaction.${keyof Transaction}`[] = [
   // NOTE: type specific properties are not included
 ];
 
+export const defaultTransactionReceiptInclude: `transactionReceipt.${keyof TransactionReceipt}`[] =
+  [
+    "transactionReceipt.blockHash",
+    "transactionReceipt.blockNumber",
+    "transactionReceipt.contractAddress",
+    "transactionReceipt.cumulativeGasUsed",
+    "transactionReceipt.effectiveGasPrice",
+    "transactionReceipt.from",
+    "transactionReceipt.gasUsed",
+    "transactionReceipt.logs",
+    "transactionReceipt.logsBloom",
+    "transactionReceipt.status",
+    "transactionReceipt.to",
+    "transactionReceipt.transactionHash",
+    "transactionReceipt.transactionIndex",
+    "transactionReceipt.type",
+  ];
+
 const defaultTraceInclude: `trace.${keyof UserTrace}`[] = [
   "trace.id",
   "trace.type",
@@ -279,6 +297,7 @@ export const defaultLogFilterInclude: LogFilter["include"] = [
 
 export const defaultTransactionFilterInclude: TransactionFilter["include"] = [
   ...defaultTransactionInclude,
+  ...defaultTransactionReceiptInclude,
   ...defaultBlockFilterInclude,
 ];
 
@@ -300,7 +319,7 @@ export const shouldGetTransactionReceipt = (
   // transactions must request receipts for "reverted" information
   if (filter.type === "transaction") return true;
 
-  // ??
+  // TODO(kyle) should include be a required property?
   if (filter.include === undefined) return true;
 
   if (filter.include.some((prop) => prop.startsWith("transactionReceipt."))) {

--- a/packages/core/src/sync/source.ts
+++ b/packages/core/src/sync/source.ts
@@ -314,8 +314,8 @@ export const defaultTransferFilterInclude: TransferFilter["include"] = [
 ];
 
 export const shouldGetTransactionReceipt = (
-  filter: Exclude<Filter, BlockFilter>,
-) => {
+  filter: Pick<Exclude<Filter, BlockFilter>, "include" | "type">,
+): boolean => {
   // transactions must request receipts for "reverted" information
   if (filter.type === "transaction") return true;
 

--- a/packages/core/src/sync/source.ts
+++ b/packages/core/src/sync/source.ts
@@ -314,10 +314,12 @@ export const defaultTransferFilterInclude: TransferFilter["include"] = [
 ];
 
 export const shouldGetTransactionReceipt = (
-  filter: Pick<Exclude<Filter, BlockFilter>, "include" | "type">,
+  filter: Pick<Filter, "include" | "type">,
 ): boolean => {
   // transactions must request receipts for "reverted" information
   if (filter.type === "transaction") return true;
+
+  if (filter.type === "block") return false;
 
   // TODO(kyle) should include be a required property?
   if (filter.include === undefined) return true;


### PR DESCRIPTION
Adds back support for including transaction receipts in indexing function events