### PR TITLE
fix: malformed "eth_getLogs" request in `sync-historical`

### DIFF
--- a/.changeset/flat-donkeys-explain.md
+++ b/.changeset/flat-donkeys-explain.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug that caused no events to be found in the historical backfill. Affected users should resync their apps to get rid of the incorrect cached data.

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -153,6 +153,22 @@ export const createHistoricalSync = async (
             filter.topic3 ?? null,
           ];
 
+    // Note: the `topics` field is very fragile for many rpc providers, and
+    // cannot handle extra "null" topics
+
+    if (topics[3] === null) {
+      topics.pop();
+      if (topics[2] === null) {
+        topics.pop();
+        if (topics[1] === null) {
+          topics.pop();
+          if (topics[0] === null) {
+            topics.pop();
+          }
+        }
+      }
+    }
+
     // Batch large arrays of addresses, handling arrays that are empty
 
     let addressBatches: (Address | Address[] | undefined)[];


### PR DESCRIPTION
Closes #1338 

It appears that most rpcs (excluding alchemy) have a bug where `topics: [["0x..."]]` and `topics: [["0x..."], null, null, null]` return a different response for "eth_getLogs" requests. Ponder began formatting requests in the second shape starting in v0.8.0.