### PR TITLE
fix: update broken link foundry.mdx

### DIFF
--- a/docs/pages/docs/advanced/foundry.mdx
+++ b/docs/pages/docs/advanced/foundry.mdx
@@ -80,7 +80,7 @@ Foundry scripts write transaction inputs and receipts to JSON files in the `broa
 
 <Callout type="info">
   Remember to enable
-  [broadcast](https://book.getfoundry.sh/tutorials/solidity-scripting?highlight=deploy#deploying-locally)
+  [broadcast](https://book.getfoundry.sh/guides/scripting-with-solidity#deploying-to-a-local-anvil-instance)
   so that `forge script` submits transactions to Anvil.
 </Callout>
 


### PR DESCRIPTION
Hi! I fixes a broken link in the `foundry.mdx` file. The outdated link to Foundry's documentation has been updated to the correct URL