### PR TITLE
WIP: bigint array decode against postgres

### DIFF
--- a/.changeset/three-flowers-think.md
+++ b/.changeset/three-flowers-think.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug where `t.bigint().array()` column values greater than `Number.MAX_SAFE_INTEGER` would lose precision when using Postgres.

--- a/packages/core/src/graphql/index.test.ts
+++ b/packages/core/src/graphql/index.test.ts
@@ -11,8 +11,9 @@ import { type GraphQLType, execute, parse } from "graphql";
 import { beforeEach, expect, test, vi } from "vitest";
 import { buildDataLoaderCache, buildGraphQLSchema } from "./index.js";
 
+const BIGINT_MAX = 2n ** 256n - 1n;
 // https://github.com/ponder-sh/ponder/issues/1475#issuecomment-2625967710
-const LARGE_BIGINT =
+const BIGINT_LARGE =
   81043282338925483631878461732084420541800751556297842951124152226153187811344n;
 
 beforeEach(setupCommon);
@@ -135,14 +136,14 @@ test("scalar, scalar not null, scalar array, scalar array not null", async (cont
     floatArray: [0],
     booleanArray: [false],
     hexArray: ["0x0"],
-    bigintArray: [0n, LARGE_BIGINT],
+    bigintArray: [0n, BIGINT_LARGE, BIGINT_MAX],
 
     stringArrayNotNull: ["0"],
     intArrayNotNull: [0],
     floatArrayNotNull: [0],
     booleanArrayNotNull: [false],
     hexArrayNotNull: ["0x0"],
-    bigintArrayNotNull: [0n, LARGE_BIGINT],
+    bigintArrayNotNull: [0n, BIGINT_LARGE, BIGINT_MAX],
   });
 
   const graphqlSchema = buildGraphQLSchema({ schema });
@@ -207,14 +208,14 @@ test("scalar, scalar not null, scalar array, scalar array not null", async (cont
       floatArray: [0],
       booleanArray: [false],
       hexArray: ["0x00"],
-      bigintArray: ["0", LARGE_BIGINT.toString()],
+      bigintArray: ["0", BIGINT_LARGE.toString(), BIGINT_MAX.toString()],
 
       stringArrayNotNull: ["0"],
       intArrayNotNull: [0],
       floatArrayNotNull: [0],
       booleanArrayNotNull: [false],
       hexArrayNotNull: ["0x00"],
-      bigintArrayNotNull: ["0", LARGE_BIGINT.toString()],
+      bigintArrayNotNull: ["0", BIGINT_LARGE.toString(), BIGINT_MAX.toString()],
     },
   });
 

--- a/packages/core/src/graphql/index.test.ts
+++ b/packages/core/src/graphql/index.test.ts
@@ -11,6 +11,10 @@ import { type GraphQLType, execute, parse } from "graphql";
 import { beforeEach, expect, test, vi } from "vitest";
 import { buildDataLoaderCache, buildGraphQLSchema } from "./index.js";
 
+// https://github.com/ponder-sh/ponder/issues/1475#issuecomment-2625967710
+const LARGE_BIGINT =
+  81043282338925483631878461732084420541800751556297842951124152226153187811344n;
+
 beforeEach(setupCommon);
 beforeEach(setupIsolatedDatabase);
 
@@ -131,14 +135,14 @@ test("scalar, scalar not null, scalar array, scalar array not null", async (cont
     floatArray: [0],
     booleanArray: [false],
     hexArray: ["0x0"],
-    bigintArray: [0n],
+    bigintArray: [0n, LARGE_BIGINT],
 
     stringArrayNotNull: ["0"],
     intArrayNotNull: [0],
     floatArrayNotNull: [0],
     booleanArrayNotNull: [false],
     hexArrayNotNull: ["0x0"],
-    bigintArrayNotNull: [0n],
+    bigintArrayNotNull: [0n, LARGE_BIGINT],
   });
 
   const graphqlSchema = buildGraphQLSchema({ schema });
@@ -203,14 +207,14 @@ test("scalar, scalar not null, scalar array, scalar array not null", async (cont
       floatArray: [0],
       booleanArray: [false],
       hexArray: ["0x00"],
-      bigintArray: ["0"],
+      bigintArray: ["0", LARGE_BIGINT.toString()],
 
       stringArrayNotNull: ["0"],
       intArrayNotNull: [0],
       floatArrayNotNull: [0],
       booleanArrayNotNull: [false],
       hexArrayNotNull: ["0x00"],
-      bigintArrayNotNull: ["0"],
+      bigintArrayNotNull: ["0", LARGE_BIGINT.toString()],
     },
   });
 

