### PR TITLE
fix: clarify subgraph deployment id, not subgraph id

### DIFF
--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -288,13 +288,13 @@ export async function run({
       const result = await prompts({
         type: "text",
         name: "id",
-        message: "Enter a subgraph ID",
+        message: "Enter a subgraph Deployment ID",
         initial: "Qmb3hd2hYd2nWFgcmRswykF1dUBSrDUrinYCgN1dmE1tNy",
       });
       subgraph = result.id;
     }
     if (!subgraph) {
-      log(pico.red("No subgraph ID provided."));
+      log(pico.red("No subgraph Deployment ID provided."));
       process.exit(0);
     }
   }


### PR DESCRIPTION
When trying to migrate from Uniswap V2 subgraph, got this error: 
<img width="919" alt="image" src="https://github.com/user-attachments/assets/0522879e-72d4-4161-831a-5f3e47367d93" />

Actually, we should use the Deployment ID, not the subgraph ID:
<img width="766" alt="image" src="https://github.com/user-attachments/assets/d14f9d3b-aa2d-43bb-8d16-62ffaa9be63c" />
