### PR TITLE
docs: update dead link

### DIFF
--- a/docs/pages/0_6/docs/advanced/foundry.mdx
+++ b/docs/pages/0_6/docs/advanced/foundry.mdx
@@ -85,7 +85,7 @@ Foundry scripts write transaction inputs and receipts to JSON files in the `broa
 
 <Callout type="info">
   Remember to enable
-  [broadcast](https://book.getfoundry.sh/tutorials/solidity-scripting?highlight=deploy#deploying-locally)
+  [broadcast](https://book.getfoundry.sh/guides/scripting-with-solidity#deploying-to-a-local-anvil-instance)
   so that `forge script` submits transactions to Anvil.
 </Callout>
 


### PR DESCRIPTION
While reviewing the documentation, I noticed that a link to Foundry's scripting tutorial in the foundry.mdx file was broken. I’ve updated the link to point to the correct location: https://book.getfoundry.sh/guides/scripting-with-solidity#deploying-to-a-local-anvil-instance.