### PR TITLE
CI: migrate workflows to checkout v4

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -71,7 +71,7 @@ jobs:
           - 8040:8040
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
Bumps checkout to v4 for future-proofing against Node 20 runner updates. Workflows compile the same.