### PR TITLE
don't use async buffer with omnichain ordering

### DIFF
--- a/.changeset/modern-icons-draw.md
+++ b/.changeset/modern-icons-draw.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved historical indexing performance.

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -395,15 +395,12 @@ export const createSync = async (params: {
           ),
           limit: Math.round(
             params.common.options.syncEventsQuerySize /
-              (params.indexingBuild.networks.length * 2),
+              (params.indexingBuild.networks.length + 1),
           ),
         });
 
-        return bufferAsyncGenerator(
-          sortCompletedAndPendingEvents(
-            decodeEventGenerator(localEventGenerator),
-          ),
-          1,
+        return sortCompletedAndPendingEvents(
+          decodeEventGenerator(localEventGenerator),
         );
       },
     );


### PR DESCRIPTION
The function used to merge event generators between all chains (`mergeAsyncGeneratorsWithEventOrder`) already implements a look-ahead mechanism. Ponder is better off using a larger batch of events.