### PR TITLE
docs: replace event.log.id with event.id for global uniqueness

### DIFF
--- a/docs/pages/docs/migration-guide.mdx
+++ b/docs/pages/docs/migration-guide.mdx
@@ -33,7 +33,7 @@ import { transferEvent } from "ponder:registry";
 ponder.on("ERC20:Transfer", ({ event, context }) => {
   await context.db
     .insert(transferEvent)
-    .values({ id: event.log.id });
+    .values({ id: event.id });
 });
 ```
 


### PR DESCRIPTION
In version 0.10, the property `event.log.id` was removed (along with `event.trace.id`). I've updated the code to use the new `event.id`, which serves as the globally unique identifier for events.

This ensures compatibility with the latest changes and maintains event tracking integrity.