### PR TITLE
fix: Fix queryKey dependency tracking in React

### DIFF
--- a/packages/react/src/hook.ts
+++ b/packages/react/src/hook.ts
@@ -36,7 +36,7 @@ export function usePonderQuery<result>(
       () => queryClient.invalidateQueries({ queryKey: queryOptions.queryKey }),
     );
     return unsubscribe;
-  }, queryOptions.queryKey);
+  }, [queryOptions.queryKey]);
 
   return useQuery({
     ...params,


### PR DESCRIPTION
Noticed that `queryOptions.queryKey` was being passed directly instead of as an array. Wrapped it in `[queryOptions.queryKey]` to ensure React tracks dependencies correctly. This prevents potential stale data issues.