### PR TITLE
chore: improve GraphQL enum not found error message

### DIFF
--- a/.changeset/good-pugs-appear.md
+++ b/.changeset/good-pugs-appear.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improve error message when forgetting to export enum from `ponder.schema.ts`.

--- a/packages/core/src/graphql/index.ts
+++ b/packages/core/src/graphql/index.ts
@@ -457,7 +457,7 @@ const columnToGraphQLCore = (
     const enumType = enumTypes[column.enum.enumName];
     if (enumType === undefined) {
       throw new Error(
-        `Internal error: Expected to find a GraphQL enum named "${column.enum.enumName}"`,
+        `Internal error: Expected to find a GraphQL enum named "${column.enum.enumName}". This may happen if "${column.enum.enumName}" has not been exported from your Ponder schema`,
       );
     }
 


### PR DESCRIPTION
This error is often thrown when an enum has not been exported from the Ponder schema. This PR updates the error message to make the fix more obvious.