### PR TITLE
docs: Fix typo in /ready route description

### DIFF
--- a/docs/pages/docs/query/api-functions.mdx
+++ b/docs/pages/docs/query/api-functions.mdx
@@ -166,6 +166,6 @@ export default app;
 If you register API functions that conflict with these internal routes, the build will fail.
 
 - `/health`: Returns a `200` status code immediately after the app starts running. [Read more](/docs/production/deploy#healthchecks) about healthchecks.
-- `/ready`: Returns a `200` status code after the app has completed the historical backfill and is available to serve traffic. [Read more](/docs/production/deploy#healthchecks) about heatlthchecks.
+- `/ready`: Returns a `200` status code after the app has completed the historical backfill and is available to serve traffic. [Read more](/docs/production/deploy#healthchecks) about healthchecks.
 - `/metrics`: Returns Prometheus metrics. [Read more](/docs/advanced/metrics) about metrics.
 - `/status`: Returns indexing status object. [Read more](/docs/advanced/status) about indexing status.


### PR DESCRIPTION
<img width="961" alt="Снимок экрана 2025-03-11 в 12 29 32" src="https://github.com/user-attachments/assets/23ba9780-0a02-4a55-8e9c-fa656ec4bccf" />

In the "Reserved routes" section, changed "heatlthchecks" to "**healthchecks**" in the `/ready` route description.