### PR TITLE
fixes duplicate event when deep reorg occurs

### DIFF
--- a/.changeset/empty-tips-rush.md
+++ b/.changeset/empty-tips-rush.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug with reorg handling that would sometimes cause a duplicate event.

--- a/.changeset/empty-tips-rush.md
+++ b/.changeset/empty-tips-rush.md
@@ -2,4 +2,4 @@
 "ponder": patch
 ---
 
-Fixed a bug with reorg handling that would sometimes cause a duplicate event.
+Fixed a bug with reorg handling that would sometimes cause a duplicate event after the log `Error: Encountered unrecoverable 'arbitrum' reorg beyond finalized block 330098801`.

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -1032,5 +1032,6 @@ test("handleReorg() throws error for deep reorg", async (context) => {
     },
   });
 
-  expect(realtimeSync.unfinalizedBlocks).toHaveLength(0);
+  // block 4 is not added to `unfinalizedBlocks`
+  expect(realtimeSync.unfinalizedBlocks).toHaveLength(3);
 });

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -683,7 +683,7 @@ export const createRealtimeSync = (
       if (unfinalizedBlocks.length === 0) {
         // No compatible block was found in the local chain, must be a deep reorg.
 
-        // Note: reorgedBlocks aren't removed from `unfinalizedBlocks`
+        // Note: reorgedBlocks aren't removed from `unfinalizedBlocks` because no "reorg" event is emitted.
         unfinalizedBlocks = reorgedBlocks;
 
         const msg = `Encountered unrecoverable '${args.network.name}' reorg beyond finalized block ${hexToNumber(finalizedBlock.number)}`;

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -683,7 +683,9 @@ export const createRealtimeSync = (
       if (unfinalizedBlocks.length === 0) {
         // No compatible block was found in the local chain, must be a deep reorg.
 
-        // Note: reorgedBlocks aren't removed from `unfinalizedBlocks` because no "reorg" event is emitted.
+        // Note: reorgedBlocks aren't removed from `unfinalizedBlocks` because we are "bailing"
+        // from this attempt to reconcile the reorg, we need to reset the local chain state back
+        // to what it was before we started.
         unfinalizedBlocks = reorgedBlocks;
 
         const msg = `Encountered unrecoverable '${args.network.name}' reorg beyond finalized block ${hexToNumber(finalizedBlock.number)}`;

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -683,6 +683,9 @@ export const createRealtimeSync = (
       if (unfinalizedBlocks.length === 0) {
         // No compatible block was found in the local chain, must be a deep reorg.
 
+        // Note: reorgedBlocks aren't removed from `unfinalizedBlocks`
+        unfinalizedBlocks = reorgedBlocks;
+
         const msg = `Encountered unrecoverable '${args.network.name}' reorg beyond finalized block ${hexToNumber(finalizedBlock.number)}`;
 
         args.common.logger.warn({ service: "realtime", msg });


### PR DESCRIPTION
There is a bug in deep reorg handling because we are:

1) evicting blocks from `unfinalizedBlocks`
2) not throwing a "reorg" event (that would cause db rows to be reverted)

This is a bug because once the chain eventually reconciles, events in evicted blocks are duplicated. I fixed this by making sure that no blocks are evicted when a deep reorg occurs. 