### PR TITLE
sync-historical refactor: alternative algo

### DIFF
--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -712,12 +712,9 @@ export const createHistoricalSync = async (
 
                   for (const {
                     filter,
-                    interval,
                     fromChildAddresses,
                     toChildAddresses,
                   } of requiredTraceOrTransferIntervals) {
-                    if (interval[0] > number || interval[1] < number) continue;
-
                     if (
                       filter.type === "trace" &&
                       isTraceFilterMatched({


### PR DESCRIPTION
Relates to #1287. This pr suggest a different algo to lower the size of the memory cache stored during historicalSync.sync() by processing logFilters by interval and other filters blockwise removing the need for cache storage throughout the total interval period. 