### PR TITLE
fix: replace unpkg w/ jsdelivr

### DIFF
--- a/.changeset/soft-hats-whisper.md
+++ b/.changeset/soft-hats-whisper.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Updated the `graphql` middleware to use the jsDelivr CDN for the GraphiQL bundle.

--- a/packages/core/src/graphql/graphiql.html.ts
+++ b/packages/core/src/graphql/graphiql.html.ts
@@ -34,15 +34,15 @@ export const graphiQLHtml = (path: string) => `<!--
         overflow: -moz-scrollbars-none;
       }
     </style>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql@3.7.2/graphiql.min.css" />
-    <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer@3.2.3/dist/style.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphiql@3.7.2/graphiql.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer@3.2.3/dist/style.css" />
   </head>
   <body>
     <div id="graphiql">Loading...</div>
-    <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>1
-    <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/graphiql@3.7.2/graphiql.min.js" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/@graphiql/plugin-explorer@3.2.3/dist/index.umd.js" crossorigin="anonymous"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18.3.1/umd/react.development.js"></script>1
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18.3.1/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/graphiql@3.7.2/graphiql.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer@3.2.3/dist/index.umd.js" crossorigin="anonymous"></script>
     <script>
       const fetcher = GraphiQL.createFetcher({ url: "${path}" });
       const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();


### PR DESCRIPTION
UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG usage with jsDelivr inside `graphql.html`.