### PR TITLE
feat(core.indexing-store): introduce mode param to indexing functions

### DIFF
--- a/packages/core/src/indexing-store/historical.test.ts
+++ b/packages/core/src/indexing-store/historical.test.ts
@@ -36,6 +36,8 @@ test("find", async (context) => {
     initialCheckpoint: encodeCheckpoint(zeroCheckpoint),
   });
 
+  expect(indexingStore.mode).toBe("historical");
+
   // empty
 
   let result = await indexingStore.find(schema.account, {

--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -1001,6 +1001,9 @@ export const createHistoricalIndexingStore = ({
     isCacheFull() {
       return cacheBytes > maxBytes;
     },
+    get mode() {
+      return "historical" as const;
+    },
   } satisfies IndexingStore<"historical">;
 
   // @ts-ignore

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -9,14 +9,14 @@ import type { Schema } from "@/drizzle/index.js";
 import type { Db } from "@/types/db.js";
 
 export type IndexingStore<policy extends "historical" | "realtime"> =
-  policy extends "realtime"
-    ? Db<Schema>
-    : Db<Schema> & {
+  policy extends "historical"
+    ? Db<Schema> & { mode: policy } & {
         /** Persist the cache to the database. */
         flush: () => Promise<void>;
         /** Return `true` if the cache size in bytes is above the limit specified by `option.indexingCacheMaxBytes`. */
         isCacheFull: () => boolean;
-      };
+      }
+    : Db<Schema> & { mode: policy };
 
 export const parseSqlError = (e: any): Error => {
   let error = getBaseError(e);

--- a/packages/core/src/indexing-store/realtime.test.ts
+++ b/packages/core/src/indexing-store/realtime.test.ts
@@ -36,6 +36,8 @@ test("find", async (context) => {
     schema,
   });
 
+  expect(indexingStore.mode).toBe("realtime");
+
   // empty
 
   let result = await indexingStore.find(schema.account, {

--- a/packages/core/src/indexing-store/realtime.ts
+++ b/packages/core/src/indexing-store/realtime.ts
@@ -411,6 +411,9 @@ export const createRealtimeIndexingStore = ({
         }),
       { schema, casing: "snake_case" },
     ),
+    get mode() {
+      return "realtime" as const;
+    },
   } satisfies IndexingStore<"realtime">;
 
   // @ts-ignore

--- a/packages/core/src/indexing/service.test.ts
+++ b/packages/core/src/indexing/service.test.ts
@@ -152,6 +152,7 @@ test("processSetupEvents()", async (context) => {
   expect(indexingFunctions["Erc20:setup"]).toHaveBeenCalledWith({
     context: {
       network: { chainId: 1, name: "mainnet" },
+      store: { mode: "realtime" },
       contracts: {
         Erc20: {
           abi: expect.any(Object),
@@ -242,6 +243,7 @@ test("processEvent() log events", async (context) => {
     },
     context: {
       network: { chainId: 1, name: "mainnet" },
+      store: { mode: "realtime" },
       contracts: {
         Erc20: {
           abi: expect.any(Object),
@@ -317,6 +319,7 @@ test("processEvents() block events", async (context) => {
     },
     context: {
       network: { chainId: 1, name: "mainnet" },
+      store: { mode: "realtime" },
       contracts: {
         Erc20: {
           abi: expect.any(Object),
@@ -397,6 +400,7 @@ test("processEvents() call trace events", async (context) => {
     },
     context: {
       network: { chainId: 1, name: "mainnet" },
+      store: { mode: "realtime" },
       contracts: {
         Erc20: {
           abi: expect.any(Object),

--- a/packages/core/src/indexing/service.ts
+++ b/packages/core/src/indexing/service.ts
@@ -33,6 +33,7 @@ import { type ReadOnlyClient, buildCachedActions } from "./ponderActions.js";
 
 export type Context = {
   network: { chainId: number; name: string };
+  store: Pick<IndexingStore<"historical" | "realtime">, "mode">;
   client: ReadOnlyClient;
   db: Db<Schema>;
   contracts: Record<
@@ -171,6 +172,7 @@ export const create = ({
       contextState,
       context: {
         network: { name: undefined!, chainId: undefined! },
+        store: { mode: undefined! },
         contracts: undefined!,
         client: undefined!,
         db: undefined!,
@@ -367,6 +369,8 @@ export const setIndexingStore = (
     delete: indexingStore.delete,
     sql: indexingStore.sql,
   };
+
+  indexingService.currentEvent.context.store.mode = indexingStore.mode;
 };
 
 export const kill = (indexingService: Service) => {


### PR DESCRIPTION
Resolves #1294 

This PR allows the indexing function to read the mode of the indexing store.

It's a useful information when sending out notifications to other services (i.e. only sending them out during the realtime indexing phase).