### PR TITLE
feat: replacing getTransactionReceipt with getBlockReceipts

### DIFF
--- a/.changeset/long-ligers-travel.md
+++ b/.changeset/long-ligers-travel.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Added support for "eth_getBlockReceipts" request for better performance and cost.

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -314,10 +314,10 @@ export const createHistoricalSync = async (
   const syncTransactionReceipts = async (
     block: Hash,
     transactionHashes: Set<Hash>,
-  ) => {
+  ): Promise<SyncTransactionReceipt[]> => {
     if (isBlockReceipts === false) {
       const transactionReceipts = await Promise.all(
-        Array.from(transactionHashes).map(async (hash) =>
+        Array.from(transactionHashes).map((hash) =>
           syncTransactionReceipt(hash),
         ),
       );
@@ -490,7 +490,7 @@ export const createHistoricalSync = async (
       if (isKilled) return;
 
       await args.syncStore.insertTransactionReceipts({
-        transactionReceipts: Array.from(transactionReceipts),
+        transactionReceipts,
         chainId: args.network.chainId,
       });
     }
@@ -575,7 +575,7 @@ export const createHistoricalSync = async (
     if (isKilled) return;
 
     await args.syncStore.insertTransactionReceipts({
-      transactionReceipts: Array.from(transactionReceipts),
+      transactionReceipts,
       chainId: args.network.chainId,
     });
   };
@@ -671,7 +671,7 @@ export const createHistoricalSync = async (
       if (isKilled) return;
 
       await args.syncStore.insertTransactionReceipts({
-        transactionReceipts: Array.from(transactionReceipts),
+        transactionReceipts,
         chainId: args.network.chainId,
       });
     }

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -328,7 +328,16 @@ export const createHistoricalSync = async (
     let blockReceipts: SyncTransactionReceipt[];
     try {
       blockReceipts = await syncBlockReceipts(block);
-    } catch {
+    } catch (_error) {
+      const error = _error as Error;
+      args.common.logger.warn({
+        service: "sync",
+        msg: `Caught eth_getBlockReceipts error on '${
+          args.network.name
+        }', switching to eth_getTransactionReceipt method.`,
+        error,
+      });
+
       isBlockReceipts = false;
       return syncTransactionReceipts(block, transactionHashes);
     }

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -597,7 +597,16 @@ export const createRealtimeSync = (
       blockReceipts = await _eth_getBlockReceipts(args.requestQueue, {
         blockHash,
       });
-    } catch {
+    } catch (_error) {
+      const error = _error as Error;
+      args.common.logger.warn({
+        service: "realtime",
+        msg: `Caught eth_getBlockReceipts error on '${
+          args.network.name
+        }', switching to eth_getTransactionReceipt method.`,
+        error,
+      });
+
       isBlockReceipts = false;
       return syncTransactionReceipts(blockHash, transactionHashes);
     }

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -30,7 +30,6 @@ import {
   _eth_getBlockByNumber,
   _eth_getBlockReceipts,
   _eth_getLogs,
-  _eth_getTransactionReceipt,
 } from "@/utils/rpc.js";
 import { wait } from "@/utils/wait.js";
 import { type Queue, createQueue } from "@ponder/common";
@@ -781,9 +780,9 @@ export const createRealtimeSync = (
     ////////
 
     const blockReceipts = await _eth_getBlockReceipts(args.requestQueue, {
-      blockNumber: block.number,
+      blockHash: block.hash,
     });
-    
+
     // Validate that block transaction receipts include all required transactions
     const blockReceiptsTransactionHashes = new Set(
       blockReceipts.map((r) => r.transactionHash),

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -581,7 +581,7 @@ export const createRealtimeSync = (
   const syncTransactionReceipts = async (
     blockHash: Hash,
     transactionHashes: Set<Hash>,
-  ) => {
+  ): Promise<SyncTransactionReceipt[]> => {
     if (isBlockReceipts === false) {
       const transactionReceipts = await Promise.all(
         Array.from(transactionHashes).map(async (hash) =>

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -770,7 +770,7 @@ export const createRealtimeSync = (
     for (const hash of Array.from(requiredTransactions)) {
       if (blockTransactionsHashes.has(hash) === false) {
         throw new Error(
-          `Detected inconsistent RPC responses. Transaction with hash ${hash} is missing in \`block.transactions\`.`,
+          `Detected inconsistent RPC responses. 'transaction.hash' ${hash} not found in eth_getBlockReceipts response for block '${block.hash}'.`,
         );
       }
     }

--- a/packages/core/src/utils/rpc.ts
+++ b/packages/core/src/utils/rpc.ts
@@ -147,6 +147,24 @@ export const _eth_getTransactionReceipt = (
     });
 
 /**
+ * Helper function for "eth_getBlockReceipts" request.
+ */
+export const _eth_getBlockReceipts = (
+  requestQueue: RequestQueue,
+  { blockNumber }: { blockNumber: Hex | number },
+): Promise<SyncTransactionReceipt[]> =>
+  requestQueue
+    .request({
+      method: "eth_getBlockReceipts",
+      params: [
+        typeof blockNumber === "number"
+          ? numberToHex(blockNumber)
+          : blockNumber,
+      ],
+    } as any)
+    .then((receipts) => receipts as unknown as SyncTransactionReceipt[]);
+
+/**
  * Helper function for "debug_traceBlockByNumber" request.
  */
 export const _debug_traceBlockByNumber = (

--- a/packages/core/src/utils/rpc.ts
+++ b/packages/core/src/utils/rpc.ts
@@ -156,9 +156,7 @@ export const _eth_getBlockReceipts = (
   requestQueue
     .request({
       method: "eth_getBlockReceipts",
-      params: [
-        blockHash
-      ],
+      params: [blockHash],
     } as any)
     .then((receipts) => receipts as unknown as SyncTransactionReceipt[]);
 

--- a/packages/core/src/utils/rpc.ts
+++ b/packages/core/src/utils/rpc.ts
@@ -151,15 +151,13 @@ export const _eth_getTransactionReceipt = (
  */
 export const _eth_getBlockReceipts = (
   requestQueue: RequestQueue,
-  { blockNumber }: { blockNumber: Hex | number },
+  { blockHash }: { blockHash: Hash },
 ): Promise<SyncTransactionReceipt[]> =>
   requestQueue
     .request({
       method: "eth_getBlockReceipts",
       params: [
-        typeof blockNumber === "number"
-          ? numberToHex(blockNumber)
-          : blockNumber,
+        blockHash
       ],
     } as any)
     .then((receipts) => receipts as unknown as SyncTransactionReceipt[]);


### PR DESCRIPTION
Closes #1197 . Includes the new helper function (`_eth_getBlockReceipts`) and changes to sync-realtime / sync-histroical. This change should lower the number of requests to RPC and CU costs. 