### PR TITLE
improve user schema migrations

### DIFF
--- a/packages/core/src/bin/commands/dev.ts
+++ b/packages/core/src/bin/commands/dev.ts
@@ -173,7 +173,9 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
           preBuild,
           schemaBuild,
         });
-        await database.migrate(indexingBuildResult.result);
+        crashRecoveryCheckpoint = await database.migrate(
+          indexingBuildResult.result,
+        );
 
         const apiResult = await build.executeApi({
           indexingBuild,
@@ -239,6 +241,7 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
           preBuild,
           schemaBuild,
           indexingBuild: indexingBuildResult.result,
+          crashRecoveryCheckpoint,
           onFatalError: () => {
             exit({ reason: "Received fatal error", code: 1 });
           },
@@ -288,6 +291,7 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
 
   let indexingBuild: IndexingBuild | undefined;
   let database: Database | undefined;
+  let crashRecoveryCheckpoint: string | undefined;
 
   const namespace =
     cliOptions.schema ?? process.env.DATABASE_SCHEMA ?? "public";

--- a/packages/core/src/bin/commands/start.ts
+++ b/packages/core/src/bin/commands/start.ts
@@ -113,7 +113,9 @@ export async function start({ cliOptions }: { cliOptions: CliOptions }) {
     preBuild,
     schemaBuild,
   });
-  await database.migrate(indexingBuildResult.result);
+  const crashRecoveryCheckpoint = await database.migrate(
+    indexingBuildResult.result,
+  );
 
   const apiResult = await build.executeApi({
     indexingBuild: indexingBuildResult.result,
@@ -160,6 +162,7 @@ export async function start({ cliOptions }: { cliOptions: CliOptions }) {
     preBuild,
     schemaBuild,
     indexingBuild: indexingBuildResult.result,
+    crashRecoveryCheckpoint,
     onFatalError: () => {
       exit({ reason: "Received fatal error", code: 1 });
     },

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -30,6 +30,7 @@ export async function run({
   schemaBuild,
   indexingBuild,
   database,
+  crashRecoveryCheckpoint,
   onFatalError,
   onReloadableError,
 }: {
@@ -38,10 +39,10 @@ export async function run({
   schemaBuild: SchemaBuild;
   indexingBuild: IndexingBuild;
   database: Database;
+  crashRecoveryCheckpoint: string | undefined;
   onFatalError: (error: Error) => void;
   onReloadableError: (error: Error) => void;
 }) {
-  const crashRecoveryCheckpoint = await database.recoverCheckpoint();
   await database.migrateSync();
 
   runCodegen({ common });

--- a/packages/core/src/database/index.test.ts
+++ b/packages/core/src/database/index.test.ts
@@ -278,7 +278,7 @@ test("migrate() succeeds with crash recovery after waiting for lock", async (con
   await context.common.shutdown.kill();
 });
 
-test("recoverCheckpoint() with crash recovery reverts rows", async (context) => {
+test("migrate() with crash recovery reverts rows", async (context) => {
   const database = await createDatabase({
     common: context.common,
     namespace: "public",
@@ -342,8 +342,7 @@ test("recoverCheckpoint() with crash recovery reverts rows", async (context) => 
     },
   });
 
-  await databaseTwo.migrate({ buildId: "abc" });
-  const checkpoint = await databaseTwo.recoverCheckpoint();
+  const checkpoint = await databaseTwo.migrate({ buildId: "abc" });
 
   expect(checkpoint).toStrictEqual(
     createCheckpoint({ chainId: 1n, blockNumber: 10n }),
@@ -365,7 +364,7 @@ test("recoverCheckpoint() with crash recovery reverts rows", async (context) => 
   await context.common.shutdown.kill();
 });
 
-test("recoverCheckpoint() with crash recovery drops indexes and triggers", async (context) => {
+test("migrate() with crash recovery drops indexes and triggers", async (context) => {
   const account = onchainTable(
     "account",
     (p) => ({
@@ -415,7 +414,6 @@ test("recoverCheckpoint() with crash recovery drops indexes and triggers", async
   });
 
   await databaseTwo.migrate({ buildId: "abc" });
-  await databaseTwo.recoverCheckpoint();
 
   const indexNames = await getUserIndexNames(databaseTwo, "public", "account");
 

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -871,7 +871,7 @@ EXECUTE PROCEDURE "${namespace}".${notification};`),
                   `DROP INDEX IF EXISTS "${namespace}"."${indexStatement.data.name}"`,
                 ),
               );
-              common.logger.info({
+              common.logger.debug({
                 service: "database",
                 msg: `Dropped index '${indexStatement.data.name}' in schema '${namespace}'`,
               });

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -769,6 +769,7 @@ EXECUTE PROCEDURE "${namespace}".${notification};`),
               } as const;
             }
 
+            // Note: ponder <=0.8 will evaluate this as true because the version is undefined
             if (previousApp.version !== VERSION) {
               const error = new NonRetryableError(
                 `Schema '${namespace}' was previously used by a Ponder app with a different minor version. Drop the schema first, or use a different schema. Read more: https://ponder.sh/docs/getting-started/database#database-schema`,

--- a/packages/core/src/indexing-store/cache.test.ts
+++ b/packages/core/src/indexing-store/cache.test.ts
@@ -32,7 +32,7 @@ test("flush() insert", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -78,7 +78,7 @@ test("flush() update", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -163,7 +163,7 @@ test("flush() encoding", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -226,7 +226,7 @@ test("flush() encoding escape", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -304,7 +304,7 @@ test("prefetch() uses profile metadata", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: { "Contract:Event": 0 },
   });
 
@@ -360,7 +360,7 @@ test("prefetch() evicts rows", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -7,7 +7,6 @@ import type { Common } from "@/internal/common.js";
 import { FlushError } from "@/internal/errors.js";
 import type { Event, Schema, SchemaBuild } from "@/internal/types.js";
 import type { Drizzle } from "@/types/db.js";
-import { ZERO_CHECKPOINT_STRING } from "@/utils/checkpoint.js";
 import { dedupe } from "@/utils/dedupe.js";
 import { prettyPrint } from "@/utils/print.js";
 import { startClock } from "@/utils/timer.js";
@@ -285,7 +284,7 @@ export const createIndexingCache = ({
 }: {
   common: Common;
   schemaBuild: Pick<SchemaBuild, "schema">;
-  crashRecoveryCheckpoint: string;
+  crashRecoveryCheckpoint: string | undefined;
   eventCount: { [eventName: string]: number };
 }): IndexingCache => {
   /**
@@ -295,7 +294,7 @@ export const createIndexingCache = ({
    */
   let cacheBytes = 0;
   let event: Event | undefined;
-  let isCacheComplete = crashRecoveryCheckpoint === ZERO_CHECKPOINT_STRING;
+  let isCacheComplete = crashRecoveryCheckpoint === undefined;
   const primaryKeyCache = new Map<Table, [string, Column][]>();
 
   const cache: Cache = new Map();

--- a/packages/core/src/indexing-store/historical.test.ts
+++ b/packages/core/src/indexing-store/historical.test.ts
@@ -10,7 +10,6 @@ import {
   NotNullConstraintError,
   UniqueConstraintError,
 } from "@/internal/errors.js";
-import { ZERO_CHECKPOINT_STRING } from "@/utils/checkpoint.js";
 import { eq } from "drizzle-orm";
 import { pgTable } from "drizzle-orm/pg-core";
 import { toBytes, zeroAddress } from "viem";
@@ -37,7 +36,7 @@ test("find", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -96,7 +95,7 @@ test("insert", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -251,7 +250,7 @@ test("update", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -346,7 +345,7 @@ test("delete", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -405,7 +404,7 @@ test("sql", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -484,7 +483,7 @@ test("sql followed by find", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -525,7 +524,7 @@ test("onchain table", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -561,7 +560,7 @@ test("missing rows", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -599,7 +598,7 @@ test("notNull", async (context) => {
   let indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -649,7 +648,7 @@ test("notNull", async (context) => {
     indexingCache = createIndexingCache({
       common: context.common,
       schemaBuild: { schema },
-      crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+      crashRecoveryCheckpoint: undefined,
       eventCount: {},
     });
 
@@ -690,7 +689,7 @@ test("default", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -727,7 +726,7 @@ test("$default", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -767,7 +766,7 @@ test("$onUpdateFn", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -810,7 +809,7 @@ test("array", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -855,7 +854,7 @@ test("text array", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -905,7 +904,7 @@ test("enum", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -949,7 +948,7 @@ test("json bigint", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -984,7 +983,7 @@ test("bytes", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -1026,7 +1025,7 @@ test("text with null bytes", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -1068,7 +1067,7 @@ test.skip("time", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -1110,7 +1109,7 @@ test("timestamp", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -1152,7 +1151,7 @@ test.skip("date", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -1194,7 +1193,7 @@ test.skip("interval", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -1236,7 +1235,7 @@ test("point", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 
@@ -1278,7 +1277,7 @@ test("line", async (context) => {
   const indexingCache = createIndexingCache({
     common: context.common,
     schemaBuild: { schema },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     eventCount: {},
   });
 

--- a/packages/core/src/sync/index.test.ts
+++ b/packages/core/src/sync/index.test.ts
@@ -16,11 +16,7 @@ import {
 import { buildConfigAndIndexingFunctions } from "@/build/configAndIndexingFunctions.js";
 import type { BlockFilter, Event, Filter, Fragment } from "@/internal/types.js";
 import { createHistoricalSync } from "@/sync-historical/index.js";
-import {
-  MAX_CHECKPOINT_STRING,
-  ZERO_CHECKPOINT_STRING,
-  decodeCheckpoint,
-} from "@/utils/checkpoint.js";
+import { MAX_CHECKPOINT_STRING, decodeCheckpoint } from "@/utils/checkpoint.js";
 import { drainAsyncGenerator } from "@/utils/generators.js";
 import type { Interval } from "@/utils/interval.js";
 import { promiseWithResolvers } from "@/utils/promiseWithResolvers.js";
@@ -1056,7 +1052,7 @@ test("createSync()", async (context) => {
     syncStore,
     onRealtimeEvent: async () => {},
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
@@ -1093,7 +1089,7 @@ test("getEvents() multichain", async (context) => {
     ],
     onRealtimeEvent: async () => {},
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
@@ -1135,7 +1131,7 @@ test("getEvents() omnichain", async (context) => {
     ],
     onRealtimeEvent: async () => {},
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "omnichain",
   });
 
@@ -1178,7 +1174,7 @@ test("getEvents() mulitchain updates status", async (context) => {
     ],
     onRealtimeEvent: async () => {},
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
@@ -1221,7 +1217,7 @@ test("getEvents() omnichain updates status", async (context) => {
     ],
     onRealtimeEvent: async () => {},
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
@@ -1306,7 +1302,7 @@ test.skip("startRealtime()", async (context) => {
     ],
     onRealtimeEvent: async () => {},
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
@@ -1356,7 +1352,7 @@ test("onEvent() multichain handles block", async (context) => {
       }
     },
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
@@ -1403,7 +1399,7 @@ test("onEvent() omnichain handles block", async (context) => {
       }
     },
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "omnichain",
   });
 
@@ -1454,7 +1450,7 @@ test("onEvent() handles finalize", async (context) => {
       }
     },
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
@@ -1510,7 +1506,7 @@ test("onEvent() kills realtime when finalized", async (context) => {
       }
     },
     onFatalError: () => {},
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
@@ -1559,7 +1555,7 @@ test("onEvent() handles errors", async (context) => {
     onFatalError: () => {
       promise.resolve();
     },
-    crashRecoveryCheckpoint: ZERO_CHECKPOINT_STRING,
+    crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -223,7 +223,7 @@ export const createSync = async (params: {
   syncStore: SyncStore;
   onRealtimeEvent(event: RealtimeEvent): Promise<void>;
   onFatalError(error: Error): void;
-  crashRecoveryCheckpoint: string;
+  crashRecoveryCheckpoint: string | undefined;
   ordering: "omnichain" | "multichain";
 }): Promise<Sync> => {
   const perNetworkSync = new Map<
@@ -350,12 +350,13 @@ export const createSync = async (params: {
           for await (const { events, checkpoint } of eventGenerator) {
             // Sort out any events before the crash recovery checkpoint
             if (
+              params.crashRecoveryCheckpoint &&
               events.length > 0 &&
               events[0]!.checkpoint < params.crashRecoveryCheckpoint
             ) {
               const [, right] = partition(
                 events,
-                (event) => event.checkpoint <= params.crashRecoveryCheckpoint,
+                (event) => event.checkpoint <= params.crashRecoveryCheckpoint!,
               );
               yield { events: right, checkpoint };
               // Sort out any events between the omnichain finalized checkpoint and the single-chain


### PR DESCRIPTION
Migrations of the "user" schema now validate the "version" of the `_ponder_meta` table.

https://github.com/ponder-sh/ponder/blob/5a3a2ddc80c550f2c2b6d630ddaf340718d40ccb/packages/core/src/database/index.ts#L104

New instances of Ponder will validate using this version or throw an error. Note that versions <=0.8 will throw the error because the `version` column was added in 0.9.

Also combined the `database.migrate()` and `database.recoverCheckpoint()` function.