### PR TITLE
Fix typos: Correct spelling of "delimiter" and "yourself", update foreign/foreign keyword

### DIFF
--- a/benchmarks/src/subgraph.ts
+++ b/benchmarks/src/subgraph.ts
@@ -144,7 +144,7 @@ const changeMappingFileDelim = (delim: string) => {
 };
 
 const bench = async () => {
-  // Reset handler delimeter
+  // Reset handler delimiter
   changeMappingFileDelim("-");
 
   const subgraphCold = await subgraph();

--- a/docs/pages/0_6/docs/indexing/read-contract-data.mdx
+++ b/docs/pages/0_6/docs/indexing/read-contract-data.mdx
@@ -148,7 +148,7 @@ ponder.on("Blitmap:Mint", async ({ event, context }) => {
     abi: context.contracts.Blitmap.abi,
     address: context.contracts.Blitmap.address,
     functionName: "totalSupply",
-    // This is set automatically, no need to include it youself.
+    // This is set automatically, no need to include it yourself.
     // blockNumber: event.block.number,
   });
 });

--- a/docs/pages/0_6/docs/schema.mdx
+++ b/docs/pages/0_6/docs/schema.mdx
@@ -449,7 +449,7 @@ const bob = await Person.get("Bob");
 
 ### Many-to-many
 
-To add a many-to-many relationship to the GraphQL schema, create a "join table" that contains a foriegn key column referencing the two tables you want to connect.
+To add a many-to-many relationship to the GraphQL schema, create a "join table" that contains a foreign key column referencing the two tables you want to connect.
 
 To create a relationship, insert a new record into the join table referencing the two related records.
 


### PR DESCRIPTION
This PR includes the following fixes:
- Corrects spelling of "delimiter" in benchmarks/src/subgraph.ts comment
- Fixes typo "youself" to "yourself" in docs/pages/0_6/docs/indexing/read-contract-data.mdx
- Updates "foriegn" to "foreign" keyword in docs/pages/0_6/docs/schema.mdx

These changes are minor spelling corrections that improve code documentation readability.