### PR TITLE
fix: flush index

### DIFF
--- a/.changeset/itchy-chairs-share.md
+++ b/.changeset/itchy-chairs-share.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a regression with evicting cached indexing data introduced in v0.9.20.

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -594,6 +594,7 @@ export const createIndexingCache = ({
           for (const [key, entry] of insertBuffer.get(table)!) {
             const bytes = getBytes(entry.row);
             cacheBytes += bytes;
+            totalCacheOps++;
             tableSpillover.set(key, {
               bytes,
               operationIndex: 0,
@@ -741,11 +742,9 @@ export const createIndexingCache = ({
       let cacheSize = 0;
       for (const { size } of cache.values()) cacheSize += size;
 
-      const flushIndex = Math.max(
+      const flushIndex =
         totalCacheOps -
-          cacheSize * (1 - common.options.indexingCacheEvictRatio),
-        0,
-      );
+        cacheSize * (1 - common.options.indexingCacheEvictRatio);
 
       if (cacheBytes + spilloverBytes > common.options.indexingCacheMaxBytes) {
         isCacheComplete = false;

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -741,9 +741,11 @@ export const createIndexingCache = ({
       let cacheSize = 0;
       for (const { size } of cache.values()) cacheSize += size;
 
-      const flushIndex =
+      const flushIndex = Math.max(
         totalCacheOps -
-        cacheSize * (1 - common.options.indexingCacheEvictRatio);
+          cacheSize * (1 - common.options.indexingCacheEvictRatio),
+        0,
+      );
 
       if (cacheBytes + spilloverBytes > common.options.indexingCacheMaxBytes) {
         isCacheComplete = false;
@@ -752,7 +754,7 @@ export const createIndexingCache = ({
 
         for (const tableCache of cache.values()) {
           for (const [key, entry] of tableCache) {
-            if (entry.operationIndex < flushIndex) {
+            if (entry.operationIndex <= flushIndex) {
               tableCache.delete(key);
               cacheBytes -= entry.bytes;
               rowCount += 1;


### PR DESCRIPTION
Fixed a regression where cached indexing data wouldn't get evicted properly when `totalCacheOps < num cache entries`. This would only occur when all or a high percentage of cache operations were inserts and not updates.