### PR TITLE
docs: Fixed incorrect syntax in COPY command example

### DIFF
--- a/docs/pages/docs/indexing/write-to-the-database.mdx
+++ b/docs/pages/docs/indexing/write-to-the-database.mdx
@@ -198,7 +198,7 @@ const rows = await db
 
 EVM indexing workloads often involve a large number of small inserts and updates. To mitigate the performance penalty of many (blocking) database queries, the store API runs **in-memory** during historical indexing.
 
-When the in-memory cache exceeds a certain size, the store flushes all pending data to the database using one `COPY{:sql}` statement per table. During development, the store also flushes every 5 seconds regardless of size to ensure that the database state is reasonably up-to-date to support ad-hoc queries.
+When the in-memory cache exceeds a certain size, the store flushes all pending data to the database using one `COPY sql` statement per table. During development, the store also flushes every 5 seconds regardless of size to ensure that the database state is reasonably up-to-date to support ad-hoc queries.
 
 ## Raw SQL
 


### PR DESCRIPTION
Noticed a issue where the `COPY {:sql}` command had an extra `{:sql}` part, which is not valid in SQL syntax.
It should be just `COPY sql`.

This update removes the unnecessary part and ensures the example aligns with correct SQL syntax.