### PR TITLE
fix empty transaction hash in zksync

### DIFF
--- a/.changeset/orange-roses-enjoy.md
+++ b/.changeset/orange-roses-enjoy.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed an issue where ZKsync system logs with transaction receipts failed with the error `Detected inconsistent RPC responses. 'transaction.hash' 0x0000000000000000000000000000000000000000000000000000000000000000 not found in eth_getBlockReceipts response for block (...)`.

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -529,11 +529,21 @@ export const createHistoricalSync = async (
     if (shouldGetTransactionReceipt(filter)) {
       const transactionReceipts = await Promise.all(
         Array.from(requiredBlocks).map((blockHash) => {
-          const blockTransactionHashes = new Set(
-            logs
-              .filter((l) => l.blockHash === blockHash)
-              .map((l) => l.transactionHash),
-          );
+          const blockTransactionHashes = new Set<Hash>();
+
+          for (const log of logs) {
+            if (log.blockHash === blockHash) {
+              if (log.transactionHash === zeroHash) {
+                args.common.logger.warn({
+                  service: "sync",
+                  msg: `Detected log with empty transaction hash in block ${log.blockHash} at log index ${hexToNumber(log.logIndex)}. This is expected for some networks like ZKsync.`,
+                });
+              } else {
+                blockTransactionHashes.add(log.transactionHash);
+              }
+            }
+          }
+
           return syncTransactionReceipts(blockHash, blockTransactionHashes);
         }),
       ).then((receipts) => receipts.flat());

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -852,7 +852,8 @@ export const createSyncStore = ({
       const hasLog = row.log_id !== null;
       const hasTransaction = row.tx_hash !== null;
       const hasTrace = row.trace_id !== null;
-      const hasTransactionReceipt = shouldGetTransactionReceipt(filter);
+      const hasTransactionReceipt =
+        shouldGetTransactionReceipt(filter) && row.txr_from !== null;
 
       return {
         chainId: filter.chainId,

--- a/packages/core/src/sync/events.ts
+++ b/packages/core/src/sync/events.ts
@@ -236,11 +236,13 @@ export const buildEvents = ({
                         transactionCache.get(log.transactionHash)!,
                       )
                     : undefined,
-                  transactionReceipt: shouldGetTransactionReceipt(filter)
-                    ? convertTransactionReceipt(
-                        transactionReceiptCache.get(log.transactionHash)!,
-                      )
-                    : undefined,
+                  transactionReceipt:
+                    transactionReceiptCache.has(log.transactionHash) &&
+                    shouldGetTransactionReceipt(filter)
+                      ? convertTransactionReceipt(
+                          transactionReceiptCache.get(log.transactionHash)!,
+                        )
+                      : undefined,
                   trace: undefined,
                 });
               }

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -514,7 +514,6 @@ export const createSync = async (args: CreateSyncParameters): Promise<Sync> => {
               to: to < estimatedTo ? to : estimatedTo,
               limit: getEventsMaxBatchSize,
             });
-            consecutiveErrors = 0;
 
             args.common.logger.debug({
               service: "sync",
@@ -536,6 +535,7 @@ export const createSync = async (args: CreateSyncParameters): Promise<Sync> => {
               maxIncrease: 1.08,
             });
 
+            consecutiveErrors = 0;
             yield { events, checkpoint: to };
             from = cursor;
           } catch (error) {


### PR DESCRIPTION
Seems like we had a regression when merging #1342 and #1411 