### PR TITLE
fix `flush()` when using raw sql

### DIFF
--- a/.changeset/few-trains-rule.md
+++ b/.changeset/few-trains-rule.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a regression introduced in v0.9.20 that caused an error when using raw sql queries.

--- a/packages/core/src/indexing-store/cache.test.ts
+++ b/packages/core/src/indexing-store/cache.test.ts
@@ -110,7 +110,24 @@ test("flush() update", async (context) => {
 
     await indexingCache.flush({ client });
 
-    const result = await indexingStore.find(schema.account, {
+    let result = await indexingStore.find(schema.account, {
+      address: zeroAddress,
+    });
+
+    expect(result).toStrictEqual({
+      address: zeroAddress,
+      balance: 12n,
+    });
+
+    // flush again to make sure temp tables are cleaned up
+
+    await indexingStore.update(schema.account, { address: zeroAddress }).set({
+      balance: 12n,
+    });
+
+    await indexingCache.flush({ client });
+
+    result = await indexingStore.find(schema.account, {
       address: zeroAddress,
     });
 


### PR DESCRIPTION
Fixes a bug that occurs when calling `flush()` multiple times for the same batch of events (same transaction). This occurs because the "update" logic creates a temp table and isn't accounting for the case when the temp table already exists.

With this pr, the temp table is only created if not exists and truncated at the end of the function. Another solution would be to drop the temp table at the end of the function and recreate it on every call.