### PR TITLE
fix: Cleanup spillover once insert/update are flushed to the cache

### DIFF
--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -423,6 +423,9 @@ export const createIndexingCache = ({
               operationIndex: totalCacheOps++,
               row: entry.row,
             });
+            // Clean the spillover for this entry since it's been added to the cache
+            spillover.get(table)!.delete(key);
+            spilloverBytes -= cacheBytes;
           }
           insertBuffer.get(table)!.clear();
 
@@ -473,6 +476,9 @@ export const createIndexingCache = ({
               operationIndex: totalCacheOps++,
               row: entry.row,
             });
+            // Clean the spillover for this entry since it's been added to the cache
+            spillover.get(table)!.delete(key);
+            spilloverBytes -= cacheBytes;
           }
           updateBuffer.get(table)!.clear();
 


### PR DESCRIPTION
Resolve: https://github.com/ponder-sh/ponder/issues/1535

Not sure it's the best approach, but since the newly updated value are stored in the main cache, it shouldn't impact performance of both `has` and `get` method on the internal cache + it provide the latest data via the `get`.