### PR TITLE
fix: build script hono instance check

### DIFF
--- a/.changeset/many-dragons-cry.md
+++ b/.changeset/many-dragons-cry.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed an issue where libraries that subclass `Hono` (like `@hono/zod-openapi`) were not supported by API functions.

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -19,7 +19,7 @@ import { getNextAvailablePort } from "@/utils/port.js";
 import type { Result } from "@/utils/result.js";
 import { serialize } from "@/utils/serialize.js";
 import { glob } from "glob";
-import type { Hono } from "hono";
+import { Hono } from "hono";
 import { createServer } from "vite";
 import { ViteNodeRunner } from "vite-node/client";
 import { ViteNodeServer } from "vite-node/server";
@@ -310,8 +310,7 @@ export const createBuild = async ({
 
       const app = executeResult.exports.default;
 
-      // TODO: Consider a stricter validation here.
-      if (app?.constructor?.name !== "Hono") {
+      if (!(app instanceof Hono)) {
         const error = new BuildError(
           "API function file does not export a Hono instance as the default export. Read more: https://ponder-docs-git-v09-ponder-sh.vercel.app/docs/query/api-functions",
         );

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -310,9 +310,9 @@ export const createBuild = async ({
 
       const app = executeResult.exports.default;
 
-      if (!(app instanceof Hono)) {
+      if (!(app instanceof Hono || app?.constructor?.name === "Hono")) {
         const error = new BuildError(
-          "API function file does not export a Hono instance as the default export. Read more: https://ponder-docs-git-v09-ponder-sh.vercel.app/docs/query/api-functions",
+          "API function file does not export a Hono instance as the default export. Read more: https://ponder.sh/docs/query/api-functions",
         );
         error.stack = undefined;
         common.logger.error({


### PR DESCRIPTION
fix https://github.com/ponder-sh/ponder/issues/1551

check the Hono instance using `instanceof` instead of checking constructor name. 

this allows the devs to use Hono extended instances such as `@hono/zod-openapi` with ponder.

#### Peer dependency
as long as the peer dependency of hono is correctly setup and both the ponder and the devs are using the same Hono package, the check should work.

if we are worrying the devs could using a different package of hono then alternatively  we can loosen up the check like this:
```
if (!(app instanceof Hono || app?.constructor?.name === "Hono")) {
```

wdyt?