### PR TITLE
fix: null bytes

### DIFF
--- a/.changeset/eleven-onions-itch.md
+++ b/.changeset/eleven-onions-itch.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed the `FlushError: invalid byte sequence for encoding "UTF8": 0x00` error by removing null characters from decoded ABI parameters.

--- a/packages/core/src/sync/events.test.ts
+++ b/packages/core/src/sync/events.test.ts
@@ -53,6 +53,7 @@ import {
   buildEvents,
   decodeEventLog,
   decodeEvents,
+  removeNullCharacters,
 } from "./events.js";
 import type { LogFactory, LogFilter } from "./source.js";
 
@@ -834,7 +835,7 @@ test("buildEvents() matches getEvents() trace", async (context) => {
   await cleanup();
 });
 
-test("decodeEventLog removes null characters", () => {
+test("removeNullCharacters removes null characters", () => {
   // NameRegistered event from this transaction contains null characters:
   // https://etherscan.io/tx/0x2e67be22d5e700e61e102b926f28ba451c53a6cd6438c53b43dbb783c2081a12#eventlog
   const log = {
@@ -890,6 +891,9 @@ test("decodeEventLog removes null characters", () => {
     data: log.data,
   });
 
-  // Failing test: 'tencentclub\x00\x00\x00\x00\x00\x00'
-  expect(args.name).toBe("tencentclub");
+  expect(args.name).toBe("tencentclub\x00\x00\x00\x00\x00\x00");
+
+  const cleanedArgs = removeNullCharacters(args);
+
+  expect((cleanedArgs as any).name).toBe("tencentclub");
 });

--- a/packages/core/src/sync/events.test.ts
+++ b/packages/core/src/sync/events.test.ts
@@ -51,6 +51,7 @@ import {
   type TraceEvent,
   type TransferEvent,
   buildEvents,
+  decodeEventLog,
   decodeEvents,
 } from "./events.js";
 import type { LogFactory, LogFilter } from "./source.js";
@@ -831,4 +832,64 @@ test("buildEvents() matches getEvents() trace", async (context) => {
   expect(events2).toStrictEqual(events1);
 
   await cleanup();
+});
+
+test("decodeEventLog removes null characters", () => {
+  // NameRegistered event from this transaction contains null characters:
+  // https://etherscan.io/tx/0x2e67be22d5e700e61e102b926f28ba451c53a6cd6438c53b43dbb783c2081a12#eventlog
+  const log = {
+    topics: [
+      "0xca6abbe9d7f11422cb6ca7629fbf6fe9efb1c621f71ce8f02b9f2a230097404f",
+      "0x56e1003dc29ff83445ba93c493f4a76570eb667494e78c6974a745593131ae2a",
+      "0x0000000000000000000000008504a09352555ff1acf9c8a8d9fb5fdcc4161cbc",
+    ],
+    data: "0x0000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000697a5dd2a81dc000000000000000000000000000000000000000000000000000000006457430e000000000000000000000000000000000000000000000000000000000000001174656e63656e74636c7562000000000000000000000000000000000000000000",
+  } as const;
+
+  const abiItem = {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "string",
+        name: "name",
+        type: "string",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "label",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "cost",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "expires",
+        type: "uint256",
+      },
+    ],
+    name: "NameRegistered",
+    type: "event",
+  } as const;
+
+  const args = decodeEventLog({
+    abiItem,
+    topics: log.topics as unknown as [signature: Hex, ...args: Hex[]],
+    data: log.data,
+  });
+
+  // Failing test: 'tencentclub\x00\x00\x00\x00\x00\x00'
+  expect(args.name).toBe("tencentclub");
 });

--- a/packages/core/src/sync/events.ts
+++ b/packages/core/src/sync/events.ts
@@ -500,7 +500,7 @@ export const decodeEvents = (
 
                 event: {
                   name: safeName,
-                  args,
+                  args: removeNullCharacters(args),
                   log: event.log!,
                   block: event.block,
                   transaction: event.transaction!,
@@ -556,8 +556,8 @@ export const decodeEvents = (
                 name: `${source.name}.${safeName}`,
 
                 event: {
-                  args,
-                  result,
+                  args: removeNullCharacters(args),
+                  result: removeNullCharacters(result),
                   trace: event.trace!,
                   block: event.block,
                   transaction: event.transaction!,
@@ -716,10 +716,7 @@ export function decodeEventLog({
     }
   }
 
-  // Remove null bytes from any string values present in the decoded args.
-  return Object.values(args).length > 0
-    ? removeNullCharacters(args)
-    : undefined;
+  return Object.values(args).length > 0 ? args : undefined;
 }
 
 function decodeTopic({ param, value }: { param: AbiParameter; value: Hex }) {
@@ -734,7 +731,7 @@ function decodeTopic({ param, value }: { param: AbiParameter; value: Hex }) {
   return decodedArg[0];
 }
 
-function removeNullCharacters(obj: unknown): unknown {
+export function removeNullCharacters(obj: unknown): unknown {
   if (typeof obj === "string") {
     return obj.replace(/\0/g, "");
   }


### PR DESCRIPTION
It's possible for decoded values for `string` ABI parameters to contain null characters. Null characters are ignored by almost all software systems, except the postgres `TEXT` data type does not accept them ([context](https://www.commandprompt.com/blog/null-characters-workarounds-arent-good-enough)).

This PR removes null characters from all decoded ABI strings.

Fixes #1378 #1376