### PR TITLE
typo: merge abis url

### DIFF
--- a/docs/pages/docs/contracts-and-networks.mdx
+++ b/docs/pages/docs/contracts-and-networks.mdx
@@ -80,7 +80,7 @@ export default createConfig({
 
 ### Multiple ABIs
 
-It's occasionally useful to provide multiple ABIs for one contract, like when defining a proxy/upgradable contract that has gone through multiple implementation contracts. The [`mergeAbis`](/docs/utilities/abi) utility function safely removes duplicate ABI items and maintains strict types.
+It's occasionally useful to provide multiple ABIs for one contract, like when defining a proxy/upgradable contract that has gone through multiple implementation contracts. The [`mergeAbis`](/docs/utilities/merge-abi) utility function safely removes duplicate ABI items and maintains strict types.
 
 ```ts filename="ponder.config.ts" {1,14}
 import { createConfig, mergeAbis } from "ponder";
@@ -466,7 +466,7 @@ event ChildCreated(ChildContract child);
 
 ### Proxy & upgradable contracts
 
-To index a proxy/upgradable contract, use the proxy contract address in the `address` field. Then, be sure to include the ABIs of all implementation contracts that the proxy has ever had. The implementation ABIs are required to properly identify and decode all historical event logs. To add multiple ABIs safely, use the [`mergeAbis`](/docs/utilities/abi) utility function.
+To index a proxy/upgradable contract, use the proxy contract address in the `address` field. Then, be sure to include the ABIs of all implementation contracts that the proxy has ever had. The implementation ABIs are required to properly identify and decode all historical event logs. To add multiple ABIs safely, use the [`mergeAbis`](/docs/utilities/merge-abi) utility function.
 
 <Callout>
 Tip: On Etherscan, there is a link to the current implementation contract on the **Contract → Read as Proxy** tab. You can copy all the implementation ABIs as text and paste them into `.ts` files.

--- a/docs/pages/docs/contracts-and-networks.mdx
+++ b/docs/pages/docs/contracts-and-networks.mdx
@@ -80,7 +80,7 @@ export default createConfig({
 
 ### Multiple ABIs
 
-It's occasionally useful to provide multiple ABIs for one contract, like when defining a proxy/upgradable contract that has gone through multiple implementation contracts. The [`mergeAbis`](/docs/utilities/merge-abi) utility function safely removes duplicate ABI items and maintains strict types.
+It's occasionally useful to provide multiple ABIs for one contract, like when defining a proxy/upgradable contract that has gone through multiple implementation contracts. The [`mergeAbis`](/docs/utilities/merge-abis) utility function safely removes duplicate ABI items and maintains strict types.
 
 ```ts filename="ponder.config.ts" {1,14}
 import { createConfig, mergeAbis } from "ponder";
@@ -466,7 +466,7 @@ event ChildCreated(ChildContract child);
 
 ### Proxy & upgradable contracts
 
-To index a proxy/upgradable contract, use the proxy contract address in the `address` field. Then, be sure to include the ABIs of all implementation contracts that the proxy has ever had. The implementation ABIs are required to properly identify and decode all historical event logs. To add multiple ABIs safely, use the [`mergeAbis`](/docs/utilities/merge-abi) utility function.
+To index a proxy/upgradable contract, use the proxy contract address in the `address` field. Then, be sure to include the ABIs of all implementation contracts that the proxy has ever had. The implementation ABIs are required to properly identify and decode all historical event logs. To add multiple ABIs safely, use the [`mergeAbis`](/docs/utilities/merge-abis) utility function.
 
 <Callout>
 Tip: On Etherscan, there is a link to the current implementation contract on the **Contract → Read as Proxy** tab. You can copy all the implementation ABIs as text and paste them into `.ts` files.


### PR DESCRIPTION
The `mergeAbi` documentation URL was incorrect