### PR TITLE
refactor cache metrics

### DIFF
--- a/.changeset/gold-dolls-sort.md
+++ b/.changeset/gold-dolls-sort.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Added `ponder_indexing_cache_access`, `ponder_indexing_cache_duration`, `ponder_indexing_store_count` and `ponder_indexing_store_raw_sql_duration` metrics.

--- a/.changeset/gold-dolls-sort.md
+++ b/.changeset/gold-dolls-sort.md
@@ -2,4 +2,4 @@
 "ponder": patch
 ---
 
-Added `ponder_indexing_cache_access`, `ponder_indexing_cache_duration`, `ponder_indexing_store_count` and `ponder_indexing_store_raw_sql_duration` metrics.
+Added `ponder_indexing_cache_requests_total`, `ponder_indexing_cache_query_duration`, `ponder_indexing_store_queries_total` and `ponder_indexing_store_raw_sql_duration` metrics.

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -77,7 +77,6 @@ export async function run({
 
   const indexingCache = createIndexingCache({
     common,
-    database,
     schemaBuild,
     checkpoint: initialCheckpoint,
   });
@@ -121,7 +120,6 @@ export async function run({
         const historicalIndexingStore = createHistoricalIndexingStore({
           common,
           schemaBuild,
-          database,
           indexingCache,
           db: tx,
           client,
@@ -147,7 +145,6 @@ export async function run({
             const historicalIndexingStore = createHistoricalIndexingStore({
               common,
               schemaBuild,
-              database,
               indexingCache,
               db: tx,
               client,

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -2,11 +2,7 @@ import { randomUUID } from "node:crypto";
 import { getPrimaryKeyColumns, getTableNames } from "@/drizzle/index.js";
 import { getColumnCasing, getReorgTable } from "@/drizzle/kit/index.js";
 import type { Common } from "@/internal/common.js";
-import {
-  FlushError,
-  NonRetryableError,
-  ShutdownError,
-} from "@/internal/errors.js";
+import { NonRetryableError, ShutdownError } from "@/internal/errors.js";
 import type {
   IndexingBuild,
   NamespaceBuild,
@@ -490,13 +486,11 @@ export const createDatabase = async ({
           method: options.method,
         });
 
-        if (error instanceof FlushError === false) {
-          common.logger.warn({
-            service: "database",
-            msg: `Failed '${options.method}' database method (id=${id})`,
-            error,
-          });
-        }
+        common.logger.warn({
+          service: "database",
+          msg: `Failed '${options.method}' database method (id=${id})`,
+          error,
+        });
 
         throw error;
       } finally {
@@ -1247,7 +1241,7 @@ FOR EACH ROW EXECUTE FUNCTION "${namespace}".${getTableNames(table).triggerFn};
       );
     },
     getStatus() {
-      return this.wrap({ method: "_ponder_status.get()" }, async () => {
+      return this.wrap({ method: "getStatus" }, async () => {
         const result = await this.qb.drizzle.select().from(PONDER_STATUS);
 
         if (result.length === 0) {
@@ -1273,7 +1267,7 @@ FOR EACH ROW EXECUTE FUNCTION "${namespace}".${getTableNames(table).triggerFn};
       });
     },
     setStatus(status) {
-      return this.wrap({ method: "_ponder_status.set()" }, async () => {
+      return this.wrap({ method: "setStatus" }, async () => {
         await this.qb.drizzle
           .insert(PONDER_STATUS)
           .values(

--- a/packages/core/src/indexing-store/cache.test.ts
+++ b/packages/core/src/indexing-store/cache.test.ts
@@ -29,7 +29,6 @@ test("flush() insert", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -37,7 +36,6 @@ test("flush() insert", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -76,7 +74,6 @@ test("flush() update", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -84,7 +81,7 @@ test("flush() update", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
+
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -144,7 +141,6 @@ test("flush() encoding", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -152,7 +148,6 @@ test("flush() encoding", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -208,7 +203,6 @@ test("flush() encoding escape", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -216,7 +210,6 @@ test("flush() encoding escape", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -420,7 +420,7 @@ export const createIndexingCache = ({
         updateBuffer.get(table)!.get(ck) ?? insertBuffer.get(table)!.get(ck);
 
       if (bufferEntry) {
-        common.metrics.ponder_indexing_cache_access.inc({
+        common.metrics.ponder_indexing_cache_requests_total.inc({
           table: getTableName(table),
           type: "hit",
         });
@@ -433,7 +433,7 @@ export const createIndexingCache = ({
         entry.operationIndex = totalCacheOps++;
 
         if (entry.row) {
-          common.metrics.ponder_indexing_cache_access.inc({
+          common.metrics.ponder_indexing_cache_requests_total.inc({
             table: getTableName(table),
             type: "hit",
           });
@@ -442,14 +442,14 @@ export const createIndexingCache = ({
       }
 
       if (isCacheComplete) {
-        common.metrics.ponder_indexing_cache_access.inc({
+        common.metrics.ponder_indexing_cache_requests_total.inc({
           table: getTableName(table),
           type: "hit",
         });
         return null;
       }
 
-      common.metrics.ponder_indexing_cache_access.inc({
+      common.metrics.ponder_indexing_cache_requests_total.inc({
         table: getTableName(table),
         type: "miss",
       });
@@ -473,7 +473,7 @@ export const createIndexingCache = ({
           return row;
         });
 
-      common.metrics.ponder_indexing_cache_duration.observe(
+      common.metrics.ponder_indexing_cache_query_duration.observe(
         {
           table: getTableName(table),
           method: "find",
@@ -599,7 +599,7 @@ export const createIndexingCache = ({
             throw new FlushError(error.message);
           });
 
-          common.metrics.ponder_indexing_cache_duration.observe(
+          common.metrics.ponder_indexing_cache_query_duration.observe(
             {
               table: getTableName(table),
               method: "flush",
@@ -711,7 +711,7 @@ export const createIndexingCache = ({
           // @ts-ignore
           await client.query(updateQuery);
 
-          common.metrics.ponder_indexing_cache_duration.observe(
+          common.metrics.ponder_indexing_cache_query_duration.observe(
             {
               table: getTableName(table),
               method: "flush",

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -1,6 +1,5 @@
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import type { Database } from "@/database/index.js";
 import { getPrimaryKeyColumns } from "@/drizzle/index.js";
 import { getColumnCasing } from "@/drizzle/kit/index.js";
 import { addErrorMeta } from "@/indexing/index.js";
@@ -15,6 +14,7 @@ import type { Event, Schema, SchemaBuild } from "@/internal/types.js";
 import type { Drizzle } from "@/types/db.js";
 import { ZERO_CHECKPOINT_STRING } from "@/utils/checkpoint.js";
 import { prettyPrint } from "@/utils/print.js";
+import { startClock } from "@/utils/timer.js";
 import { PGlite } from "@electric-sql/pglite";
 import {
   type Column,
@@ -357,12 +357,10 @@ export const recoverBatchError = async <T>(
 
 export const createIndexingCache = ({
   common,
-  database,
   schemaBuild: { schema },
   checkpoint,
 }: {
   common: Common;
-  database: Database;
   schemaBuild: Pick<SchemaBuild, "schema">;
   checkpoint: string;
 }): IndexingCache => {
@@ -414,7 +412,7 @@ export const createIndexingCache = ({
         updateBuffer.get(table)!.has(ck)
       );
     },
-    get({ table, key, db }) {
+    async get({ table, key, db }) {
       const ck = getCacheKey(table, key, primaryKeyCache);
       // Note: order is important, it is an invariant that update entries
       // are prioritized over insert entries
@@ -422,7 +420,10 @@ export const createIndexingCache = ({
         updateBuffer.get(table)!.get(ck) ?? insertBuffer.get(table)!.get(ck);
 
       if (bufferEntry) {
-        common.metrics.ponder_indexing_cache_hit.inc();
+        common.metrics.ponder_indexing_cache_access.inc({
+          table: getTableName(table),
+          type: "hit",
+        });
         return structuredClone(bufferEntry.row);
       }
 
@@ -432,31 +433,34 @@ export const createIndexingCache = ({
         entry.operationIndex = totalCacheOps++;
 
         if (entry.row) {
-          common.metrics.ponder_indexing_cache_hit.inc();
+          common.metrics.ponder_indexing_cache_access.inc({
+            table: getTableName(table),
+            type: "hit",
+          });
           return structuredClone(entry.row);
         }
       }
 
       if (isCacheComplete) {
-        common.metrics.ponder_indexing_cache_hit.inc();
+        common.metrics.ponder_indexing_cache_access.inc({
+          table: getTableName(table),
+          type: "hit",
+        });
         return null;
       }
 
-      common.metrics.ponder_indexing_cache_miss.inc();
+      common.metrics.ponder_indexing_cache_access.inc({
+        table: getTableName(table),
+        type: "miss",
+      });
 
-      return database
-        .record(
-          {
-            method: `${getTableName(table) ?? "unknown"}.cache.find()`,
-          },
-          async () => {
-            return db
-              .select()
-              .from(table)
-              .where(getWhereCondition(table, key))
-              .then((res) => (res.length === 0 ? null : res[0]!));
-          },
-        )
+      const endClock = startClock();
+
+      const result = await db
+        .select()
+        .from(table)
+        .where(getWhereCondition(table, key))
+        .then((res) => (res.length === 0 ? null : res[0]!))
         .then((row) => {
           const bytes = getBytes(row);
           spilloverBytes += bytes;
@@ -468,6 +472,16 @@ export const createIndexingCache = ({
           });
           return row;
         });
+
+      common.metrics.ponder_indexing_cache_duration.observe(
+        {
+          table: getTableName(table),
+          method: "find",
+        },
+        endClock(),
+      );
+
+      return result;
     },
     set({ table, key, row: _row, isUpdate, metadata }) {
       const row = normalizeRow(table, _row, isUpdate);
@@ -536,56 +550,61 @@ export const createIndexingCache = ({
             insertValues.map(({ row }) => row),
           );
 
-          await database.record(
-            { method: `${getTableName(table)}.flush()` },
-            async () => {
-              // @ts-ignore
-              await client.query("SAVEPOINT flush");
-              await copy(table, text).catch(async (error) => {
-                console.error(error);
-                const result = await recoverBatchError(
-                  insertValues,
-                  async (values) => {
-                    // @ts-ignore
-                    await client.query("ROLLBACK to flush");
-                    const text = getCopyText(
-                      table,
-                      values.map(({ row }) => row),
-                    );
-                    await copy(table, text);
-                    // @ts-ignore
-                    await client.query("SAVEPOINT flush");
-                  },
-                );
+          const endClock = startClock();
 
-                if (result.status === "success") {
-                  return;
-                }
-
-                // Note: rollback so that the connection is available for other queries
+          // @ts-ignore
+          await client.query("SAVEPOINT flush");
+          await copy(table, text).catch(async (error) => {
+            console.error(error);
+            const result = await recoverBatchError(
+              insertValues,
+              async (values) => {
                 // @ts-ignore
                 await client.query("ROLLBACK to flush");
+                const text = getCopyText(
+                  table,
+                  values.map(({ row }) => row),
+                );
+                await copy(table, text);
+                // @ts-ignore
+                await client.query("SAVEPOINT flush");
+              },
+            );
 
-                error = parseSqlError(result.error);
-                error.stack = undefined;
+            if (result.status === "success") {
+              return;
+            }
 
-                if (result.value.metadata.event) {
-                  addErrorMeta(
-                    error,
-                    `db.insert arguments:\n${prettyPrint(result.value.row)}`,
-                  );
-                  addErrorMeta(error, toErrorMeta(result.value.metadata.event));
-                  common.logger.error({
-                    service: "indexing",
-                    msg: `Error while processing ${getTableName(
-                      table,
-                    )}.insert() in event '${result.value.metadata.event.name}'`,
-                    error,
-                  });
-                }
-                throw new FlushError(error.message);
+            // Note: rollback so that the connection is available for other queries
+            // @ts-ignore
+            await client.query("ROLLBACK to flush");
+
+            error = parseSqlError(result.error);
+            error.stack = undefined;
+
+            if (result.value.metadata.event) {
+              addErrorMeta(
+                error,
+                `db.insert arguments:\n${prettyPrint(result.value.row)}`,
+              );
+              addErrorMeta(error, toErrorMeta(result.value.metadata.event));
+              common.logger.error({
+                service: "indexing",
+                msg: `Error while processing ${getTableName(
+                  table,
+                )}.insert() in event '${result.value.metadata.event.name}'`,
+                error,
               });
+            }
+            throw new FlushError(error.message);
+          });
+
+          common.metrics.ponder_indexing_cache_duration.observe(
+            {
+              table: getTableName(table),
+              method: "flush",
             },
+            endClock(),
           );
 
           for (const [key, entry] of insertBuffer.get(table)!) {
@@ -648,51 +667,56 @@ export const createIndexingCache = ({
             updateValues.map(({ row }) => row),
           );
 
-          await database.record(
-            { method: `${getTableName(table)}.flush()` },
-            async () => {
-              // @ts-ignore
-              await client.query(createTempTableQuery);
-              // @ts-ignore
-              await client.query("SAVEPOINT flush");
-              await copy(table, text, false).catch(async (error) => {
-                console.error(error);
-                const result = await recoverBatchError(
-                  updateValues,
-                  async (values) => {
-                    // @ts-ignore
-                    await client.query("ROLLBACK to flush");
-                    const text = getCopyText(
-                      table,
-                      values.map(({ row }) => row),
-                    );
-                    await copy(table, text, false);
-                    // @ts-ignore
-                    await client.query("SAVEPOINT flush");
-                  },
-                );
+          const endClock = startClock();
 
-                if (result.status === "success") {
-                  return;
-                }
-
-                // Note: rollback so that the connection is available for other queries
+          // @ts-ignore
+          await client.query(createTempTableQuery);
+          // @ts-ignore
+          await client.query("SAVEPOINT flush");
+          await copy(table, text, false).catch(async (error) => {
+            console.error(error);
+            const result = await recoverBatchError(
+              updateValues,
+              async (values) => {
                 // @ts-ignore
                 await client.query("ROLLBACK to flush");
-
-                error = parseSqlError(result.error);
-                error.stack = undefined;
-
-                addErrorMeta(
-                  error,
-                  `db.update arguments:\n${prettyPrint(result.value.row)}`,
+                const text = getCopyText(
+                  table,
+                  values.map(({ row }) => row),
                 );
+                await copy(table, text, false);
+                // @ts-ignore
+                await client.query("SAVEPOINT flush");
+              },
+            );
 
-                throw error;
-              });
-              // @ts-ignore
-              await client.query(updateQuery);
+            if (result.status === "success") {
+              return;
+            }
+
+            // Note: rollback so that the connection is available for other queries
+            // @ts-ignore
+            await client.query("ROLLBACK to flush");
+
+            error = parseSqlError(result.error);
+            error.stack = undefined;
+
+            addErrorMeta(
+              error,
+              `db.update arguments:\n${prettyPrint(result.value.row)}`,
+            );
+
+            throw error;
+          });
+          // @ts-ignore
+          await client.query(updateQuery);
+
+          common.metrics.ponder_indexing_cache_duration.observe(
+            {
+              table: getTableName(table),
+              method: "flush",
             },
+            endClock(),
           );
 
           for (const [key, entry] of updateBuffer.get(table)!) {

--- a/packages/core/src/indexing-store/historical.test.ts
+++ b/packages/core/src/indexing-store/historical.test.ts
@@ -36,7 +36,6 @@ test("find", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -45,7 +44,6 @@ test("find", async (context) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
       schemaBuild: { schema },
-      database,
       indexingCache,
       db: tx,
       client,
@@ -96,7 +94,6 @@ test("insert", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -104,7 +101,6 @@ test("insert", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -252,7 +248,6 @@ test("update", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -260,7 +255,6 @@ test("update", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -347,7 +341,6 @@ test("delete", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -355,7 +348,6 @@ test("delete", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -404,7 +396,6 @@ test("sql", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -412,7 +403,6 @@ test("sql", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -489,7 +479,6 @@ test("sql followed by find", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -497,7 +486,6 @@ test("sql followed by find", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -531,7 +519,6 @@ test("onchain table", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -539,7 +526,6 @@ test("onchain table", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -569,7 +555,6 @@ test("missing rows", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -577,7 +562,6 @@ test("missing rows", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -608,7 +592,6 @@ test("notNull", async (context) => {
 
   let indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -616,7 +599,6 @@ test("notNull", async (context) => {
   await database.transaction(async (client, tx) => {
     let indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -659,14 +641,12 @@ test("notNull", async (context) => {
 
     indexingCache = createIndexingCache({
       common: context.common,
-      database,
       schemaBuild: { schema },
       checkpoint: ZERO_CHECKPOINT_STRING,
     });
 
     indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -701,7 +681,6 @@ test("default", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -709,7 +688,7 @@ test("default", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
+
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -738,7 +717,6 @@ test("$default", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -746,7 +724,7 @@ test("$default", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
+
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -778,7 +756,6 @@ test("$onUpdateFn", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -786,7 +763,7 @@ test("$onUpdateFn", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
+
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -821,7 +798,6 @@ test("array", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -829,7 +805,7 @@ test("array", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
+
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -866,7 +842,6 @@ test("text array", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -874,7 +849,6 @@ test("text array", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -917,7 +891,6 @@ test("enum", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -925,7 +898,6 @@ test("enum", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,
@@ -962,7 +934,6 @@ test("json bigint", async (context) => {
 
   const indexingCache = createIndexingCache({
     common: context.common,
-    database,
     schemaBuild: { schema },
     checkpoint: ZERO_CHECKPOINT_STRING,
   });
@@ -970,7 +941,6 @@ test("json bigint", async (context) => {
   await database.transaction(async (client, tx) => {
     const indexingStore = createHistoricalIndexingStore({
       common: context.common,
-      database,
       schemaBuild: { schema },
       indexingCache,
       db: tx,

--- a/packages/core/src/indexing-store/historical.test.ts
+++ b/packages/core/src/indexing-store/historical.test.ts
@@ -435,16 +435,14 @@ test("sql", async (context) => {
     // @ts-ignore
     await client.query("SAVEPOINT test");
 
-    // @ts-ignore
-    let error = await indexingStore.sql
-      .insert(schema.account)
-      .values({
-        address: "0x0000000000000000000000000000000000000001",
-        balance: undefined,
-      })
-      .catch((error) => error);
-
-    expect(error).instanceOf(NotNullConstraintError);
+    await expect(
+      async () =>
+        // @ts-ignore
+        await indexingStore.sql.insert(schema.account).values({
+          address: "0x0000000000000000000000000000000000000001",
+          balance: undefined,
+        }),
+    ).rejects.toThrowError(NotNullConstraintError);
 
     // TODO(kyle) check constraint
 
@@ -453,15 +451,12 @@ test("sql", async (context) => {
     // @ts-ignore
     await client.query("ROLLBACK TO test");
 
-    error = await indexingStore.sql
-      .insert(schema.account)
-      .values({
-        address: zeroAddress,
-        balance: 10n,
-      })
-      .catch((error) => error);
-
-    expect(error).instanceOf(UniqueConstraintError);
+    await expect(
+      async () =>
+        await indexingStore.sql
+          .insert(schema.account)
+          .values({ address: zeroAddress, balance: 10n }),
+    ).rejects.toThrowError(UniqueConstraintError);
   });
 });
 
@@ -534,12 +529,11 @@ test("onchain table", async (context) => {
 
     // check error
 
-    const error = await indexingStore
-      // @ts-ignore
-      .find(schema.account, { address: zeroAddress })
-      .catch((error) => error);
-
-    expect(error).toBeDefined();
+    expect(() =>
+      indexingStore
+        // @ts-ignore
+        .find(schema.account, { address: zeroAddress }),
+    ).toThrow();
   });
 });
 
@@ -570,13 +564,13 @@ test("missing rows", async (context) => {
 
     // error
 
-    const error = await indexingStore
-      .insert(schema.account)
-      // @ts-ignore
-      .values({ address: zeroAddress })
-      .catch((error) => error);
-
-    expect(error).toBeDefined();
+    await expect(
+      async () =>
+        await indexingStore
+          .insert(schema.account)
+          // @ts-ignore
+          .values({ address: zeroAddress }),
+    ).rejects.toThrow();
   });
 });
 
@@ -653,19 +647,19 @@ test("notNull", async (context) => {
       client,
     });
 
-    let error = await indexingStore
-      .insert(schema.account)
-      .values({ address: zeroAddress })
-      .catch((error) => error);
+    await expect(
+      async () =>
+        await indexingStore
+          .insert(schema.account)
+          .values({ address: zeroAddress }),
+    ).rejects.toThrow();
 
-    expect(error).toBeDefined();
-
-    error = await indexingStore
-      .insert(schema.account)
-      .values({ address: zeroAddress, balance: null })
-      .catch((error) => error);
-
-    expect(error).toBeDefined();
+    await expect(
+      async () =>
+        await indexingStore
+          .insert(schema.account)
+          .values({ address: zeroAddress, balance: null }),
+    ).rejects.toThrow();
   });
 });
 
@@ -947,16 +941,11 @@ test("json bigint", async (context) => {
       client,
     });
 
-    const error = await indexingStore
-      .insert(schema.account)
-      .values({
-        address: zeroAddress,
-        metadata: {
-          balance: 10n,
-        },
-      })
-      .catch((error) => error);
-
-    expect(error).toBeInstanceOf(BigIntSerializationError);
+    await expect(
+      async () =>
+        await indexingStore
+          .insert(schema.account)
+          .values({ address: zeroAddress, metadata: { balance: 10n } }),
+    ).rejects.toThrowError(BigIntSerializationError);
   });
 });

--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -1,12 +1,9 @@
-import type { Database } from "@/database/index.js";
 import type { Common } from "@/internal/common.js";
-import {
-  RecordNotFoundError,
-  UniqueConstraintError,
-} from "@/internal/errors.js";
+import { RecordNotFoundError } from "@/internal/errors.js";
 import type { Event, Schema, SchemaBuild } from "@/internal/types.js";
 import type { Drizzle } from "@/types/db.js";
 import { prettyPrint } from "@/utils/print.js";
+import { startClock } from "@/utils/timer.js";
 import type { PGlite } from "@electric-sql/pglite";
 import { type QueryWithTypings, type Table, getTableName } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pg-proxy";
@@ -19,14 +16,13 @@ import {
 } from "./index.js";
 
 export const createHistoricalIndexingStore = ({
-  database,
+  common,
   schemaBuild: { schema },
   indexingCache,
   db,
   client,
 }: {
   common: Common;
-  database: Database;
   schemaBuild: Pick<SchemaBuild, "schema">;
   indexingCache: IndexingCache;
   db: Drizzle<Schema>;
@@ -36,236 +32,198 @@ export const createHistoricalIndexingStore = ({
 
   return {
     // @ts-ignore
-    find: (table: Table, key) =>
-      database.record(
-        {
-          method: `${getTableName(table) ?? "unknown"}.find()`,
-        },
-        async () => {
-          checkOnchainTable(table, "find");
-          return indexingCache.get({ table, key, db });
-        },
-      ),
+    find: (table: Table, key) => {
+      common.metrics.ponder_indexing_store_count.inc({
+        table: getTableName(table),
+        method: "find",
+      });
+      checkOnchainTable(table, "find");
+      return indexingCache.get({ table, key, db });
+    },
+
     // @ts-ignore
     insert(table: Table) {
       return {
         values: (values: any) => {
           // @ts-ignore
           const inner = {
-            onConflictDoNothing: () =>
-              database.record(
-                {
-                  method: `${getTableName(table) ?? "unknown"}.insert()`,
-                },
-                async () => {
-                  checkOnchainTable(table, "insert");
+            onConflictDoNothing: async () => {
+              common.metrics.ponder_indexing_store_count.inc({
+                table: getTableName(table),
+                method: "insert",
+              });
+              checkOnchainTable(table, "insert");
 
-                  if (Array.isArray(values)) {
-                    const rows = [];
-                    for (const value of values) {
-                      const row = await indexingCache.get({
+              if (Array.isArray(values)) {
+                const rows = [];
+                for (const value of values) {
+                  const row = await indexingCache.get({
+                    table,
+                    key: value,
+                    db,
+                  });
+
+                  if (row) {
+                    rows.push(null);
+                  } else {
+                    rows.push(
+                      indexingCache.set({
                         table,
                         key: value,
-                        db,
-                      });
-
-                      if (row) {
-                        rows.push(null);
-                      } else {
-                        rows.push(
-                          indexingCache.set({
-                            table,
-                            key: value,
-                            row: value,
-                            isUpdate: false,
-                            metadata: { event },
-                          }),
-                        );
-                      }
-                    }
-                    return rows;
-                  } else {
-                    const row = await indexingCache.get({
-                      table,
-                      key: values,
-                      db,
-                    });
-
-                    if (row) {
-                      return null;
-                    }
-
-                    return indexingCache.set({
-                      table,
-                      key: values,
-                      row: values,
-                      isUpdate: false,
-                      metadata: { event },
-                    });
+                        row: value,
+                        isUpdate: false,
+                        metadata: { event },
+                      }),
+                    );
                   }
-                },
-              ),
-            onConflictDoUpdate: (valuesU: any) =>
-              database.record(
-                {
-                  method: `${getTableName(table) ?? "unknown"}.insert()`,
-                },
-                async () => {
-                  checkOnchainTable(table, "insert");
+                }
+                return rows;
+              } else {
+                const row = await indexingCache.get({
+                  table,
+                  key: values,
+                  db,
+                });
 
-                  if (Array.isArray(values)) {
-                    const rows = [];
-                    for (const value of values) {
-                      const row = await indexingCache.get({
-                        table,
-                        key: value,
-                        db,
-                      });
+                if (row) {
+                  return null;
+                }
 
-                      if (row) {
-                        if (typeof valuesU === "function") {
-                          for (const [key, value] of Object.entries(
-                            valuesU(row),
-                          )) {
-                            if (value === undefined) continue;
-                            row[key] = value;
-                          }
-                        } else {
-                          for (const [key, value] of Object.entries(valuesU)) {
-                            if (value === undefined) continue;
-                            row[key] = value;
-                          }
-                        }
-                        rows.push(
-                          indexingCache.set({
-                            table,
-                            key: value,
-                            row,
-                            isUpdate: true,
-                            metadata: { event },
-                          }),
-                        );
-                      } else {
-                        rows.push(
-                          indexingCache.set({
-                            table,
-                            key: value,
-                            row: value,
-                            isUpdate: false,
-                            metadata: { event },
-                          }),
-                        );
+                return indexingCache.set({
+                  table,
+                  key: values,
+                  row: values,
+                  isUpdate: false,
+                  metadata: { event },
+                });
+              }
+            },
+            onConflictDoUpdate: async (valuesU: any) => {
+              common.metrics.ponder_indexing_store_count.inc({
+                table: getTableName(table),
+                method: "insert",
+              });
+              checkOnchainTable(table, "insert");
+
+              if (Array.isArray(values)) {
+                const rows = [];
+                for (const value of values) {
+                  const row = await indexingCache.get({
+                    table,
+                    key: value,
+                    db,
+                  });
+
+                  if (row) {
+                    if (typeof valuesU === "function") {
+                      for (const [key, value] of Object.entries(valuesU(row))) {
+                        if (value === undefined) continue;
+                        row[key] = value;
+                      }
+                    } else {
+                      for (const [key, value] of Object.entries(valuesU)) {
+                        if (value === undefined) continue;
+                        row[key] = value;
                       }
                     }
-                    return rows;
-                  } else {
-                    const row = await indexingCache.get({
-                      table,
-                      key: values,
-                      db,
-                    });
-
-                    if (row) {
-                      if (typeof valuesU === "function") {
-                        for (const [key, value] of Object.entries(
-                          valuesU(row),
-                        )) {
-                          if (value === undefined) continue;
-                          row[key] = value;
-                        }
-                      } else {
-                        for (const [key, value] of Object.entries(valuesU)) {
-                          if (value === undefined) continue;
-                          row[key] = value;
-                        }
-                      }
-                      return indexingCache.set({
+                    rows.push(
+                      indexingCache.set({
                         table,
-                        key: values,
+                        key: value,
                         row,
                         isUpdate: true,
                         metadata: { event },
-                      });
-                    }
-
-                    return indexingCache.set({
-                      table,
-                      key: values,
-                      row: values,
-                      isUpdate: false,
-                      metadata: { event },
-                    });
-                  }
-                },
-              ),
-            // biome-ignore lint/suspicious/noThenProperty: <explanation>
-            then: (onFulfilled, onRejected) =>
-              database
-                .record(
-                  {
-                    method: `${getTableName(table) ?? "unknown"}.insert()`,
-                  },
-                  async () => {
-                    checkOnchainTable(table, "insert");
-
-                    if (Array.isArray(values)) {
-                      const rows = [];
-                      for (const value of values) {
-                        // Note: optimistic assumption that no conflict exists
-                        // because error is recovered at flush time
-
-                        if (
-                          indexingCache.has({ table, key: value }) &&
-                          indexingCache.get({ table, key: value, db })
-                        ) {
-                          const error = new UniqueConstraintError(
-                            `Unique constraint failed for '${getTableName(table)}'.`,
-                          );
-                          error.meta.push(
-                            `db.insert arguments:\n${prettyPrint(value)}`,
-                          );
-                          throw error;
-                        }
-
-                        rows.push(
-                          indexingCache.set({
-                            table,
-                            key: value,
-                            row: value,
-                            isUpdate: false,
-                            metadata: { event },
-                          }),
-                        );
-                      }
-                      return rows;
-                    } else {
-                      // Note: optimistic assumption that no conflict exists
-                      // because error is recovered at flush time
-
-                      if (
-                        indexingCache.has({ table, key: values }) &&
-                        indexingCache.get({ table, key: values, db })
-                      ) {
-                        const error = new UniqueConstraintError(
-                          `Unique constraint failed for '${getTableName(table)}'.`,
-                        );
-                        error.meta.push(
-                          `db.insert arguments:\n${prettyPrint(values)}`,
-                        );
-                        throw error;
-                      }
-
-                      return indexingCache.set({
+                      }),
+                    );
+                  } else {
+                    rows.push(
+                      indexingCache.set({
                         table,
-                        key: values,
-                        row: values,
+                        key: value,
+                        row: value,
                         isUpdate: false,
                         metadata: { event },
-                      });
+                      }),
+                    );
+                  }
+                }
+                return rows;
+              } else {
+                const row = await indexingCache.get({
+                  table,
+                  key: values,
+                  db,
+                });
+
+                if (row) {
+                  if (typeof valuesU === "function") {
+                    for (const [key, value] of Object.entries(valuesU(row))) {
+                      if (value === undefined) continue;
+                      row[key] = value;
                     }
-                  },
-                )
-                .then(onFulfilled, onRejected),
+                  } else {
+                    for (const [key, value] of Object.entries(valuesU)) {
+                      if (value === undefined) continue;
+                      row[key] = value;
+                    }
+                  }
+                  return indexingCache.set({
+                    table,
+                    key: values,
+                    row,
+                    isUpdate: true,
+                    metadata: { event },
+                  });
+                }
+
+                return indexingCache.set({
+                  table,
+                  key: values,
+                  row: values,
+                  isUpdate: false,
+                  metadata: { event },
+                });
+              }
+            },
+            // biome-ignore lint/suspicious/noThenProperty: <explanation>
+            then: (onFulfilled, onRejected) => {
+              common.metrics.ponder_indexing_store_count.inc({
+                table: getTableName(table),
+                method: "insert",
+              });
+              checkOnchainTable(table, "insert");
+
+              if (Array.isArray(values)) {
+                const rows = [];
+                for (const value of values) {
+                  // Note: optimistic assumption that no conflict exists
+                  // because error is recovered at flush time
+
+                  rows.push(
+                    indexingCache.set({
+                      table,
+                      key: value,
+                      row: value,
+                      isUpdate: false,
+                      metadata: { event },
+                    }),
+                  );
+                }
+                return Promise.resolve(rows).then(onFulfilled, onRejected);
+              } else {
+                // Note: optimistic assumption that no conflict exists
+                // because error is recovered at flush time
+
+                const result = indexingCache.set({
+                  table,
+                  key: values,
+                  row: values,
+                  isUpdate: false,
+                  metadata: { event },
+                });
+                return Promise.resolve(result).then(onFulfilled, onRejected);
+              }
+            },
             catch: (onRejected) => inner.then(undefined, onRejected),
             finally: (onFinally) =>
               inner.then(
@@ -288,58 +246,54 @@ export const createHistoricalIndexingStore = ({
     // @ts-ignore
     update(table: Table, key) {
       return {
-        set: (values: any) =>
-          database.record(
-            {
-              method: `${getTableName(table) ?? "unknown"}.update()`,
-            },
-            async () => {
-              checkOnchainTable(table, "update");
+        set: async (values: any) => {
+          common.metrics.ponder_indexing_store_count.inc({
+            table: getTableName(table),
+            method: "update",
+          });
+          checkOnchainTable(table, "update");
 
-              const row = await indexingCache.get({ table, key, db });
+          const row = await indexingCache.get({ table, key, db });
 
-              if (row === null) {
-                const error = new RecordNotFoundError(
-                  `No existing record found in table '${getTableName(table)}'`,
-                );
-                error.meta.push(`db.update arguments:\n${prettyPrint(key)}`);
-                throw error;
-              }
+          if (row === null) {
+            const error = new RecordNotFoundError(
+              `No existing record found in table '${getTableName(table)}'`,
+            );
+            error.meta.push(`db.update arguments:\n${prettyPrint(key)}`);
+            throw error;
+          }
 
-              if (typeof values === "function") {
-                for (const [key, value] of Object.entries(values(row))) {
-                  if (value === undefined) continue;
-                  row[key] = value;
-                }
-              } else {
-                for (const [key, value] of Object.entries(values)) {
-                  if (value === undefined) continue;
-                  row[key] = value;
-                }
-              }
+          if (typeof values === "function") {
+            for (const [key, value] of Object.entries(values(row))) {
+              if (value === undefined) continue;
+              row[key] = value;
+            }
+          } else {
+            for (const [key, value] of Object.entries(values)) {
+              if (value === undefined) continue;
+              row[key] = value;
+            }
+          }
 
-              return indexingCache.set({
-                table,
-                key,
-                row,
-                isUpdate: true,
-                metadata: { event },
-              });
-            },
-          ),
+          return indexingCache.set({
+            table,
+            key,
+            row,
+            isUpdate: true,
+            metadata: { event },
+          });
+        },
       };
     },
     // @ts-ignore
-    delete: (table: Table, key) =>
-      database.record(
-        {
-          method: `${getTableName(table) ?? "unknown"}.delete()`,
-        },
-        async () => {
-          checkOnchainTable(table, "delete");
-          return indexingCache.delete({ table, key, db });
-        },
-      ),
+    delete: async (table: Table, key) => {
+      common.metrics.ponder_indexing_store_count.inc({
+        table: getTableName(table),
+        method: "delete",
+      });
+      checkOnchainTable(table, "delete");
+      return indexingCache.delete({ table, key, db });
+    },
     // @ts-ignore
     sql: drizzle(
       async (_sql, params, method, typings) => {
@@ -347,19 +301,21 @@ export const createHistoricalIndexingStore = ({
         indexingCache.invalidate();
 
         const query: QueryWithTypings = { sql: _sql, params, typings };
+        const endClock = startClock();
 
-        const res = await database.record({ method: "sql" }, async () => {
-          try {
-            return await db._.session
-              .prepareQuery(query, undefined, undefined, method === "all")
-              .execute();
-          } catch (e) {
-            throw parseSqlError(e);
-          }
-        });
+        const result = await db._.session
+          .prepareQuery(query, undefined, undefined, method === "all")
+          .execute()
+          .catch((error) => {
+            throw parseSqlError(error);
+          });
+
+        common.metrics.ponder_indexing_store_raw_sql_duration.observe(
+          endClock(),
+        );
 
         // @ts-ignore
-        return { rows: res.rows.map((row) => Object.values(row)) };
+        return { rows: result.rows.map((row) => Object.values(row)) };
       },
       { schema, casing: "snake_case" },
     ),

--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -33,7 +33,7 @@ export const createHistoricalIndexingStore = ({
   return {
     // @ts-ignore
     find: (table: Table, key) => {
-      common.metrics.ponder_indexing_store_count.inc({
+      common.metrics.ponder_indexing_store_queries_total.inc({
         table: getTableName(table),
         method: "find",
       });
@@ -48,7 +48,7 @@ export const createHistoricalIndexingStore = ({
           // @ts-ignore
           const inner = {
             onConflictDoNothing: async () => {
-              common.metrics.ponder_indexing_store_count.inc({
+              common.metrics.ponder_indexing_store_queries_total.inc({
                 table: getTableName(table),
                 method: "insert",
               });
@@ -99,7 +99,7 @@ export const createHistoricalIndexingStore = ({
               }
             },
             onConflictDoUpdate: async (valuesU: any) => {
-              common.metrics.ponder_indexing_store_count.inc({
+              common.metrics.ponder_indexing_store_queries_total.inc({
                 table: getTableName(table),
                 method: "insert",
               });
@@ -187,7 +187,7 @@ export const createHistoricalIndexingStore = ({
             },
             // biome-ignore lint/suspicious/noThenProperty: <explanation>
             then: (onFulfilled, onRejected) => {
-              common.metrics.ponder_indexing_store_count.inc({
+              common.metrics.ponder_indexing_store_queries_total.inc({
                 table: getTableName(table),
                 method: "insert",
               });
@@ -247,7 +247,7 @@ export const createHistoricalIndexingStore = ({
     update(table: Table, key) {
       return {
         set: async (values: any) => {
-          common.metrics.ponder_indexing_store_count.inc({
+          common.metrics.ponder_indexing_store_queries_total.inc({
             table: getTableName(table),
             method: "update",
           });
@@ -287,7 +287,7 @@ export const createHistoricalIndexingStore = ({
     },
     // @ts-ignore
     delete: async (table: Table, key) => {
-      common.metrics.ponder_indexing_store_count.inc({
+      common.metrics.ponder_indexing_store_queries_total.inc({
         table: getTableName(table),
         method: "delete",
       });

--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -303,19 +303,20 @@ export const createHistoricalIndexingStore = ({
         const query: QueryWithTypings = { sql: _sql, params, typings };
         const endClock = startClock();
 
-        const result = await db._.session
-          .prepareQuery(query, undefined, undefined, method === "all")
-          .execute()
-          .catch((error) => {
-            throw parseSqlError(error);
-          });
+        try {
+          const result = await db._.session
+            .prepareQuery(query, undefined, undefined, method === "all")
+            .execute();
 
-        common.metrics.ponder_indexing_store_raw_sql_duration.observe(
-          endClock(),
-        );
+          common.metrics.ponder_indexing_store_raw_sql_duration.observe(
+            endClock(),
+          );
 
-        // @ts-ignore
-        return { rows: result.rows.map((row) => Object.values(row)) };
+          // @ts-ignore
+          return { rows: result.rows.map((row) => Object.values(row)) };
+        } catch (error) {
+          throw parseSqlError(error);
+        }
       },
       { schema, casing: "snake_case" },
     ),

--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -308,14 +308,14 @@ export const createHistoricalIndexingStore = ({
             .prepareQuery(query, undefined, undefined, method === "all")
             .execute();
 
-          common.metrics.ponder_indexing_store_raw_sql_duration.observe(
-            endClock(),
-          );
-
           // @ts-ignore
           return { rows: result.rows.map((row) => Object.values(row)) };
         } catch (error) {
           throw parseSqlError(error);
+        } finally {
+          common.metrics.ponder_indexing_store_raw_sql_duration.observe(
+            endClock(),
+          );
         }
       },
       { schema, casing: "snake_case" },

--- a/packages/core/src/indexing-store/realtime.ts
+++ b/packages/core/src/indexing-store/realtime.ts
@@ -4,6 +4,7 @@ import type { Common } from "@/internal/common.js";
 import { RecordNotFoundError } from "@/internal/errors.js";
 import type { SchemaBuild } from "@/internal/types.js";
 import { prettyPrint } from "@/utils/print.js";
+import { startClock } from "@/utils/timer.js";
 import { type QueryWithTypings, type Table, getTableName } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pg-proxy";
 import { getCacheKey, getWhereCondition } from "./cache.js";
@@ -14,6 +15,7 @@ import {
 } from "./index.js";
 
 export const createRealtimeIndexingStore = ({
+  common,
   schemaBuild: { schema },
   database,
 }: {
@@ -32,14 +34,14 @@ export const createRealtimeIndexingStore = ({
   return {
     // @ts-ignore
     find: (table: Table, key) =>
-      database.wrap(
-        { method: `${getTableName(table) ?? "unknown"}.find()` },
-        async () => {
-          checkOnchainTable(table, "find");
-
-          return find(table, key);
-        },
-      ),
+      database.retry(async () => {
+        common.metrics.ponder_indexing_store_count.inc({
+          table: getTableName(table),
+          method: "find",
+        });
+        checkOnchainTable(table, "find");
+        return find(table, key);
+      }),
     // @ts-ignore
     insert(table: Table) {
       return {
@@ -47,156 +49,153 @@ export const createRealtimeIndexingStore = ({
           // @ts-ignore
           const inner = {
             onConflictDoNothing: () =>
-              database.wrap(
-                {
-                  method: `${getTableName(table) ?? "unknown"}.insert()`,
-                },
-                async () => {
-                  checkOnchainTable(table, "insert");
+              database.retry(async () => {
+                common.metrics.ponder_indexing_store_count.inc({
+                  table: getTableName(table),
+                  method: "insert",
+                });
+                checkOnchainTable(table, "insert");
 
-                  const parseResult = (result: { [x: string]: any }[]) => {
-                    if (Array.isArray(values) === false) {
-                      return result.length === 1 ? result[0] : null;
+                const parseResult = (result: { [x: string]: any }[]) => {
+                  if (Array.isArray(values) === false) {
+                    return result.length === 1 ? result[0] : null;
+                  }
+
+                  const rows = [];
+                  let resultIndex = 0;
+
+                  for (let i = 0; i < values.length; i++) {
+                    if (
+                      getCacheKey(table, values[i]) ===
+                      getCacheKey(table, result[resultIndex]!)
+                    ) {
+                      rows.push(result[resultIndex++]!);
+                    } else {
+                      rows.push(null);
                     }
+                  }
 
-                    const rows = [];
-                    let resultIndex = 0;
+                  return rows;
+                };
 
-                    for (let i = 0; i < values.length; i++) {
-                      if (
-                        getCacheKey(table, values[i]) ===
-                        getCacheKey(table, result[resultIndex]!)
-                      ) {
-                        rows.push(result[resultIndex++]!);
-                      } else {
-                        rows.push(null);
-                      }
-                    }
+                try {
+                  return await database.qb.drizzle
+                    .insert(table)
+                    .values(values)
+                    .onConflictDoNothing()
+                    .returning()
+                    .then(parseResult);
+                } catch (e) {
+                  throw parseSqlError(e);
+                }
+              }),
+            onConflictDoUpdate: (valuesU: any) =>
+              database.retry(async () => {
+                common.metrics.ponder_indexing_store_count.inc({
+                  table: getTableName(table),
+                  method: "insert",
+                });
+                checkOnchainTable(table, "insert");
 
-                    return rows;
-                  };
-
+                if (typeof valuesU === "object") {
                   try {
                     return await database.qb.drizzle
                       .insert(table)
                       .values(values)
-                      .onConflictDoNothing()
+                      .onConflictDoUpdate({
+                        target: getPrimaryKeyColumns(table).map(
+                          // @ts-ignore
+                          ({ js }) => table[js],
+                        ),
+                        set: valuesU,
+                      })
                       .returning()
-                      .then(parseResult);
+                      .then((res) => (Array.isArray(values) ? res : res[0]));
                   } catch (e) {
                     throw parseSqlError(e);
                   }
-                },
-              ),
-            onConflictDoUpdate: (valuesU: any) =>
-              database.wrap(
-                {
-                  method: `${getTableName(table) ?? "unknown"}.insert()`,
-                },
-                async () => {
-                  checkOnchainTable(table, "insert");
+                }
 
-                  if (typeof valuesU === "object") {
-                    try {
-                      return await database.qb.drizzle
-                        .insert(table)
-                        .values(values)
-                        .onConflictDoUpdate({
-                          target: getPrimaryKeyColumns(table).map(
-                            // @ts-ignore
-                            ({ js }) => table[js],
-                          ),
-                          set: valuesU,
-                        })
-                        .returning()
-                        .then((res) => (Array.isArray(values) ? res : res[0]));
-                    } catch (e) {
-                      throw parseSqlError(e);
-                    }
-                  }
-
-                  if (Array.isArray(values)) {
-                    const rows = [];
-                    for (const value of values) {
-                      const row = await find(table, value);
-
-                      if (row === null) {
-                        try {
-                          rows.push(
-                            await database.qb.drizzle
-                              .insert(table)
-                              .values(value)
-                              .returning()
-                              .then((res) => res[0]),
-                          );
-                        } catch (e) {
-                          throw parseSqlError(e);
-                        }
-                      } else {
-                        try {
-                          rows.push(
-                            await database.qb.drizzle
-                              .update(table)
-                              .set(valuesU(row))
-                              .where(getWhereCondition(table, value))
-                              .returning()
-                              .then((res) => res[0]),
-                          );
-                        } catch (e) {
-                          throw parseSqlError(e);
-                        }
-                      }
-                    }
-                    return rows;
-                  } else {
-                    const row = await find(table, values);
+                if (Array.isArray(values)) {
+                  const rows = [];
+                  for (const value of values) {
+                    const row = await find(table, value);
 
                     if (row === null) {
                       try {
-                        return await database.qb.drizzle
-                          .insert(table)
-                          .values(values)
-                          .returning()
-                          .then((res) => res[0]);
+                        rows.push(
+                          await database.qb.drizzle
+                            .insert(table)
+                            .values(value)
+                            .returning()
+                            .then((res) => res[0]),
+                        );
                       } catch (e) {
                         throw parseSqlError(e);
                       }
                     } else {
                       try {
-                        return await database.qb.drizzle
-                          .update(table)
-                          .set(valuesU(row))
-                          .where(getWhereCondition(table, values))
-                          .returning()
-                          .then((res) => res[0]);
+                        rows.push(
+                          await database.qb.drizzle
+                            .update(table)
+                            .set(valuesU(row))
+                            .where(getWhereCondition(table, value))
+                            .returning()
+                            .then((res) => res[0]),
+                        );
                       } catch (e) {
                         throw parseSqlError(e);
                       }
                     }
                   }
-                },
-              ),
-            // biome-ignore lint/suspicious/noThenProperty: <explanation>
-            then: (onFulfilled, onRejected) =>
-              database
-                .wrap(
-                  {
-                    method: `${getTableName(table) ?? "unknown"}.insert()`,
-                  },
-                  async () => {
-                    checkOnchainTable(table, "insert");
+                  return rows;
+                } else {
+                  const row = await find(table, values);
 
+                  if (row === null) {
                     try {
                       return await database.qb.drizzle
                         .insert(table)
                         .values(values)
                         .returning()
-                        .then((res) => (Array.isArray(values) ? res : res[0]));
+                        .then((res) => res[0]);
                     } catch (e) {
                       throw parseSqlError(e);
                     }
-                  },
-                )
+                  } else {
+                    try {
+                      return await database.qb.drizzle
+                        .update(table)
+                        .set(valuesU(row))
+                        .where(getWhereCondition(table, values))
+                        .returning()
+                        .then((res) => res[0]);
+                    } catch (e) {
+                      throw parseSqlError(e);
+                    }
+                  }
+                }
+              }),
+            // biome-ignore lint/suspicious/noThenProperty: <explanation>
+            then: (onFulfilled, onRejected) =>
+              database
+                .retry(async () => {
+                  common.metrics.ponder_indexing_store_count.inc({
+                    table: getTableName(table),
+                    method: "insert",
+                  });
+                  checkOnchainTable(table, "insert");
+
+                  try {
+                    return await database.qb.drizzle
+                      .insert(table)
+                      .values(values)
+                      .returning()
+                      .then((res) => (Array.isArray(values) ? res : res[0]));
+                  } catch (e) {
+                    throw parseSqlError(e);
+                  }
+                })
                 .then(onFulfilled, onRejected),
             catch: (onRejected) => inner.then(undefined, onRejected),
             finally: (onFinally) =>
@@ -221,80 +220,86 @@ export const createRealtimeIndexingStore = ({
     update(table: Table, key) {
       return {
         set: (values: any) =>
-          database.wrap(
-            { method: `${getTableName(table) ?? "unknown"}.update()` },
-            async () => {
-              checkOnchainTable(table, "update");
+          database.retry(async () => {
+            common.metrics.ponder_indexing_store_count.inc({
+              table: getTableName(table),
+              method: "update",
+            });
+            checkOnchainTable(table, "update");
 
-              if (typeof values === "function") {
-                const row = await find(table, key);
+            if (typeof values === "function") {
+              const row = await find(table, key);
 
-                if (row === null) {
-                  const error = new RecordNotFoundError(
-                    `No existing record found in table '${getTableName(table)}'`,
-                  );
-                  error.meta.push(`db.update arguments:\n${prettyPrint(key)}`);
-                  throw error;
-                }
-
-                try {
-                  return await database.qb.drizzle
-                    .update(table)
-                    .set(values(row))
-                    .where(getWhereCondition(table, key))
-                    .returning()
-                    .then((res) => res[0]);
-                } catch (e) {
-                  throw parseSqlError(e);
-                }
-              } else {
-                try {
-                  return await database.qb.drizzle
-                    .update(table)
-                    .set(values)
-                    .where(getWhereCondition(table, key))
-                    .returning()
-                    .then((res) => res[0]);
-                } catch (e) {
-                  throw parseSqlError(e);
-                }
+              if (row === null) {
+                const error = new RecordNotFoundError(
+                  `No existing record found in table '${getTableName(table)}'`,
+                );
+                error.meta.push(`db.update arguments:\n${prettyPrint(key)}`);
+                throw error;
               }
-            },
-          ),
+
+              try {
+                return await database.qb.drizzle
+                  .update(table)
+                  .set(values(row))
+                  .where(getWhereCondition(table, key))
+                  .returning()
+                  .then((res) => res[0]);
+              } catch (e) {
+                throw parseSqlError(e);
+              }
+            } else {
+              try {
+                return await database.qb.drizzle
+                  .update(table)
+                  .set(values)
+                  .where(getWhereCondition(table, key))
+                  .returning()
+                  .then((res) => res[0]);
+              } catch (e) {
+                throw parseSqlError(e);
+              }
+            }
+          }),
       };
     },
     // @ts-ignore
     delete: (table: Table, key) =>
-      database.wrap(
-        { method: `${getTableName(table) ?? "unknown"}.delete()` },
-        async () => {
-          checkOnchainTable(table, "delete");
+      database.retry(async () => {
+        common.metrics.ponder_indexing_store_count.inc({
+          table: getTableName(table),
+          method: "delete",
+        });
+        checkOnchainTable(table, "delete");
 
-          const deleted = await database.qb.drizzle
-            .delete(table)
-            .where(getWhereCondition(table, key))
-            .returning();
+        const deleted = await database.qb.drizzle
+          .delete(table)
+          .where(getWhereCondition(table, key))
+          .returning();
 
-          return deleted.length > 0;
-        },
-      ),
+        return deleted.length > 0;
+      }),
     // @ts-ignore
     sql: drizzle(
       async (_sql, params, method, typings) => {
         const query: QueryWithTypings = { sql: _sql, params, typings };
+        const endClock = startClock();
 
-        const res = await database.wrap({ method: "sql" }, async () => {
-          try {
-            return await database.qb.drizzle._.session
-              .prepareQuery(query, undefined, undefined, method === "all")
-              .execute();
-          } catch (e) {
-            throw parseSqlError(e);
-          }
+        const result = await database.retry(async () => {
+          return await database.qb.drizzle._.session
+            .prepareQuery(query, undefined, undefined, method === "all")
+            .execute()
+            .catch((error) => {
+              throw parseSqlError(error);
+            });
         });
 
+        common.metrics.ponder_indexing_store_raw_sql_duration.observe(
+          endClock(),
+        );
+
         // @ts-ignore
-        return { rows: res.rows.map((row) => Object.values(row)) };
+        return { rows: result.rows.map((row) => Object.values(row)) };
       },
       { schema, casing: "snake_case" },
     ),

--- a/packages/core/src/indexing-store/realtime.ts
+++ b/packages/core/src/indexing-store/realtime.ts
@@ -35,7 +35,7 @@ export const createRealtimeIndexingStore = ({
     // @ts-ignore
     find: (table: Table, key) =>
       database.retry(async () => {
-        common.metrics.ponder_indexing_store_count.inc({
+        common.metrics.ponder_indexing_store_queries_total.inc({
           table: getTableName(table),
           method: "find",
         });
@@ -50,7 +50,7 @@ export const createRealtimeIndexingStore = ({
           const inner = {
             onConflictDoNothing: () =>
               database.retry(async () => {
-                common.metrics.ponder_indexing_store_count.inc({
+                common.metrics.ponder_indexing_store_queries_total.inc({
                   table: getTableName(table),
                   method: "insert",
                 });
@@ -91,7 +91,7 @@ export const createRealtimeIndexingStore = ({
               }),
             onConflictDoUpdate: (valuesU: any) =>
               database.retry(async () => {
-                common.metrics.ponder_indexing_store_count.inc({
+                common.metrics.ponder_indexing_store_queries_total.inc({
                   table: getTableName(table),
                   method: "insert",
                 });
@@ -180,7 +180,7 @@ export const createRealtimeIndexingStore = ({
             then: (onFulfilled, onRejected) =>
               database
                 .retry(async () => {
-                  common.metrics.ponder_indexing_store_count.inc({
+                  common.metrics.ponder_indexing_store_queries_total.inc({
                     table: getTableName(table),
                     method: "insert",
                   });
@@ -221,7 +221,7 @@ export const createRealtimeIndexingStore = ({
       return {
         set: (values: any) =>
           database.retry(async () => {
-            common.metrics.ponder_indexing_store_count.inc({
+            common.metrics.ponder_indexing_store_queries_total.inc({
               table: getTableName(table),
               method: "update",
             });
@@ -266,7 +266,7 @@ export const createRealtimeIndexingStore = ({
     // @ts-ignore
     delete: (table: Table, key) =>
       database.retry(async () => {
-        common.metrics.ponder_indexing_store_count.inc({
+        common.metrics.ponder_indexing_store_queries_total.inc({
           table: getTableName(table),
           method: "delete",
         });

--- a/packages/core/src/indexing-store/realtime.ts
+++ b/packages/core/src/indexing-store/realtime.ts
@@ -293,10 +293,12 @@ export const createRealtimeIndexingStore = ({
               .execute()
               .catch((error) => {
                 throw parseSqlError(error);
+              })
+              .finally(() => {
+                common.metrics.ponder_indexing_store_raw_sql_duration.observe(
+                  endClock(),
+                );
               });
-            common.metrics.ponder_indexing_store_raw_sql_duration.observe(
-              endClock(),
-            );
             // @ts-ignore
             return { rows: result.rows.map((row) => Object.values(row)) };
           });

--- a/packages/core/src/internal/metrics.ts
+++ b/packages/core/src/internal/metrics.ts
@@ -30,9 +30,11 @@ export class MetricsService {
   ponder_indexing_completed_events: prometheus.Gauge<"event">;
   ponder_indexing_function_duration: prometheus.Histogram<"event">;
   ponder_indexing_abi_decoding_duration: prometheus.Histogram;
-  ponder_indexing_cache_access: prometheus.Counter<"table" | "type">;
-  ponder_indexing_cache_duration: prometheus.Histogram<"table" | "method">;
-  ponder_indexing_store_count: prometheus.Counter<"table" | "method">;
+  ponder_indexing_cache_requests_total: prometheus.Counter<"table" | "type">;
+  ponder_indexing_cache_query_duration: prometheus.Histogram<
+    "table" | "method"
+  >;
+  ponder_indexing_store_queries_total: prometheus.Counter<"table" | "method">;
   ponder_indexing_store_raw_sql_duration: prometheus.Histogram;
 
   ponder_sync_block: prometheus.Gauge<"network">;
@@ -122,21 +124,21 @@ export class MetricsService {
       buckets: databaseQueryDurationMs,
       registers: [this.registry],
     });
-    this.ponder_indexing_cache_duration = new prometheus.Histogram({
-      name: "ponder_indexing_cache_duration",
+    this.ponder_indexing_cache_query_duration = new prometheus.Histogram({
+      name: "ponder_indexing_cache_query_duration",
       help: "Duration of cache operations",
       labelNames: ["table", "method"] as const,
       buckets: databaseQueryDurationMs,
       registers: [this.registry],
     });
-    this.ponder_indexing_cache_access = new prometheus.Counter({
-      name: "ponder_indexing_cache_access",
+    this.ponder_indexing_cache_requests_total = new prometheus.Counter({
+      name: "ponder_indexing_cache_requests_total",
       help: "Number of cache accesses",
       labelNames: ["table", "type"] as const,
       registers: [this.registry],
     });
-    this.ponder_indexing_store_count = new prometheus.Counter({
-      name: "ponder_indexing_store_count",
+    this.ponder_indexing_store_queries_total = new prometheus.Counter({
+      name: "ponder_indexing_store_queries_total",
       help: "Number of indexing store operations",
       labelNames: ["table", "method"] as const,
       registers: [this.registry],

--- a/packages/core/src/internal/metrics.ts
+++ b/packages/core/src/internal/metrics.ts
@@ -30,8 +30,10 @@ export class MetricsService {
   ponder_indexing_completed_events: prometheus.Gauge<"event">;
   ponder_indexing_function_duration: prometheus.Histogram<"event">;
   ponder_indexing_abi_decoding_duration: prometheus.Histogram;
-  ponder_indexing_cache_hit: prometheus.Counter;
-  ponder_indexing_cache_miss: prometheus.Counter;
+  ponder_indexing_cache_access: prometheus.Counter<"table" | "type">;
+  ponder_indexing_cache_duration: prometheus.Histogram<"table" | "method">;
+  ponder_indexing_store_count: prometheus.Counter<"table" | "method">;
+  ponder_indexing_store_raw_sql_duration: prometheus.Histogram;
 
   ponder_sync_block: prometheus.Gauge<"network">;
   ponder_sync_is_realtime: prometheus.Gauge<"network">;
@@ -120,14 +122,29 @@ export class MetricsService {
       buckets: databaseQueryDurationMs,
       registers: [this.registry],
     });
-    this.ponder_indexing_cache_hit = new prometheus.Counter({
-      name: "ponder_indexing_cache_hit",
-      help: "Number of cache hits",
+    this.ponder_indexing_cache_duration = new prometheus.Histogram({
+      name: "ponder_indexing_cache_duration",
+      help: "Duration of cache operations",
+      labelNames: ["table", "method"] as const,
+      buckets: databaseQueryDurationMs,
       registers: [this.registry],
     });
-    this.ponder_indexing_cache_miss = new prometheus.Counter({
-      name: "ponder_indexing_cache_miss",
-      help: "Number of cache misses",
+    this.ponder_indexing_cache_access = new prometheus.Counter({
+      name: "ponder_indexing_cache_access",
+      help: "Number of cache accesses",
+      labelNames: ["table", "type"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_indexing_store_count = new prometheus.Counter({
+      name: "ponder_indexing_store_count",
+      help: "Number of indexing store operations",
+      labelNames: ["table", "method"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_indexing_store_raw_sql_duration = new prometheus.Histogram({
+      name: "ponder_indexing_store_raw_sql_duration",
+      help: "Duration of raw SQL store operations",
+      buckets: databaseQueryDurationMs,
       registers: [this.registry],
     });
 


### PR DESCRIPTION
Adds `ponder_indexing_cache_requests_total`, `ponder_indexing_cache_query_duration`, `ponder_indexing_store_queries_total` and `ponder_indexing_store_raw_sql_duration` to metrics.