### PR TITLE
fix prediction for logs and traces with no args

### DIFF
--- a/.changeset/twenty-coats-sit.md
+++ b/.changeset/twenty-coats-sit.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug affecting logs and traces with no args.

--- a/.changeset/twenty-coats-sit.md
+++ b/.changeset/twenty-coats-sit.md
@@ -2,4 +2,4 @@
 "ponder": patch
 ---
 
-Fixed a bug affecting logs and traces with no args.
+Fixed a bug affecting logs and traces with no args that would cause the error `TypeError: Cannot convert undefined or null to object`.

--- a/packages/core/src/indexing-store/profile.test.ts
+++ b/packages/core/src/indexing-store/profile.test.ts
@@ -88,7 +88,7 @@ test("recordProfilePattern() with undefined trace event args", () => {
       args: undefined,
       result: undefined,
       trace: {} as TraceEvent["event"]["trace"],
-      transaction: {} as LogEvent["event"]["transaction"],
+      transaction: {} as TraceEvent["event"]["transaction"],
       block: {} as BlockEvent["event"]["block"],
     },
   } satisfies TraceEvent;

--- a/packages/core/src/indexing-store/profile.test.ts
+++ b/packages/core/src/indexing-store/profile.test.ts
@@ -115,6 +115,81 @@ test("recordProfilePattern() with undefined trace event args", () => {
   expect(pattern).toBeUndefined();
 });
 
