### PR TITLE
fix(core/build): improve db connection string parse error message

### DIFF
--- a/.changeset/brown-singers-thank.md
+++ b/.changeset/brown-singers-thank.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved error message for invalid database connection strings.

--- a/packages/core/src/build/pre.ts
+++ b/packages/core/src/build/pre.ts
@@ -6,8 +6,17 @@ import type { DatabaseConfig } from "@/internal/types.js";
 import parse from "pg-connection-string";
 
 function getDatabaseName(connectionString: string) {
-  const parsed = (parse as unknown as typeof parse.parse)(connectionString);
-  return `${parsed.host}:${parsed.port}/${parsed.database}`;
+  try {
+    const parsed = (parse as unknown as typeof parse.parse)(connectionString);
+    return `${parsed.host}:${parsed.port}/${parsed.database}`;
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+
+    throw new Error(
+      `Failed to parse database connection string: ${errorMessage}.`,
+    );
+  }
 }
 
 export function buildPre({


### PR DESCRIPTION
This PR changes error message when pg connection parse throws an error.

Error message before:
```
10:14:01 PM ERROR build      Failed build
BuildError: Invalid URL
```

Error message after:
```
8:05:31 AM ERROR build      Failed build
BuildError: Failed to parse database connection string: Invalid URL
```

Resolves #1591