### PR TITLE
docs: fix variable name in Context example

### DIFF
--- a/docs/pages/docs/utilities/types.mdx
+++ b/docs/pages/docs/utilities/types.mdx
@@ -66,7 +66,7 @@ A generic type that optionally accepts an event name and returns the `context` o
 import { ponder, type Context } from "ponder:registry";
 
 function helper(context: Context<"Weth:Deposit">) {
-  event;
+  context;
   // ^? {
   //      network: { name: "mainnet"; chainId: 1; };
   //      client: ReadonlyClient;


### PR DESCRIPTION
corrected a mismatch where `context` was referred to as `event` in the comment.