### PR TITLE
spin eventloop after cpu work

### DIFF
--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -217,6 +217,7 @@ export async function run({
                 await new Promise(setImmediate);
               }
             }
+            await new Promise(setImmediate);
 
             // underlying metrics collection is actually synchronous
             // https://github.com/siimon/prom-client/blob/master/lib/histogram.js#L102-L125
@@ -277,6 +278,8 @@ export async function run({
         { step: "commit" },
         endClock(),
       );
+
+      await new Promise(setImmediate);
     }
 
     await database.setStatus(sync.getStatus());

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -407,6 +407,8 @@ export const createIndexingCache = ({
             insertValues.map(({ row }) => row),
           );
 
+          await new Promise(setImmediate);
+
           const endClock = startClock();
 
           // @ts-ignore
@@ -483,6 +485,8 @@ export const createIndexingCache = ({
               table,
             )}' rows`,
           });
+
+          await new Promise(setImmediate);
         }
 
         if (updateValues.length > 0) {
@@ -526,6 +530,8 @@ export const createIndexingCache = ({
             table,
             updateValues.map(({ row }) => row),
           );
+
+          await new Promise(setImmediate);
 
           const endClock = startClock();
 
@@ -596,6 +602,8 @@ export const createIndexingCache = ({
             service: "database",
             msg: `Updated ${updateValues.length} '${getTableName(table)}' rows`,
           });
+
+          await new Promise(setImmediate);
         }
 
         if (insertValues.length > 0 || updateValues.length > 0) {

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -752,6 +752,8 @@ export const createSyncStore = ({
           endClock(),
         );
 
+        await new Promise(setImmediate);
+
         let cursor: number;
         if (
           Math.max(

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -334,6 +334,9 @@ export const createSync = async (params: {
               { step: "decode" },
               endClock(),
             );
+
+            await new Promise(setImmediate);
+
             yield { events: decodedEvents, checkpoint };
           }
         }
@@ -1219,6 +1222,8 @@ export async function* getLocalEventGenerator(params: {
         service: "sync",
         msg: `Extracted ${events.length} '${params.network.name}' events for block range [${cursor}, ${queryCursor}]`,
       });
+
+      await new Promise(setImmediate);
 
       cursor = queryCursor + 1;
       if (cursor === toBlock) {


### PR DESCRIPTION
Use `setImmediate` to allow for the event loop to be cleared out after compute-heavy work. This has been shown to have more reliable performance and reduce contention.