### PR TITLE
Add configurable block range limits for network syncing

### DIFF
--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -184,6 +184,8 @@ export const getNetwork = (params?: {
     pollingInterval: 1_000,
     finalityBlockCount: params?.finalityBlockCount ?? 1,
     disableCache: false,
+    maxBlockRange: 100_000,
+    minBlockRange: 25,
   } satisfies Network;
 };
 

--- a/packages/core/src/build/configAndIndexingFunctions.test.ts
+++ b/packages/core/src/build/configAndIndexingFunctions.test.ts
@@ -188,7 +188,7 @@ test("buildConfigAndIndexingFunctions() builds topics for event with args", asyn
   expect((sources[0]!.filter as LogFilter).topic0).toMatchObject([
     toEventSelector(event0),
   ]);
-  expect((sources[0]!.filter as LogFilter).topic1).toMatchObject(bytes1);
+  expect((sources[0]!.filter as LogFilter).topic1).toEqual(bytes1);
 });
 
 test("buildConfigAndIndexingFunctions() builds topics for event with unnamed parameters", async () => {
@@ -583,7 +583,7 @@ test("buildConfigAndIndexingFunctions() includeCallTraces with factory", async (
   expect((sources[0]!.filter as TraceFilter).fromAddress).toBeUndefined();
   expect(
     ((sources[0]!.filter as TraceFilter).toAddress as LogFactory).address,
-  ).toMatchObject(address2);
+  ).toEqual(address2);
   expect((sources[0]!.filter as TraceFilter).functionSelector).toMatchObject([
     toFunctionSelector(func0),
   ]);

--- a/packages/core/src/build/configAndIndexingFunctions.ts
+++ b/packages/core/src/build/configAndIndexingFunctions.ts
@@ -103,7 +103,7 @@ export async function buildConfigAndIndexingFunctions({
         network.pollingInterval! < 100
       ) {
         throw new Error(
-          `Invalid 'pollingInterval' for network '${networkName}. Expected 100 milliseconds or greater, got ${network.pollingInterval} milliseconds.`,
+          `Invalid 'pollingInterval' for network '${networkName}'. Expected 100 milliseconds or greater, got ${network.pollingInterval} milliseconds.`,
         );
       }
 
@@ -114,6 +114,8 @@ export async function buildConfigAndIndexingFunctions({
         transport: network.transport({ chain }),
         maxRequestsPerSecond: network.maxRequestsPerSecond ?? 50,
         pollingInterval: network.pollingInterval ?? 1_000,
+        maxBlockRange: network.maxBlockRange ?? 100_000,
+        minBlockRange: network.minBlockRange ?? 25,
         finalityBlockCount: getFinalityBlockCount({ chainId }),
         disableCache: network.disableCache ?? false,
       } satisfies Network;

--- a/packages/core/src/common/telemetry.test.ts
+++ b/packages/core/src/common/telemetry.test.ts
@@ -53,10 +53,10 @@ test("telemetry calls fetch with event body", async (context) => {
 
   expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-  const fetchUrl = fetchSpy.mock.calls[0][0];
+  const fetchUrl = fetchSpy.mock.calls[0]?.[0];
   expect(fetchUrl).toBe(context.common.options.telemetryUrl);
 
-  const fetchBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+  const fetchBody = JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body ?? "{}");
   expect(fetchBody).toMatchObject({
     distinctId: expect.any(String),
     event: "lifecycle:heartbeat_send",

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -109,6 +109,10 @@ type NetworkConfig<network> = {
   maxRequestsPerSecond?: number;
   /** Disable RPC request caching. Default: `false`. */
   disableCache?: boolean;
+  /** Maximum number of blocks to process in a single request. Default: `100_000`. */
+  maxBlockRange?: number;
+  /** Minimum number of blocks to process in a single request. Default: `25`. */
+  minBlockRange?: number;
 };
 
 type NetworksConfig<networks> = {} extends networks

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -10,6 +10,8 @@ export type Network = {
   maxRequestsPerSecond: number;
   finalityBlockCount: number;
   disableCache: boolean;
+  maxBlockRange: number;
+  minBlockRange: number;
 };
 
 /**

--- a/packages/core/src/database/index.test.ts
+++ b/packages/core/src/database/index.test.ts
@@ -42,7 +42,7 @@ test("setup() succeeds with empty schema", async (context) => {
 
   const { checkpoint } = await database.setup({ buildId: "abc" });
 
-  expect(checkpoint).toMatchObject(encodeCheckpoint(zeroCheckpoint));
+  expect(checkpoint).toEqual(encodeCheckpoint(zeroCheckpoint));
 
   const tableNames = await getUserTableNames(database, "public");
   expect(tableNames).toContain("account");
@@ -130,7 +130,7 @@ test("setup() succeeds with crash recovery", async (context) => {
 
   const { checkpoint } = await databaseTwo.setup({ buildId: "abc" });
 
-  expect(checkpoint).toMatchObject(createCheckpoint(10));
+  expect(checkpoint).toEqual(createCheckpoint(10));
 
   const metadata = await databaseTwo.qb.internal
     .selectFrom("_ponder_meta")
@@ -179,7 +179,7 @@ test("setup() succeeds with crash recovery after waiting for lock", async (conte
 
   const { checkpoint } = await databaseTwo.setup({ buildId: "abc" });
 
-  expect(checkpoint).toMatchObject(createCheckpoint(10));
+  expect(checkpoint).toEqual(createCheckpoint(10));
 
   await database.unlock();
   await database.kill();
@@ -339,7 +339,7 @@ test("setup() with crash recovery reverts rows", async (context) => {
 
   const { checkpoint } = await databaseTwo.setup({ buildId: "abc" });
 
-  expect(checkpoint).toMatchObject(createCheckpoint(10));
+  expect(checkpoint).toEqual(createCheckpoint(10));
 
   const rows = await databaseTwo.drizzle
     .execute(sql`SELECT * from "account"`)

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -1205,14 +1205,14 @@ export async function* localHistoricalSyncGenerator({
       );
 
       // Use the duration and interval of the last call to `sync` to update estimate
-      // 25 <= estimate(new) <= estimate(prev) * 2 <= 100_000
+      // minBlockRange <= estimate(new) <= estimate(prev) * 2 <= maxBlockRange
       estimateRange = Math.min(
         Math.max(
-          25,
+          network.minBlockRange,
           Math.round((1_000 * (interval[1] - interval[0])) / duration),
         ),
         estimateRange * 2,
-        100_000,
+        network.maxBlockRange,
       );
     }
 


### PR DESCRIPTION
- Introduce maxBlockRange and minBlockRange options in NetworkConfig
- Update buildConfigAndIndexingFunctions to use new options
- Modify localHistoricalSyncGenerator to use configurable block range limits
- Set default values: maxBlockRange (100,000) and minBlockRange (25)