--- a/packages/core/src/graphql/index.test.ts
+++ b/packages/core/src/graphql/index.test.ts
@@ -11,11 +11,6 @@ import { type GraphQLType, execute, parse } from "graphql";
 import { beforeEach, expect, test, vi } from "vitest";
 import { buildDataLoaderCache, buildGraphQLSchema } from "./index.js";
 
-const BIGINT_MAX = 2n ** 256n - 1n;
-// https://github.com/ponder-sh/ponder/issues/1475#issuecomment-2625967710
-const BIGINT_LARGE =
-  81043282338925483631878461732084420541800751556297842951124152226153187811344n;
-
 beforeEach(setupCommon);
 beforeEach(setupIsolatedDatabase);
 
@@ -136,14 +131,14 @@ test("scalar, scalar not null, scalar array, scalar array not null", async (cont
     floatArray: [0],
     booleanArray: [false],
     hexArray: ["0x0"],
-    bigintArray: [0n, BIGINT_LARGE, BIGINT_MAX],
+    bigintArray: [0n],
 
     stringArrayNotNull: ["0"],
     intArrayNotNull: [0],
     floatArrayNotNull: [0],
     booleanArrayNotNull: [false],
     hexArrayNotNull: ["0x0"],
-    bigintArrayNotNull: [0n, BIGINT_LARGE, BIGINT_MAX],
+    bigintArrayNotNull: [0n],
   });
 
   const graphqlSchema = buildGraphQLSchema({ schema });
@@ -208,14 +203,14 @@ test("scalar, scalar not null, scalar array, scalar array not null", async (cont
       floatArray: [0],
       booleanArray: [false],
       hexArray: ["0x00"],
-      bigintArray: ["0", BIGINT_LARGE.toString(), BIGINT_MAX.toString()],
+      bigintArray: ["0"],
 
       stringArrayNotNull: ["0"],
       intArrayNotNull: [0],
       floatArrayNotNull: [0],
       booleanArrayNotNull: [false],
       hexArrayNotNull: ["0x00"],
-      bigintArrayNotNull: ["0", BIGINT_LARGE.toString(), BIGINT_MAX.toString()],
+      bigintArrayNotNull: ["0"],
     },
   });
 

--- a/packages/core/src/utils/pg.ts
+++ b/packages/core/src/utils/pg.ts
@@ -2,6 +2,12 @@ import type { Logger } from "@/internal/logger.js";
 import pg, { type PoolConfig } from "pg";
 import { prettyPrint } from "./print.js";
 
+// The default parser for numeric[] (1231) seems to parse values as Number
+// or perhaps through JSON.parse(). Use the int8[] (1016) parser instead,
+// which properly returns an array of strings.
+const bigIntArrayParser = pg.types.getTypeParser(1016);
+pg.types.setTypeParser(1231, bigIntArrayParser);
+
 // Monkeypatch Pool.query to get more informative stack traces. I have no idea why this works.
 // https://stackoverflow.com/a/70601114
 const originalClientQuery = pg.Client.prototype.query;


### PR DESCRIPTION
closes #1475 

BigInt array parsing from the `node-postgres` driver, when pointed at actual postgres, parses bigint array values incorrectly iff they're above `MAX_SAFE_INTEGER`. This PR adds a failing test to demonstrate that behavior.

To reproduce, checkout the first or second commit on this PR. With `DATABASE_URL` **UNSET** in your `.env.local`, the tests will pass (`pnpm run --filter ponder test src/graphql/index.test.ts`) because it uses pglite. Set `DATABASE_URL` to a local postgres instance and rerun the tests — they will fail with:

```diff
      "bigintArray": Array [
        "0",
-       "81043282338925483631878461732084420541800751556297842951124152226153187811344",
+       "81043282338925488948964270414290117064232697336223238797682374271791829876736",
      ],
      "bigintArrayNotNull": Array [
        "0",
-       "81043282338925483631878461732084420541800751556297842951124152226153187811344",
+       "81043282338925488948964270414290117064232697336223238797682374271791829876736",
      ],
```

I've tracked this down to being the same issue as https://github.com/drizzle-team/drizzle-orm/issues/3106 but my knowledge of drizzle is not expansive enough to propose a fix.