### PR TITLE
fix: broken link in docs

### DIFF
--- a/docs/pages/docs/contracts-and-networks.mdx
+++ b/docs/pages/docs/contracts-and-networks.mdx
@@ -538,7 +538,7 @@ ponder.on("ERC20:Transfer", async ({ event }) => {
 
 The `includeCallTraces{:ts}` option specifies whether to enable call trace indexing for a contract. By default, call traces are **disabled**.
 
-After enabling this option, each function in the contract ABI will become available as an indexing function event name. [Read more](/docs/indexing/call-traces) about call traces.
+After enabling this option, each function in the contract ABI will become available as an indexing function event name. [Read more](/docs/call-traces) about call traces.
 
 <div className="code-columns">
 


### PR DESCRIPTION
Fixed broken link to Call Traces(/docs/call-traces) on Contracts & Networks page(/docs/contracts-and-networks).