### PR TITLE
fix: duplicate logs

### DIFF
--- a/.changeset/stale-timers-remain.md
+++ b/.changeset/stale-timers-remain.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug resulting in `error: ON CONFLICT DO UPDATE command cannot affect row a second time`.

--- a/packages/common/src/dedupe.ts
+++ b/packages/common/src/dedupe.ts
@@ -16,7 +16,10 @@
  * ) // [{a: 1, b: 2}, {a: 2, b: 2}]
  *
  */
-export function dedupe<item, id>(arr: item[], getId?: (x: item) => id): item[] {
+export function dedupe<item, id>(
+  arr: item[] | readonly item[],
+  getId?: (x: item) => id,
+): item[] {
   const seen = new Set<id | item>();
 
   return arr.filter((x) => {

--- a/packages/core/src/build/configAndIndexingFunctions.ts
+++ b/packages/core/src/build/configAndIndexingFunctions.ts
@@ -21,7 +21,8 @@ import {
 } from "@/sync/source.js";
 import { chains } from "@/utils/chains.js";
 import { toLowerCase } from "@/utils/lowercase.js";
-import type { Address, Hex, LogTopic } from "viem";
+import { dedupe } from "@ponder/common";
+import type { Hex, LogTopic } from "viem";
 import { buildLogFactory } from "./factory.js";
 
 export type RawIndexingFunctions = {
@@ -488,9 +489,9 @@ export async function buildConfigAndIndexingFunctions({
       }
 
       const validatedAddress = Array.isArray(resolvedAddress)
-        ? (resolvedAddress.map((r) => toLowerCase(r)) as Address[])
+        ? dedupe(resolvedAddress).map((r) => toLowerCase(r))
         : resolvedAddress !== undefined
-          ? (toLowerCase(resolvedAddress) as Address)
+          ? toLowerCase(resolvedAddress)
           : undefined;
 
       const logSource = {
@@ -680,9 +681,9 @@ export async function buildConfigAndIndexingFunctions({
       }
 
       const validatedAddress = Array.isArray(resolvedAddress)
-        ? (resolvedAddress.map((r) => toLowerCase(r)) as Address[])
+        ? dedupe(resolvedAddress).map((r) => toLowerCase(r))
         : resolvedAddress !== undefined
-          ? (toLowerCase(resolvedAddress) as Address)
+          ? toLowerCase(resolvedAddress)
           : undefined;
 
       return [

--- a/packages/core/src/build/factory.ts
+++ b/packages/core/src/build/factory.ts
@@ -1,8 +1,9 @@
 import type { LogFactory } from "@/sync/source.js";
 import { toLowerCase } from "@/utils/lowercase.js";
 import { getBytesConsumedByParam } from "@/utils/offset.js";
+import { dedupe } from "@ponder/common";
 import type { AbiEvent } from "abitype";
-import { type Address, getEventSelector } from "viem";
+import { type Address, toEventSelector } from "viem";
 
 export function buildLogFactory({
   address: _address,
@@ -16,9 +17,9 @@ export function buildLogFactory({
   chainId: number;
 }): LogFactory {
   const address = Array.isArray(_address)
-    ? _address.map(toLowerCase)
+    ? dedupe(_address).map(toLowerCase)
     : toLowerCase(_address);
-  const eventSelector = getEventSelector(event);
+  const eventSelector = toEventSelector(event);
 
   // Check if the provided parameter is present in the list of indexed inputs.
   const indexedInputPosition = event.inputs

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -184,6 +184,7 @@ export const createHistoricalSync = async (
       return [];
     } else {
       // many addresses
+      // Note: it is assumed that `address` is deduplicated
       addressBatches = [];
       for (let i = 0; i < address.length; i += 50) {
         addressBatches.push(address.slice(i, i + 50));

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -141,6 +141,7 @@ const logFactorySQL = (
         }
       })().as("childAddress"),
     )
+    .distinct()
     .$call((qb) => {
       if (Array.isArray(factory.address)) {
         return qb.where("address", "in", factory.address);
@@ -270,7 +271,6 @@ export const createSyncStore = ({
       return await db
         .selectFrom("logs")
         .$call((qb) => logFactorySQL(qb, filter))
-        .orderBy("id asc")
         .$if(limit !== undefined, (qb) => qb.limit(limit!))
         .execute()
         .then((addresses) => addresses.map(({ childAddress }) => childAddress));


### PR DESCRIPTION
## Description
The factory child address logic was not deduplicating its results, leading to `syncLogsDynamic` being called with many duplicate values. This function has some address batching logic, which would cause multiple replica eth_getLogs requests to be made. The resulting logs failed when being inserted into the database.

## Example
- factory contract with many duplicated child addresses