### PR TITLE
docs: update railway healthcheck timeout

### DIFF
--- a/docs/pages/0_6/docs/production/deploy.mdx
+++ b/docs/pages/0_6/docs/production/deploy.mdx
@@ -34,7 +34,7 @@ From the Railway console:
 1. Click **New Project** → **Deploy from GitHub repo** and select your repo from the list
 2. Click **Add variables**, then add RPC URLs (e.g. `PONDER_RPC_URL_1`) and other environment variables
 3. Create a public domain. In **Settings** → **Networking**, click **Generate Domain**
-4. Set the healthcheck path and timeout. In **Settings** → **Deploy**, set the **Healthcheck Path** to `/ready` and the **Healthcheck Timeout** to `86400` seconds (1 day)
+4. Set the healthcheck path and timeout. In **Settings** → **Deploy**, set the **Healthcheck Path** to `/ready` and the **Healthcheck Timeout** to `3600` seconds (1 hour)
 
 <Callout type="warning">
   _Monorepo users:_ Configure the **Root Directory** and **Start Command** such


### PR DESCRIPTION
Railway's maximum accepted healthcheck timeout is 1 hour (3600s), not 1 day (86400s)