### PR TITLE
fix: reorgs with multiple chains causing missing events

### DIFF
--- a/.changeset/lemon-news-teach.md
+++ b/.changeset/lemon-news-teach.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug that occassionaly caused reorgs to lead to missing events. Please note that this did not affect the rpc cache, users do not have to re-sync.

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -711,6 +711,7 @@ export const createSync = async (args: CreateSyncParameters): Promise<Sync> => {
             service: "sync",
             msg: `Finalized block for '${network.name}' has surpassed overall indexing checkpoint`,
           });
+          // exit early because we need to keep `unfinalizedBlocks.events`
           return;
         }
 


### PR DESCRIPTION
### Description
Fixes an issues when handling reorgs with a multi chain configuration. This bug occurs when a reorg on one chain caused an event on a different chain to be reverted and never re-run.

### Example
1. event occurs on chain A, get handled with an indexing function
2. reorg detected on chain B
3. event on chain A gets reverted, because it is chronologically ahead of the reorg
4. chain B gets reprocessed, but not chain A