### PR TITLE
docs: add description for "silent" log level

### DIFF
--- a/docs/pages/0_6/docs/advanced/logging.mdx
+++ b/docs/pages/0_6/docs/advanced/logging.mdx
@@ -45,7 +45,7 @@ ponder dev -v
 
 | Log level        | Example                                           |
 | :--------------- | :------------------------------------------------ |
-| `silent`         |                                                   |
+| `silent`         | No logs are produced                              |
 | `error`          | Unrecoverable RPC error, SQL constraint violation |
 | `warn`           | Reorg reconciliation, malformed config            |
 | `info` (default) | Indexing progress, real-time block processing     |


### PR DESCRIPTION
I noticed that the "silent" log level didn't have a description in the table. To clarify its meaning, I added the following:

| `silent`         | No logs are produced                             |

This provides a complete understanding of the log levels and their effects.