### PR TITLE
improve build robustness

### DIFF
--- a/.changeset/curvy-socks-draw.md
+++ b/.changeset/curvy-socks-draw.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved import rules between config, schema, indexing functions, and api function files.

--- a/packages/core/src/bin/commands/dev.ts
+++ b/packages/core/src/bin/commands/dev.ts
@@ -115,7 +115,7 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
           return;
         }
 
-        const schemaResult = await build.executeSchema({ namespace });
+        const schemaResult = await build.executeSchema();
         if (schemaResult.status === "error") {
           buildQueue.add({
             status: "error",
@@ -291,6 +291,8 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
 
   const namespace =
     cliOptions.schema ?? process.env.DATABASE_SCHEMA ?? "public";
+
+  globalThis.PONDER_NAMESPACE_BUILD = namespace;
 
   build.startDev({
     onReload: (kind) => {

--- a/packages/core/src/bin/commands/serve.ts
+++ b/packages/core/src/bin/commands/serve.ts
@@ -69,9 +69,7 @@ export async function serve({ cliOptions }: { cliOptions: CliOptions }) {
     return;
   }
 
-  const schemaResult = await build.executeSchema({
-    namespace: namespaceResult.result,
-  });
+  const schemaResult = await build.executeSchema();
   if (schemaResult.status === "error") {
     await exit({ reason: "Failed intial build", code: 1 });
     return;

--- a/packages/core/src/bin/commands/start.ts
+++ b/packages/core/src/bin/commands/start.ts
@@ -72,9 +72,7 @@ export async function start({ cliOptions }: { cliOptions: CliOptions }) {
     return;
   }
 
-  const schemaResult = await build.executeSchema({
-    namespace: namespaceResult.result,
-  });
+  const schemaResult = await build.executeSchema();
   if (schemaResult.status === "error") {
     await exit({ reason: "Failed intial build", code: 1 });
     return;

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -51,9 +51,7 @@ type ApiResult = Result<{ app: Hono }>;
 
 export type Build = {
   executeConfig: () => Promise<ConfigResult>;
-  executeSchema: (params: {
-    namespace: NamespaceBuild;
-  }) => Promise<SchemaResult>;
+  executeSchema: () => Promise<SchemaResult>;
   executeIndexingFunctions: () => Promise<IndexingResult>;
   executeApi: (params: {
     indexingBuild: IndexingBuild;
@@ -193,16 +191,7 @@ export const createBuild = async ({
         result: { config, contentHash },
       } as const;
     },
-    async executeSchema({ namespace }): Promise<SchemaResult> {
-      const schemaFile = toFilePath(
-        common.options.schemaFile,
-        common.options.rootDir,
-      ).path;
-
-      viteNodeRunner.moduleCache.invalidateDepTree([schemaFile]);
-      viteNodeRunner.moduleCache.deleteByModuleId("ponder:schema");
-
-      globalThis.PONDER_NAMESPACE_BUILD = namespace;
+    async executeSchema(): Promise<SchemaResult> {
       const executeResult = await executeFile({
         file: common.options.schemaFile,
       });
@@ -232,9 +221,6 @@ export const createBuild = async ({
       const files = glob.sync(indexingPattern, {
         ignore: apiPattern,
       });
-
-      viteNodeRunner.moduleCache.invalidateDepTree(files);
-      viteNodeRunner.moduleCache.deleteByModuleId("ponder:registry");
 
       const executeResults = await Promise.all(
         files.map(async (file) => ({
@@ -303,9 +289,6 @@ export const createBuild = async ({
         return { status: "error", error };
       }
 
-      viteNodeRunner.moduleCache.invalidateDepTree(glob.sync(apiPattern));
-      viteNodeRunner.moduleCache.deleteByModuleId("ponder:api");
-
       const executeResult = await executeFile({
         file: common.options.apiFile,
       });
@@ -360,9 +343,14 @@ export const createBuild = async ({
         });
         return { status: "error", error } as const;
       }
+
+      const namespace = cliOptions.schema ?? process.env.DATABASE_SCHEMA!;
+
+      globalThis.PONDER_NAMESPACE_BUILD = namespace;
+
       return {
         status: "success",
-        result: cliOptions.schema ?? process.env.DATABASE_SCHEMA!,
+        result: namespace,
       } as const;
     },
     preCompile({ config }): Result<PreBuild> {

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -194,6 +194,14 @@ export const createBuild = async ({
       } as const;
     },
     async executeSchema({ namespace }): Promise<SchemaResult> {
+      const schemaFile = toFilePath(
+        common.options.schemaFile,
+        common.options.rootDir,
+      ).path;
+
+      viteNodeRunner.moduleCache.invalidateDepTree([schemaFile]);
+      viteNodeRunner.moduleCache.deleteByModuleId("ponder:schema");
+
       globalThis.PONDER_NAMESPACE_BUILD = namespace;
       const executeResult = await executeFile({
         file: common.options.schemaFile,
@@ -224,6 +232,10 @@ export const createBuild = async ({
       const files = glob.sync(indexingPattern, {
         ignore: apiPattern,
       });
+
+      viteNodeRunner.moduleCache.invalidateDepTree(files);
+      viteNodeRunner.moduleCache.deleteByModuleId("ponder:registry");
+
       const executeResults = await Promise.all(
         files.map(async (file) => ({
           ...(await executeFile({ file })),

--- a/packages/core/src/build/plugin.ts
+++ b/packages/core/src/build/plugin.ts
@@ -19,7 +19,7 @@ export default schema;
 const apiModule = () => `import { createPublicClient } from "viem";
 
 if (globalThis.PONDER_INDEXING_BUILD === undefined || globalThis.PONDER_DATABASE === undefined) {
-  throw new Error('Invalid dependency graph. Please ensure that nothing is imported from "src/api/index.ts"')
+  throw new Error('Invalid dependency graph. Config, schema, and indexing function files cannot import objects from the API function file "src/api/index.ts".')
 }
 
 const publicClients = {};

--- a/packages/core/src/build/plugin.ts
+++ b/packages/core/src/build/plugin.ts
@@ -18,16 +18,20 @@ export default schema;
 
 const apiModule = () => `import { createPublicClient } from "viem";
 
+if (globalThis.PONDER_INDEXING_BUILD === undefined || globalThis.PONDER_DATABASE === undefined) {
+  throw new Error('Invalid dependency graph. Please ensure that nothing is imported from "src/api/index.ts"')
+}
+
 const publicClients = {};
 
-for (const network of globalThis.PONDER_INDEXING_BUILD.networks ?? []) {
+for (const network of globalThis.PONDER_INDEXING_BUILD.networks) {
   publicClients[network.chainId] = createPublicClient({
     chain: network.chain,
     transport: () => network.transport
   })
 }
 
-export const db = globalThis.PONDER_DATABASE?.qb.drizzleReadonly;
+export const db = globalThis.PONDER_DATABASE.qb.drizzleReadonly;
 export { publicClients };
 `;
 

--- a/packages/core/src/build/plugin.ts
+++ b/packages/core/src/build/plugin.ts
@@ -20,14 +20,14 @@ const apiModule = () => `import { createPublicClient } from "viem";
 
 const publicClients = {};
 
-for (const network of globalThis.PONDER_INDEXING_BUILD.networks) {
+for (const network of globalThis.PONDER_INDEXING_BUILD.networks ?? []) {
   publicClients[network.chainId] = createPublicClient({
     chain: network.chain,
     transport: () => network.transport
   })
 }
 
-export const db = globalThis.PONDER_DATABASE.qb.drizzleReadonly;
+export const db = globalThis.PONDER_DATABASE?.qb.drizzleReadonly;
 export { publicClients };
 `;
 


### PR DESCRIPTION
- Fixed dependency rules between `ponder.config.ts`, `ponder.schema.ts`, and `src/**.ts`. Now all of these can import from each other without issue.
- Fixed dependency rules for `src/api/index.ts`. No imports are allowed from `src/api/index.ts`. 
<img width="712" alt="Screenshot 2025-04-18 at 2 02 01 PM" src="https://github.com/user-attachments/assets/05662fb4-2ac1-4597-a6a1-c89e65316620" />
