### PR TITLE
fix: don't clear error stack

### DIFF
--- a/.changeset/clean-pears-argue.md
+++ b/.changeset/clean-pears-argue.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved logging for realtime sync errors.

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -1002,7 +1002,6 @@ export const createRealtimeSync = (
             if (isKilled) return;
 
             const error = _error as Error;
-            error.stack = undefined;
 
             args.common.logger.warn({
               service: "realtime",


### PR DESCRIPTION
I have an RPC causing errors, but only one of the two code paths for fetching block logs print the error properly, presumably because the `error.stack` is being unset?

```
caused by:
9:49:42 PM WARN  realtime   Retrying 'mainnet' sync after 1 second.
9:49:44 PM WARN  rpc        Failed eth_getLogs request
9:49:44 PM WARN  realtime   Failed to process 'mainnet' block 21682820

caused by:
9:49:44 PM WARN  realtime   Retrying 'mainnet' sync after 1 second.
9:49:46 PM WARN  rpc        Failed eth_getLogs request
9:49:46 PM WARN  realtime   Failed to process 'mainnet' block 21682820
```

```
9:49:24 PM WARN  rpc        Failed eth_getLogs request
9:49:24 PM WARN  realtime   Failed to fetch latest 'mainnet' block
RpcRequestError: RPC Request failed.

URL: https://ethereum-rpc.publicnode.com/{token}
Request body: {"method":"eth_getLogs","params":[{"blockHash":"0x7cce3b60dc32649b0cc85dce89f8cab0595e10f2eb5de001b4105b5a6b79c1c5"}]}

Details: Please specify an address in your request or, to remove restrictions, order a dedicated full node here: https://www.allnodes.com/eth/host
Version: viem@2.22.11
```