### PR TITLE
Fix CLI arg name in config.mdx

### DIFF
--- a/docs/pages/docs/api-reference/config.mdx
+++ b/docs/pages/docs/api-reference/config.mdx
@@ -24,7 +24,7 @@ export default createConfig({
 });
 ```
 
-By default, `ponder dev` and `start` look for `ponder.config.ts` in the current working directory. Use the `--config-file` CLI option to specify a different path.
+By default, `ponder dev` and `start` look for `ponder.config.ts` in the current working directory. Use the `--config` CLI option to specify a different path.
 
 ## Event ordering
 


### PR DESCRIPTION
The docs instruct users to use `--config-file` CLI arg to specify a custom config file but the actual arg is `--config`. This PR fixes it.