### PR TITLE
chore: idle debug logs

### DIFF
--- a/.changeset/warm-coats-tickle.md
+++ b/.changeset/warm-coats-tickle.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved debug-level logs for historical indexing observability.


### PR DESCRIPTION
Adds logs to help debug (likely) slow getEvents queries.

```
5:58:39 PM DEBUG app        Started using config file: ponder.config.ts
5:58:39 PM INFO  build      Using PGlite database at .ponder/pglite (default)
5:58:39 PM INFO  database   Using database schema 'public'
5:58:40 PM INFO  database   Created tables [account, allowance, transfer_event, approval_event]
5:58:40 PM DEBUG codegen    Wrote new file at ponder-env.d.ts
5:58:40 PM DEBUG codegen    Wrote new file at generated/schema.graphql
5:58:40 PM DEBUG indexing   Using a 512 MB indexing cache
5:58:40 PM INFO  historical Started syncing 'mainnet' with 100% cached
5:58:40 PM INFO  historical Skipped historical sync for 'mainnet' because all blocks are cached.
5:58:40 PM DEBUG sync       Fetched 0 events from the database for a 16m 40s range from 1630537772
5:58:40 PM DEBUG sync       Fetched 1 events from the database for a 18m 00s range from 1630538772
5:58:40 PM INFO  server     Started listening on port 42069
5:58:40 PM INFO  app        Indexed 1 events with 1.7% complete and 2s remaining
5:58:40 PM DEBUG sync       Fetched 0 events from the database for a 19m 26s range from 1630539852
5:58:40 PM DEBUG sync       Fetched 11 events from the database for a 20m 59s range from 1630541018
5:58:40 PM INFO  app        Indexed 11 events with 4.1% complete and 1s remaining
5:58:40 PM DEBUG sync       Fetched 0 events from the database for a 22m 40s range from 1630542277
5:58:40 PM DEBUG sync       Fetched 0 events from the database for a 24m 29s range from 1630543637
5:58:40 PM DEBUG sync       Fetched 0 events from the database for a 26m 27s range from 1630545106
5:58:40 PM DEBUG sync       Fetched 547 events from the database for a 28m 34s range from 1630546693
5:58:40 PM INFO  app        Indexed 547 events with 10.9% complete and 1s remaining
5:58:40 PM DEBUG sync       Fetched 690 events from the database for a 30m 51s range from 1630548407
5:58:40 PM INFO  app        Indexed 690 events with 12.8% complete and 1s remaining
5:58:40 PM DEBUG sync       Fetched 301 events from the database for a 33m 19s range from 1630550258
5:58:40 PM INFO  app        Indexed 301 events with 14.8% complete and 1s remaining
5:58:40 PM DEBUG sync       Fetched 473 events from the database for a 35m 59s range from 1630552257
5:58:40 PM INFO  app        Indexed 473 events with 17.0% complete and 1s remaining
5:58:40 PM DEBUG sync       Fetched 161 events from the database for a 38m 52s range from 1630554416
5:58:40 PM INFO  app        Indexed 161 events with 19.4% complete and 1s remaining
5:58:41 PM DEBUG sync       Fetched 142 events from the database for a 41m 59s range from 1630556748
5:58:41 PM INFO  app        Indexed 142 events with 21.9% complete and 1s remaining
...
5:58:42 PM DEBUG sync       Fetched 1392 events from the database for a 2h 13m 12s range from 1630625155
5:58:42 PM INFO  app        Indexed 1392 events with 97.7% complete and 39ms remaining
5:58:42 PM DEBUG sync       Fetched 386 events from the database for a 2h 23m 51s range from 1630633147
5:58:42 PM INFO  app        Indexed 386 events with 99.9% complete and 1ms remaining
5:58:42 PM DEBUG indexing   Completed all historical events, starting final flush
5:58:42 PM DEBUG database   Updated finalized checkpoint to (timestamp=0 chainId=0 block=0)
5:58:42 PM DEBUG indexing   Inserting 3436 cached 'account' rows into the database
5:58:42 PM DEBUG indexing   Inserting 1842 cached 'allowance' rows into the database
5:58:42 PM DEBUG indexing   Inserting 13332 cached 'transfer_event' rows into the database
5:58:42 PM DEBUG indexing   Inserting 4274 cached 'approval_event' rows into the database
5:58:43 PM DEBUG database   Updated finalized checkpoint to (timestamp=1734734735 chainId=1 block=21446803)
5:58:43 PM INFO  indexing   Completed historical indexing
5:58:43 PM INFO  server     Started responding as healthy
5:58:50 PM DEBUG database   Updated heartbeat timestamp to 1734735530183 (build_id=7fbdc52acd)
```