+test("recordProfilePattern() with array log event args", () => {
+  const event = {
+    type: "log",
+    chainId: 1,
+    checkpoint: ZERO_CHECKPOINT_STRING,
+    name: "",
+    event: {
+      id: ZERO_CHECKPOINT_STRING,
+      args: [],
+      log: {} as LogEvent["event"]["log"],
+      transaction: {} as LogEvent["event"]["transaction"],
+      block: {} as BlockEvent["event"]["block"],
+    },
+  } satisfies LogEvent;
+
+  const schema = {
+    account: onchainTable("account", (p) => ({
+      address: p.hex().primaryKey(),
+      balance: p.bigint().notNull(),
+    })),
+  };
+
+  const primaryKeyCache = new Map<Table, [string, Column][]>();
+
+  primaryKeyCache.set(schema.account, [["address", schema.account.address]]);
+
+  const pattern = recordProfilePattern(
+    event,
+    schema.account,
+    { address: zeroAddress },
+    [],
+    primaryKeyCache,
+  );
+
+  expect(pattern).toBeUndefined();
+});
+
+test("recordProfilePattern() with array trace event args", () => {
+  const event = {
+    type: "trace",
+    chainId: 1,
+    checkpoint: ZERO_CHECKPOINT_STRING,
+    name: "",
+    event: {
+      id: ZERO_CHECKPOINT_STRING,
+      args: [],
+      result: [],
+      trace: {} as TraceEvent["event"]["trace"],
+      transaction: {} as TraceEvent["event"]["transaction"],
+      block: {} as BlockEvent["event"]["block"],
+    },
+  } satisfies TraceEvent;
+
+  const schema = {
+    account: onchainTable("account", (p) => ({
+      address: p.hex().primaryKey(),
+      balance: p.bigint().notNull(),
+    })),
+  };
+
+  const primaryKeyCache = new Map<Table, [string, Column][]>();
+
+  primaryKeyCache.set(schema.account, [["address", schema.account.address]]);
+
+  const pattern = recordProfilePattern(
+    event,
+    schema.account,
+    { address: zeroAddress },
+    [],
+    primaryKeyCache,
+  );
+
+  expect(pattern).toBeUndefined();
+});
+
 test("recordProfilePattern() chainId", () => {
   const event = {
     type: "block",

--- a/packages/core/src/indexing-store/profile.test.ts
+++ b/packages/core/src/indexing-store/profile.test.ts
@@ -1,5 +1,5 @@
 import { onchainTable } from "@/drizzle/onchain.js";
-import type { BlockEvent, LogEvent } from "@/internal/types.js";
+import type { BlockEvent, LogEvent, TraceEvent } from "@/internal/types.js";
 import { ZERO_CHECKPOINT_STRING } from "@/utils/checkpoint.js";
 import type { Column, Table } from "drizzle-orm";
 import { zeroAddress } from "viem";
@@ -17,6 +17,81 @@ test("recordProfilePattern() no pattern", () => {
       block: {} as BlockEvent["event"]["block"],
     },
   } satisfies BlockEvent;
+
+  const schema = {
+    account: onchainTable("account", (p) => ({
+      address: p.hex().primaryKey(),
+      balance: p.bigint().notNull(),
+    })),
+  };
+
+  const primaryKeyCache = new Map<Table, [string, Column][]>();
+
+  primaryKeyCache.set(schema.account, [["address", schema.account.address]]);
+
+  const pattern = recordProfilePattern(
+    event,
+    schema.account,
+    { address: zeroAddress },
+    [],
+    primaryKeyCache,
+  );
+
+  expect(pattern).toBeUndefined();
+});
+
+test("recordProfilePattern() with undefined log event args", () => {
+  const event = {
+    type: "log",
+    chainId: 1,
+    checkpoint: ZERO_CHECKPOINT_STRING,
+    name: "",
+    event: {
+      id: ZERO_CHECKPOINT_STRING,
+      args: undefined,
+      log: {} as LogEvent["event"]["log"],
+      transaction: {} as LogEvent["event"]["transaction"],
+      block: {} as BlockEvent["event"]["block"],
+    },
+  } satisfies LogEvent;
+
+  const schema = {
+    account: onchainTable("account", (p) => ({
+      address: p.hex().primaryKey(),
+      balance: p.bigint().notNull(),
+    })),
+  };
+
+  const primaryKeyCache = new Map<Table, [string, Column][]>();
+
+  primaryKeyCache.set(schema.account, [["address", schema.account.address]]);
+
+  const pattern = recordProfilePattern(
+    event,
+    schema.account,
+    { address: zeroAddress },
+    [],
+    primaryKeyCache,
+  );
+
+  expect(pattern).toBeUndefined();
+});
+
+test("recordProfilePattern() with undefined trace event args", () => {
+  const event = {
+    type: "trace",
+    chainId: 1,
+    checkpoint: ZERO_CHECKPOINT_STRING,
+    name: "",
+    event: {
+      id: ZERO_CHECKPOINT_STRING,
+      args: undefined,
+      result: undefined,
+      trace: {} as TraceEvent["event"]["trace"],
+      transaction: {} as LogEvent["event"]["transaction"],
+      block: {} as BlockEvent["event"]["block"],
+    },
+  } satisfies TraceEvent;
 
   const schema = {
     account: onchainTable("account", (p) => ({

--- a/packages/core/src/indexing-store/profile.ts
+++ b/packages/core/src/indexing-store/profile.ts
@@ -132,10 +132,16 @@ export const recordProfilePattern = (
       }
 
       case "log": {
-        if (event.event.args !== undefined) {
+        // Note: explicitly skip profiling args if they are an array
+        if (
+          event.event.args !== undefined &&
+          Array.isArray(event.event.args) === false
+        ) {
           let hasMatch = false;
           for (const argKey of Object.keys(event.event.args)) {
-            const argValue = event.event.args[argKey];
+            const argValue = (event.event.args as { [key: string]: unknown })[
+              argKey
+            ] as string | bigint | number | boolean;
 
             if (typeof argValue !== "object" && eq(argValue, value)) {
               result[js] = ["args", argKey];
@@ -214,9 +220,15 @@ export const recordProfilePattern = (
       case "trace": {
         let hasMatch = false;
 
-        if (event.event.args !== undefined) {
+        // Note: explicitly skip profiling args if they are an array
+        if (
+          event.event.args !== undefined &&
+          Array.isArray(event.event.args) === false
+        ) {
           for (const argKey of Object.keys(event.event.args)) {
-            const argValue = event.event.args[argKey];
+            const argValue = (event.event.args as { [key: string]: unknown })[
+              argKey
+            ] as string | bigint | number | boolean;
 
             if (typeof argValue !== "object" && eq(argValue, value)) {
               result[js] = ["args", argKey];
@@ -226,9 +238,15 @@ export const recordProfilePattern = (
           }
         }
 
-        if (event.event.result !== undefined) {
+        // Note: explicitly skip profiling result if it is an array
+        if (
+          event.event.result !== undefined &&
+          Array.isArray(event.event.result) === false
+        ) {
           for (const argKey of Object.keys(event.event.result)) {
-            const argValue = event.event.result[argKey];
+            const argValue = (event.event.result as { [key: string]: unknown })[
+              argKey
+            ] as string | bigint | number | boolean;
 
             if (typeof argValue !== "object" && eq(argValue, value)) {
               result[js] = ["result", argKey];

--- a/packages/core/src/indexing-store/profile.ts
+++ b/packages/core/src/indexing-store/profile.ts
@@ -132,18 +132,20 @@ export const recordProfilePattern = (
       }
 
       case "log": {
-        let hasMatch = false;
-        for (const argKey of Object.keys(event.event.args)) {
-          const argValue = event.event.args[argKey];
+        if (event.event.args !== undefined) {
+          let hasMatch = false;
+          for (const argKey of Object.keys(event.event.args)) {
+            const argValue = event.event.args[argKey];
 
-          if (typeof argValue !== "object" && eq(argValue, value)) {
-            result[js] = ["args", argKey];
-            hasMatch = true;
-            break;
+            if (typeof argValue !== "object" && eq(argValue, value)) {
+              result[js] = ["args", argKey];
+              hasMatch = true;
+              break;
+            }
           }
-        }
 
-        if (hasMatch) continue;
+          if (hasMatch) continue;
+        }
 
         if (eq(event.event.log.address, value)) {
           result[js] = ["log", "address"];
@@ -211,13 +213,28 @@ export const recordProfilePattern = (
 
       case "trace": {
         let hasMatch = false;
-        for (const argKey of Object.keys(event.event.args)) {
-          const argValue = event.event.args[argKey];
 
-          if (typeof argValue !== "object" && eq(argValue, value)) {
-            result[js] = ["args", argKey];
-            hasMatch = true;
-            break;
+        if (event.event.args !== undefined) {
+          for (const argKey of Object.keys(event.event.args)) {
+            const argValue = event.event.args[argKey];
+
+            if (typeof argValue !== "object" && eq(argValue, value)) {
+              result[js] = ["args", argKey];
+              hasMatch = true;
+              break;
+            }
+          }
+        }
+
+        if (event.event.result !== undefined) {
+          for (const argKey of Object.keys(event.event.result)) {
+            const argValue = event.event.result[argKey];
+
+            if (typeof argValue !== "object" && eq(argValue, value)) {
+              result[js] = ["result", argKey];
+              hasMatch = true;
+              break;
+            }
           }
         }
 

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -341,7 +341,7 @@ export const toErrorMeta = (
 
     case "log": {
       return [
-        `Event arguments:\n${prettyPrint(event?.event?.args)}`,
+        `Event arguments:\n${prettyPrint(Array.isArray(event.event?.args) ? undefined : event.event?.args)}`,
         logText(event?.event?.log),
         transactionText(event?.event?.transaction),
         blockText(event?.event?.block),
@@ -350,7 +350,7 @@ export const toErrorMeta = (
 
     case "trace": {
       return [
-        `Call trace arguments:\n${prettyPrint(event?.event?.args)}`,
+        `Call trace arguments:\n${prettyPrint(Array.isArray(event.event?.args) ? undefined : event.event?.args)}`,
         traceText(event?.event?.trace),
         transactionText(event?.event?.transaction),
         blockText(event?.event?.block),

--- a/packages/core/src/indexing/profile.test.ts
+++ b/packages/core/src/indexing/profile.test.ts
@@ -207,6 +207,207 @@ test("recordProfilePattern() with undefined trace event args", () => {
   `);
 });
 
+test("recordProfilePattern() with array log event args", () => {
+  const event = {
+    type: "log",
+    chainId: 1,
+    checkpoint: ZERO_CHECKPOINT_STRING,
+    name: "",
+    event: {
+      id: ZERO_CHECKPOINT_STRING,
+      args: [],
+      log: {} as LogEvent["event"]["log"],
+      transaction: {} as LogEvent["event"]["transaction"],
+      block: { number: 5n } as BlockEvent["event"]["block"],
+    },
+  } satisfies LogEvent;
+
+  const pattern = recordProfilePattern({
+    event,
+    args: {
+      address: zeroAddress,
+      abi: [getAbiItem({ abi: erc20ABI, name: "balanceOf" })],
+      functionName: "balanceOf",
+      args: [ALICE],
+    },
+    hints: [],
+  });
+
+  expect(pattern).toMatchInlineSnapshot(`
+    {
+      "hasConstant": true,
+      "pattern": {
+        "abi": [
+          {
+            "inputs": [
+              {
+                "internalType": "address",
+                "name": "",
+                "type": "address",
+              },
+            ],
+            "name": "balanceOf",
+            "outputs": [
+              {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256",
+              },
+            ],
+            "stateMutability": "view",
+            "type": "function",
+          },
+        ],
+        "address": {
+          "type": "constant",
+          "value": "0x0000000000000000000000000000000000000000",
+        },
+        "args": [
+          {
+            "type": "constant",
+            "value": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          },
+        ],
+        "functionName": "balanceOf",
+      },
+    }
+  `);
+
+  expect(recoverProfilePattern(pattern!.pattern, event)).toMatchInlineSnapshot(`
+    {
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address",
+            },
+          ],
+          "name": "balanceOf",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256",
+            },
+          ],
+          "stateMutability": "view",
+          "type": "function",
+        },
+      ],
+      "address": "0x0000000000000000000000000000000000000000",
+      "args": [
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      ],
+      "blockNumber": 5n,
+      "chainId": 1,
+      "functionName": "balanceOf",
+    }
+  `);
+});
+
+test("recordProfilePattern() with array trace event args", () => {
+  const event = {
+    type: "trace",
+    chainId: 1,
+    checkpoint: ZERO_CHECKPOINT_STRING,
+    name: "",
+    event: {
+      id: ZERO_CHECKPOINT_STRING,
+      args: [],
+      result: [],
+      trace: {} as TraceEvent["event"]["trace"],
+      transaction: {} as TraceEvent["event"]["transaction"],
+      block: { number: 5n } as BlockEvent["event"]["block"],
+    },
+  } satisfies TraceEvent;
+
+  const pattern = recordProfilePattern({
+    event,
+    args: {
+      address: zeroAddress,
+      abi: [getAbiItem({ abi: erc20ABI, name: "balanceOf" })],
+      functionName: "balanceOf",
+      args: [ALICE],
+    },
+    hints: [],
+  });
+
+  expect(pattern).toMatchInlineSnapshot(`
+    {
+      "hasConstant": true,
+      "pattern": {
+        "abi": [
+          {
+            "inputs": [
+              {
+                "internalType": "address",
+                "name": "",
+                "type": "address",
+              },
+            ],
+            "name": "balanceOf",
+            "outputs": [
+              {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256",
+              },
+            ],
+            "stateMutability": "view",
+            "type": "function",
+          },
+        ],
+        "address": {
+          "type": "constant",
+          "value": "0x0000000000000000000000000000000000000000",
+        },
+        "args": [
+          {
+            "type": "constant",
+            "value": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          },
+        ],
+        "functionName": "balanceOf",
+      },
+    }
+  `);
+
+  expect(recoverProfilePattern(pattern!.pattern, event)).toMatchInlineSnapshot(`
+    {
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address",
+            },
+          ],
+          "name": "balanceOf",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256",
+            },
+          ],
+          "stateMutability": "view",
+          "type": "function",
+        },
+      ],
+      "address": "0x0000000000000000000000000000000000000000",
+      "args": [
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      ],
+      "blockNumber": 5n,
+      "chainId": 1,
+      "functionName": "balanceOf",
+    }
+  `);
+});
+
 test("recordProfilePattern() address", () => {
   const event = {
     type: "log",

--- a/packages/core/src/indexing/profile.test.ts
+++ b/packages/core/src/indexing/profile.test.ts
@@ -1,10 +1,213 @@
 import { ALICE } from "@/_test/constants.js";
 import { erc20ABI } from "@/_test/generated.js";
-import type { BlockEvent, LogEvent } from "@/internal/types.js";
+import type { BlockEvent, LogEvent, TraceEvent } from "@/internal/types.js";
 import { ZERO_CHECKPOINT_STRING } from "@/utils/checkpoint.js";
 import { getAbiItem, zeroAddress } from "viem";
 import { expect, test } from "vitest";
 import { recordProfilePattern, recoverProfilePattern } from "./profile.js";
+
+test("recordProfilePattern() with undefined log event args", () => {
+  const event = {
+    type: "log",
+    chainId: 1,
+    checkpoint: ZERO_CHECKPOINT_STRING,
+    name: "",
+    event: {
+      id: ZERO_CHECKPOINT_STRING,
+      args: undefined,
+      log: {} as LogEvent["event"]["log"],
+      transaction: {} as LogEvent["event"]["transaction"],
+      block: { number: 5n } as BlockEvent["event"]["block"],
+    },
+  } satisfies LogEvent;
+
+  const pattern = recordProfilePattern({
+    event,
+    args: {
+      address: zeroAddress,
+      abi: [getAbiItem({ abi: erc20ABI, name: "balanceOf" })],
+      functionName: "balanceOf",
+      args: [ALICE],
+    },
+    hints: [],
+  });
+
+  expect(pattern).toMatchInlineSnapshot(`
+    {
+      "hasConstant": true,
+      "pattern": {
+        "abi": [
+          {
+            "inputs": [
+              {
+                "internalType": "address",
+                "name": "",
+                "type": "address",
+              },
+            ],
+            "name": "balanceOf",
+            "outputs": [
+              {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256",
+              },
+            ],
+            "stateMutability": "view",
+            "type": "function",
+          },
+        ],
+        "address": {
+          "type": "constant",
+          "value": "0x0000000000000000000000000000000000000000",
+        },
+        "args": [
+          {
+            "type": "constant",
+            "value": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          },
+        ],
+        "functionName": "balanceOf",
+      },
+    }
+  `);
+
+  expect(recoverProfilePattern(pattern!.pattern, event)).toMatchInlineSnapshot(`
+    {
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address",
+            },
+          ],
+          "name": "balanceOf",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256",
+            },
+          ],
+          "stateMutability": "view",
+          "type": "function",
+        },
+      ],
+      "address": "0x0000000000000000000000000000000000000000",
+      "args": [
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      ],
+      "blockNumber": 5n,
+      "chainId": 1,
+      "functionName": "balanceOf",
+    }
+  `);
+});
+
+test("recordProfilePattern() with undefined trace event args", () => {
+  const event = {
+    type: "trace",
+    chainId: 1,
+    checkpoint: ZERO_CHECKPOINT_STRING,
+    name: "",
+    event: {
+      id: ZERO_CHECKPOINT_STRING,
+      args: undefined,
+      result: undefined,
+      trace: {
+        address: ALICE,
+      } as unknown as TraceEvent["event"]["trace"],
+      transaction: {} as TraceEvent["event"]["transaction"],
+      block: { number: 5n } as BlockEvent["event"]["block"],
+    },
+  } satisfies TraceEvent;
+
+  const pattern = recordProfilePattern({
+    event,
+    args: {
+      address: zeroAddress,
+      abi: [getAbiItem({ abi: erc20ABI, name: "balanceOf" })],
+      functionName: "balanceOf",
+      args: [ALICE],
+    },
+    hints: [],
+  });
+
+  expect(pattern).toMatchInlineSnapshot(`
+    {
+      "hasConstant": true,
+      "pattern": {
+        "abi": [
+          {
+            "inputs": [
+              {
+                "internalType": "address",
+                "name": "",
+                "type": "address",
+              },
+            ],
+            "name": "balanceOf",
+            "outputs": [
+              {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256",
+              },
+            ],
+            "stateMutability": "view",
+            "type": "function",
+          },
+        ],
+        "address": {
+          "type": "constant",
+          "value": "0x0000000000000000000000000000000000000000",
+        },
+        "args": [
+          {
+            "type": "constant",
+            "value": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          },
+        ],
+        "functionName": "balanceOf",
+      },
+    }
+  `);
+
+  expect(recoverProfilePattern(pattern!.pattern, event)).toMatchInlineSnapshot(`
+    {
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address",
+            },
+          ],
+          "name": "balanceOf",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256",
+            },
+          ],
+          "stateMutability": "view",
+          "type": "function",
+        },
+      ],
+      "address": "0x0000000000000000000000000000000000000000",
+      "args": [
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      ],
+      "blockNumber": 5n,
+      "chainId": 1,
+      "functionName": "balanceOf",
+    }
+  `);
+});
 
 test("recordProfilePattern() address", () => {
   const event = {

--- a/packages/core/src/indexing/profile.test.ts
+++ b/packages/core/src/indexing/profile.test.ts
@@ -116,9 +116,7 @@ test("recordProfilePattern() with undefined trace event args", () => {
       id: ZERO_CHECKPOINT_STRING,
       args: undefined,
       result: undefined,
-      trace: {
-        address: ALICE,
-      } as unknown as TraceEvent["event"]["trace"],
+      trace: {} as TraceEvent["event"]["trace"],
       transaction: {} as TraceEvent["event"]["transaction"],
       block: { number: 5n } as BlockEvent["event"]["block"],
     },

--- a/packages/core/src/indexing/profile.ts
+++ b/packages/core/src/indexing/profile.ts
@@ -102,10 +102,17 @@ export const recordProfilePattern = ({
     }
 
     case "log": {
-      let hasMatch = false;
-      if (event.event.args !== undefined) {
+      // Note: explicitly skip profiling args if they are an array
+      if (
+        event.event.args !== undefined &&
+        Array.isArray(event.event.args) === false
+      ) {
+        let hasMatch = false;
+
         for (const argKey of Object.keys(event.event.args)) {
-          const argValue = event.event.args[argKey];
+          const argValue = (event.event.args as { [key: string]: unknown })[
+            argKey
+          ] as string | bigint | number | boolean;
 
           if (typeof argValue !== "object" && eq(argValue, args.address)) {
             resultAddress = { type: "derived", value: ["args", argKey] };
@@ -113,9 +120,9 @@ export const recordProfilePattern = ({
             break;
           }
         }
-      }
 
-      if (hasMatch) break;
+        if (hasMatch) break;
+      }
 
       if (eq(event.event.log.address, args.address)) {
         resultAddress = { type: "derived", value: ["log", "address"] };
@@ -157,9 +164,15 @@ export const recordProfilePattern = ({
     case "trace": {
       let hasMatch = false;
 
-      if (event.event.args !== undefined) {
+      // Note: explicitly skip profiling args if they are an array
+      if (
+        event.event.args !== undefined &&
+        Array.isArray(event.event.args) === false
+      ) {
         for (const argKey of Object.keys(event.event.args)) {
-          const argValue = event.event.args[argKey];
+          const argValue = (event.event.args as { [key: string]: unknown })[
+            argKey
+          ] as string | bigint | number | boolean;
 
           if (typeof argValue !== "object" && eq(argValue, args.address)) {
             resultAddress = { type: "derived", value: ["args", argKey] };
@@ -169,9 +182,15 @@ export const recordProfilePattern = ({
         }
       }
 
-      if (event.event.result !== undefined) {
+      // Note: explicitly skip profiling result if it is an array
+      if (
+        event.event.result !== undefined &&
+        Array.isArray(event.event.result) === false
+      ) {
         for (const argKey of Object.keys(event.event.result)) {
-          const argValue = event.event.result[argKey];
+          const argValue = (event.event.result as { [key: string]: unknown })[
+            argKey
+          ] as string | bigint | number | boolean;
 
           if (typeof argValue !== "object" && eq(argValue, args.address)) {
             resultAddress = { type: "derived", value: ["result", argKey] };
@@ -389,10 +408,17 @@ export const recordProfilePattern = ({
       }
 
       case "log": {
-        let hasMatch = false;
-        if (event.event.args !== undefined) {
+        // Note: explicitly skip profiling args if they are an array
+        if (
+          event.event.args !== undefined &&
+          Array.isArray(event.event.args) === false
+        ) {
+          let hasMatch = false;
+
           for (const argKey of Object.keys(event.event.args)) {
-            const argValue = event.event.args[argKey];
+            const argValue = (event.event.args as { [key: string]: unknown })[
+              argKey
+            ] as string | bigint | number | boolean;
 
             if (typeof argValue !== "object" && eq(argValue, arg)) {
               resultArgs.push({ type: "derived", value: ["args", argKey] });
@@ -400,9 +426,9 @@ export const recordProfilePattern = ({
               break;
             }
           }
-        }
 
-        if (hasMatch) continue;
+          if (hasMatch) continue;
+        }
 
         if (eq(event.event.log.address, arg)) {
           resultArgs.push({ type: "derived", value: ["log", "address"] });
@@ -474,9 +500,15 @@ export const recordProfilePattern = ({
       case "trace": {
         let hasMatch = false;
 
-        if (event.event.args !== undefined) {
+        // Note: explicitly skip profiling args if they are an array
+        if (
+          event.event.args !== undefined &&
+          Array.isArray(event.event.args) === false
+        ) {
           for (const argKey of Object.keys(event.event.args)) {
-            const argValue = event.event.args[argKey];
+            const argValue = (event.event.args as { [key: string]: unknown })[
+              argKey
+            ] as string | bigint | number | boolean;
 
             if (typeof argValue !== "object" && eq(argValue, arg)) {
               resultArgs.push({ type: "derived", value: ["args", argKey] });
@@ -486,9 +518,15 @@ export const recordProfilePattern = ({
           }
         }
 
-        if (event.event.result !== undefined) {
+        // Note: explicitly skip profiling result if it is an array
+        if (
+          event.event.result !== undefined &&
+          Array.isArray(event.event.result) === false
+        ) {
           for (const argKey of Object.keys(event.event.result)) {
-            const argValue = event.event.result[argKey];
+            const argValue = (event.event.result as { [key: string]: unknown })[
+              argKey
+            ] as string | bigint | number | boolean;
 
             if (typeof argValue !== "object" && eq(argValue, arg)) {
               resultArgs.push({ type: "derived", value: ["result", argKey] });

--- a/packages/core/src/indexing/profile.ts
+++ b/packages/core/src/indexing/profile.ts
@@ -103,13 +103,15 @@ export const recordProfilePattern = ({
 
     case "log": {
       let hasMatch = false;
-      for (const argKey of Object.keys(event.event.args)) {
-        const argValue = event.event.args[argKey];
+      if (event.event.args !== undefined) {
+        for (const argKey of Object.keys(event.event.args)) {
+          const argValue = event.event.args[argKey];
 
-        if (typeof argValue !== "object" && eq(argValue, args.address)) {
-          resultAddress = { type: "derived", value: ["args", argKey] };
-          hasMatch = true;
-          break;
+          if (typeof argValue !== "object" && eq(argValue, args.address)) {
+            resultAddress = { type: "derived", value: ["args", argKey] };
+            hasMatch = true;
+            break;
+          }
         }
       }
 
@@ -154,13 +156,28 @@ export const recordProfilePattern = ({
 
     case "trace": {
       let hasMatch = false;
-      for (const argKey of Object.keys(event.event.args)) {
-        const argValue = event.event.args[argKey];
 
-        if (typeof argValue !== "object" && eq(argValue, args.address)) {
-          resultAddress = { type: "derived", value: ["args", argKey] };
-          hasMatch = true;
-          break;
+      if (event.event.args !== undefined) {
+        for (const argKey of Object.keys(event.event.args)) {
+          const argValue = event.event.args[argKey];
+
+          if (typeof argValue !== "object" && eq(argValue, args.address)) {
+            resultAddress = { type: "derived", value: ["args", argKey] };
+            hasMatch = true;
+            break;
+          }
+        }
+      }
+
+      if (event.event.result !== undefined) {
+        for (const argKey of Object.keys(event.event.result)) {
+          const argValue = event.event.result[argKey];
+
+          if (typeof argValue !== "object" && eq(argValue, args.address)) {
+            resultAddress = { type: "derived", value: ["result", argKey] };
+            hasMatch = true;
+            break;
+          }
         }
       }
 
@@ -373,13 +390,15 @@ export const recordProfilePattern = ({
 
       case "log": {
         let hasMatch = false;
-        for (const argKey of Object.keys(event.event.args)) {
-          const argValue = event.event.args[argKey];
+        if (event.event.args !== undefined) {
+          for (const argKey of Object.keys(event.event.args)) {
+            const argValue = event.event.args[argKey];
 
-          if (typeof argValue !== "object" && eq(argValue, arg)) {
-            resultArgs.push({ type: "derived", value: ["args", argKey] });
-            hasMatch = true;
-            break;
+            if (typeof argValue !== "object" && eq(argValue, arg)) {
+              resultArgs.push({ type: "derived", value: ["args", argKey] });
+              hasMatch = true;
+              break;
+            }
           }
         }
 
@@ -454,13 +473,28 @@ export const recordProfilePattern = ({
 
       case "trace": {
         let hasMatch = false;
-        for (const argKey of Object.keys(event.event.args)) {
-          const argValue = event.event.args[argKey];
 
-          if (typeof argValue !== "object" && eq(argValue, arg)) {
-            resultArgs.push({ type: "derived", value: ["args", argKey] });
-            hasMatch = true;
-            break;
+        if (event.event.args !== undefined) {
+          for (const argKey of Object.keys(event.event.args)) {
+            const argValue = event.event.args[argKey];
+
+            if (typeof argValue !== "object" && eq(argValue, arg)) {
+              resultArgs.push({ type: "derived", value: ["args", argKey] });
+              hasMatch = true;
+              break;
+            }
+          }
+        }
+
+        if (event.event.result !== undefined) {
+          for (const argKey of Object.keys(event.event.result)) {
+            const argValue = event.event.result[argKey];
+
+            if (typeof argValue !== "object" && eq(argValue, arg)) {
+              resultArgs.push({ type: "derived", value: ["result", argKey] });
+              hasMatch = true;
+              break;
+            }
           }
         }
 

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -441,7 +441,7 @@ export type LogEvent = {
 
   event: {
     id: string;
-    args: { [key: string]: any } | undefined;
+    args: { [key: string]: unknown } | readonly unknown[] | undefined;
     log: Log;
     block: Block;
     transaction: Transaction;
@@ -507,8 +507,8 @@ export type TraceEvent = {
 
   event: {
     id: string;
-    args: { [key: string]: any } | undefined;
-    result: { [key: string]: any } | undefined;
+    args: { [key: string]: unknown } | readonly unknown[] | undefined;
+    result: { [key: string]: unknown } | readonly unknown[] | undefined;
     trace: Trace;
     block: Block;
     transaction: Transaction;

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -441,7 +441,7 @@ export type LogEvent = {
 
   event: {
     id: string;
-    args: any;
+    args: { [key: string]: any } | undefined;
     log: Log;
     block: Block;
     transaction: Transaction;
@@ -507,8 +507,8 @@ export type TraceEvent = {
 
   event: {
     id: string;
-    args: any;
-    result: any;
+    args: { [key: string]: any } | undefined;
+    result: { [key: string]: any } | undefined;
     trace: Trace;
     block: Block;
     transaction: Transaction;


### PR DESCRIPTION
Closes #1683 

Handles abi items such as:
```solidity
event Paused();
function execute() external;
```