### PR TITLE
support duplicate fragments

### DIFF
--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -701,6 +701,7 @@ export const createHistoricalSync = async (
       if (args.network.disableCache === false) {
         await args.syncStore.insertIntervals({
           intervals: syncedIntervals,
+          chainId: args.network.chainId,
         });
       }
 

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -114,6 +114,7 @@ test("getIntervals() returns intervals", async (context) => {
         interval: [0, 4],
       },
     ],
+    chainId: 1,
   });
 
   const intervals = await syncStore.getIntervals({
@@ -146,6 +147,7 @@ test("getIntervals() merges intervals", async (context) => {
         interval: [0, 4],
       },
     ],
+    chainId: 1,
   });
 
   await syncStore.insertIntervals({
@@ -155,6 +157,7 @@ test("getIntervals() merges intervals", async (context) => {
         interval: [5, 8],
       },
     ],
+    chainId: 1,
   });
   const intervals = await syncStore.getIntervals({
     filters: [filter],
@@ -189,6 +192,7 @@ test("getIntervals() adjacent intervals", async (context) => {
         interval: [0, 4],
       },
     ],
+    chainId: 1,
   });
 
   await syncStore.insertIntervals({
@@ -198,7 +202,55 @@ test("getIntervals() adjacent intervals", async (context) => {
         interval: [5, 8],
       },
     ],
+    chainId: 1,
   });
+  const intervals = await syncStore.getIntervals({
+    filters: [filter],
+  });
+
+  expect(Array.from(intervals.values())[0]).toHaveLength(1);
+  expect(Array.from(intervals.values())[0]![0]).toStrictEqual([0, 8]);
+
+  await cleanup();
+});
+
+test("insertIntervals() merges duplicates", async (context) => {
+  const { cleanup, syncStore } = await setupDatabaseServices(context);
+
+  const filter = {
+    type: "block",
+    chainId: 1,
+    interval: 1,
+    offset: 0,
+    fromBlock: undefined,
+    toBlock: undefined,
+    include: [],
+  } satisfies BlockFilter;
+
+  await syncStore.insertIntervals({
+    intervals: [
+      {
+        filter,
+        interval: [0, 4],
+      },
+    ],
+    chainId: 1,
+  });
+
+  await syncStore.insertIntervals({
+    intervals: [
+      {
+        filter,
+        interval: [5, 6],
+      },
+      {
+        filter,
+        interval: [5, 8],
+      },
+    ],
+    chainId: 1,
+  });
+
   const intervals = await syncStore.getIntervals({
     filters: [filter],
   });

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -250,7 +250,7 @@ export const createSyncStore = ({
       for (let i = 0; i < filters.length; i++) {
         const filter = filters[i]!;
         const intervals = rows
-          .filter((row) => +row.filter === i)
+          .filter((row) => row.filter === `${i}`)
           .map((row) =>
             (row.merged_blocks
               ? (JSON.parse(

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -786,6 +786,7 @@ export const createSync = async (args: CreateSyncParameters): Promise<Sync> => {
             intervals: args.sources
               .filter(({ filter }) => filter.chainId === network.chainId)
               .map(({ filter }) => ({ filter, interval })),
+            chainId: network.chainId,
           });
         }
 


### PR DESCRIPTION
Fixes a bug where duplicate fragments (defining the same block filter twice) would cause Ponder to crash