### PR TITLE
New `_ponder_checkpoint` table with support for multiple chains

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,7 +12,6 @@ type Prettify<T> = {
 
 export type Status = {
   [chainName: string]: {
-    chainId: number;
     block: { number: number; timestamp: number };
   };
 };

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -11,9 +11,11 @@ type Prettify<T> = {
 } & {};
 
 export type Status = {
-  chainId: number;
-  block: { number: number; timestamp: number };
-}[];
+  [chainName: string]: {
+    chainId: number;
+    block: { number: number; timestamp: number };
+  };
+};
 
 type ClientDb<schema extends Schema = Schema> = Prettify<
   Omit<

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -11,11 +11,9 @@ type Prettify<T> = {
 } & {};
 
 export type Status = {
-  [network: string]: {
-    block: { number: number; timestamp: number } | null;
-    ready: boolean;
-  };
-};
+  chainId: number;
+  block: { number: number; timestamp: number };
+}[];
 
 type ClientDb<schema extends Schema = Schema> = Prettify<
   Omit<

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -11,7 +11,7 @@ type Prettify<T> = {
 } & {};
 
 export type Status = {
-  [chainName: string]: {
+  [networkName: string]: {
     block: { number: number; timestamp: number };
   };
 };

--- a/packages/core/src/_test/e2e/erc20/erc20.test.ts
+++ b/packages/core/src/_test/e2e/erc20/erc20.test.ts
@@ -57,7 +57,7 @@ test(
     });
     await waitForIndexedBlock({
       port,
-      networkName: "mainnet",
+      chainId: 1,
       block: { number: 2 },
     });
     const result = await client.db.select().from(schema.account);

--- a/packages/core/src/_test/e2e/erc20/erc20.test.ts
+++ b/packages/core/src/_test/e2e/erc20/erc20.test.ts
@@ -57,7 +57,7 @@ test(
     });
     await waitForIndexedBlock({
       port,
-      chainId: 1,
+      chainName: "mainnet",
       block: { number: 2 },
     });
     const result = await client.db.select().from(schema.account);

--- a/packages/core/src/_test/e2e/factory/factory.test.ts
+++ b/packages/core/src/_test/e2e/factory/factory.test.ts
@@ -63,7 +63,7 @@ test(
 
     await waitForIndexedBlock({
       port,
-      chainId: 1,
+      chainName: "mainnet",
       block: { number: 3 },
     });
 
@@ -87,7 +87,7 @@ test(
 
     await waitForIndexedBlock({
       port,
-      chainId: 1,
+      chainName: "mainnet",
       block: { number: 4 },
     });
 

--- a/packages/core/src/_test/e2e/factory/factory.test.ts
+++ b/packages/core/src/_test/e2e/factory/factory.test.ts
@@ -63,7 +63,7 @@ test(
 
     await waitForIndexedBlock({
       port,
-      networkName: "mainnet",
+      chainId: 1,
       block: { number: 3 },
     });
 
@@ -87,7 +87,7 @@ test(
 
     await waitForIndexedBlock({
       port,
-      networkName: "mainnet",
+      chainId: 1,
       block: { number: 4 },
     });
 

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -198,11 +198,11 @@ export function getFreePort(): Promise<number> {
 
 export async function waitForIndexedBlock({
   port,
-  networkName,
+  chainId,
   block,
 }: {
   port: number;
-  networkName: string;
+  chainId: number;
   block: { number: number };
 }) {
   return new Promise((resolve, reject) => {
@@ -213,14 +213,9 @@ export async function waitForIndexedBlock({
     const interval = setInterval(async () => {
       const response = await fetch(`http://localhost:${port}/status`);
       if (response.status === 200) {
-        const status = (await response.json()) as Status | null;
-        const statusBlockNumber = status
-          ? status[networkName]?.block?.number
-          : undefined;
-        if (
-          statusBlockNumber !== undefined &&
-          statusBlockNumber >= block.number
-        ) {
+        const status = (await response.json()) as Status;
+        const sb = status?.find((s) => s.chainId === chainId)?.block;
+        if (sb !== undefined && sb.number >= block.number) {
           clearTimeout(timeout);
           clearInterval(interval);
           resolve(undefined);

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -198,11 +198,11 @@ export function getFreePort(): Promise<number> {
 
 export async function waitForIndexedBlock({
   port,
-  chainId,
+  chainName,
   block,
 }: {
   port: number;
-  chainId: number;
+  chainName: string;
   block: { number: number };
 }) {
   return new Promise((resolve, reject) => {
@@ -214,7 +214,7 @@ export async function waitForIndexedBlock({
       const response = await fetch(`http://localhost:${port}/status`);
       if (response.status === 200) {
         const status = (await response.json()) as Status;
-        const sb = status?.find((s) => s.chainId === chainId)?.block;
+        const sb = status[chainName]?.block;
         if (sb !== undefined && sb.number >= block.number) {
           clearTimeout(timeout);
           clearInterval(interval);

--- a/packages/core/src/bin/commands/dev.ts
+++ b/packages/core/src/bin/commands/dev.ts
@@ -7,7 +7,10 @@ import { MetricsService } from "@/internal/metrics.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import { buildPayload, createTelemetry } from "@/internal/telemetry.js";
-import type { IndexingBuild } from "@/internal/types.js";
+import type {
+  CrashRecoveryCheckpoint,
+  IndexingBuild,
+} from "@/internal/types.js";
 import { createUi } from "@/ui/index.js";
 import { createQueue } from "@/utils/queue.js";
 import { type Result, mergeResults } from "@/utils/result.js";
@@ -291,7 +294,7 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
 
   let indexingBuild: IndexingBuild | undefined;
   let database: Database | undefined;
-  let crashRecoveryCheckpoint: string | undefined;
+  let crashRecoveryCheckpoint: CrashRecoveryCheckpoint;
 
   const namespace =
     cliOptions.schema ?? process.env.DATABASE_SCHEMA ?? "public";

--- a/packages/core/src/bin/commands/list.ts
+++ b/packages/core/src/bin/commands/list.ts
@@ -2,7 +2,7 @@ import { createBuild } from "@/build/index.js";
 import {
   type PonderApp,
   createDatabase,
-  getPonderMeta,
+  getPonderMetaTable,
 } from "@/database/index.js";
 import { TABLES } from "@/database/index.js";
 import { createLogger } from "@/internal/logger.js";
@@ -72,11 +72,11 @@ export async function list({ cliOptions }: { cliOptions: CliOptions }) {
   const queries = ponderSchemas.map((row) =>
     database.qb.drizzle
       .select({
-        value: getPonderMeta(row.schema).value,
+        value: getPonderMetaTable(row.schema).value,
         schema: sql<string>`${row.schema}`.as("schema"),
       })
-      .from(getPonderMeta(row.schema))
-      .where(eq(getPonderMeta(row.schema).key, "app")),
+      .from(getPonderMetaTable(row.schema))
+      .where(eq(getPonderMetaTable(row.schema).key, "app")),
   );
 
   if (queries.length === 0) {

--- a/packages/core/src/bin/commands/prune.ts
+++ b/packages/core/src/bin/commands/prune.ts
@@ -2,7 +2,7 @@ import { createBuild } from "@/build/index.js";
 import {
   type PonderApp,
   createDatabase,
-  getPonderMeta,
+  getPonderMetaTable,
 } from "@/database/index.js";
 import { TABLES } from "@/database/index.js";
 import { sqlToReorgTableName } from "@/drizzle/kit/index.js";
@@ -80,11 +80,11 @@ export async function prune({ cliOptions }: { cliOptions: CliOptions }) {
   const queries = ponderSchemas.map((row) =>
     database.qb.drizzle
       .select({
-        value: getPonderMeta(row.schema).value,
+        value: getPonderMetaTable(row.schema).value,
         schema: sql<string>`${row.schema}`.as("schema"),
       })
-      .from(getPonderMeta(row.schema))
-      .where(eq(getPonderMeta(row.schema).key, "app")),
+      .from(getPonderMetaTable(row.schema))
+      .where(eq(getPonderMetaTable(row.schema).key, "app")),
   );
 
   if (queries.length === 0) {

--- a/packages/core/src/bin/commands/prune.ts
+++ b/packages/core/src/bin/commands/prune.ts
@@ -124,7 +124,11 @@ export async function prune({ cliOptions }: { cliOptions: CliOptions }) {
       functionsToDrop.push(`"${schema}"."operation_reorg__${table}"`);
     }
     tablesToDrop.push(`"${schema}"."_ponder_meta"`);
-    tablesToDrop.push(`"${schema}"."_ponder_status"`);
+    if (value.version === "2") {
+      tablesToDrop.push(`"${schema}"."_ponder_checkpoint"`);
+    } else {
+      tablesToDrop.push(`"${schema}"."_ponder_status"`);
+    }
 
     const tableCount = ponderSchemas.find(
       (s) => s.schema === schema,

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -259,13 +259,18 @@ export async function run({
                 for (const network of indexingBuild.networks) {
                   common.metrics.ponder_historical_completed_indexing_seconds.set(
                     { network: network.name },
-                    Math.max(
-                      Number(checkpoint.blockTimestamp) -
-                        sync.seconds[network.name]!.start -
-                        sync.seconds[network.name]!.cached,
-                      sync.seconds[network.name]!.end -
-                        sync.seconds[network.name]!.start,
-                      0,
+                    Math.min(
+                      Math.max(
+                        Number(checkpoint.blockTimestamp) -
+                          sync.seconds[network.name]!.start -
+                          sync.seconds[network.name]!.cached,
+                        0,
+                      ),
+                      Math.max(
+                        sync.seconds[network.name]!.end -
+                          sync.seconds[network.name]!.start,
+                        0,
+                      ),
                     ),
                   );
                   common.metrics.ponder_indexing_timestamp.set(

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -163,6 +163,7 @@ export async function run({
     });
   }
 
+  // Note: `_ponder_checkpoint` must be updated after the setup events are processed.
   await database.setCheckpoints({
     checkpoints: indexingBuild.networks.map((network) => ({
       chainName: network.name,
@@ -489,7 +490,7 @@ export async function run({
         break;
       }
       case "reorg":
-        // Note: `setLatestCheckpoint` is not called here, instead it is called
+        // Note: `_ponder_checkpoint` is not called here, instead it is called
         // in the `block` case.
 
         await database.removeTriggers();

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -428,7 +428,7 @@ export async function run({
 
             common.logger.info({
               service: "app",
-              msg: `Indexed ${event.events.length} '${event.network.name}' events for block ${Number(decodeCheckpoint(event.checkpoint).blockNumber)}`,
+              msg: `Indexed ${events.length} '${network.name}' events for block ${Number(decodeCheckpoint(checkpoint).blockNumber)}`,
             });
 
             if (result.status === "error") onReloadableError(result.error);
@@ -451,6 +451,7 @@ export async function run({
           }
         }
 
+        // TODO(kyle) wrap
         await database.qb.drizzle
           .insert(database.PONDER_CHECKPOINT)
           .values(

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -255,6 +255,7 @@ export async function run({
                   Number(checkpoint.blockTimestamp),
                 );
               } else {
+                // TODO(kyle) does this handle networks with end blocks?
                 for (const network of indexingBuild.networks) {
                   common.metrics.ponder_historical_completed_indexing_seconds.set(
                     { network: network.name },

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -165,6 +165,7 @@ export async function run({
 
   await database.setCheckpoints({
     checkpoints: indexingBuild.networks.map((network) => ({
+      chainName: network.name,
       chainId: network.chainId,
       latestCheckpoint: sync.getStartCheckpoint(network),
       safeCheckpoint: sync.getStartCheckpoint(network),
@@ -323,6 +324,9 @@ export async function run({
             await database.setCheckpoints({
               checkpoints: events.checkpoints.map(
                 ({ chainId, checkpoint }) => ({
+                  chainName: indexingBuild.networks.find(
+                    (network) => network.chainId === chainId,
+                  )!.name,
                   chainId,
                   latestCheckpoint: checkpoint,
                   safeCheckpoint: checkpoint,
@@ -385,6 +389,7 @@ export async function run({
 
   await database.setCheckpoints({
     checkpoints: indexingBuild.networks.map((network) => ({
+      chainName: network.name,
       chainId: network.chainId,
       latestCheckpoint: sync.getFinalizedCheckpoint(network),
       safeCheckpoint: sync.getFinalizedCheckpoint(network),
@@ -456,13 +461,16 @@ export async function run({
           .insert(database.PONDER_CHECKPOINT)
           .values(
             event.checkpoints.map(({ chainId, checkpoint }) => ({
+              chainName: indexingBuild.networks.find(
+                (network) => network.chainId === chainId,
+              )!.name,
               chainId,
               safeCheckpoint: checkpoint,
               latestCheckpoint: checkpoint,
             })),
           )
           .onConflictDoUpdate({
-            target: database.PONDER_CHECKPOINT.chainId,
+            target: database.PONDER_CHECKPOINT.chainName,
             set: {
               latestCheckpoint: sql`excluded.latest_checkpoint`,
             },

--- a/packages/core/src/client/index.test.ts
+++ b/packages/core/src/client/index.test.ts
@@ -195,5 +195,5 @@ test("client.status", async (context) => {
   const response = await app.request("/sql/status");
   expect(response.status).toBe(200);
   const result = await response.json();
-  expect(result).toMatchInlineSnapshot("null");
+  expect(result).toMatchInlineSnapshot("{}");
 });

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -1,5 +1,6 @@
 import type { Schema } from "@/internal/types.js";
 import type { ReadonlyDrizzle } from "@/types/db.js";
+import { decodeCheckpoint } from "@/utils/checkpoint.js";
 import { promiseWithResolvers } from "@/utils/promiseWithResolvers.js";
 import type { QueryWithTypings } from "drizzle-orm";
 import type { PgSession } from "drizzle-orm/pg-core";
@@ -122,7 +123,14 @@ export const client = ({
     }
 
     if (c.req.path === "/sql/status") {
-      const statusResult = await globalThis.PONDER_DATABASE.getStatus();
+      const checkpoints = await globalThis.PONDER_DATABASE.getCheckpoints();
+      const statusResult = checkpoints.map(({ chainId, latestCheckpoint }) => ({
+        chainId,
+        block: {
+          number: Number(decodeCheckpoint(latestCheckpoint).blockNumber),
+          timestamp: Number(decodeCheckpoint(latestCheckpoint).blockTimestamp),
+        },
+      }));
       return c.json(statusResult);
     }
 

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -1,4 +1,4 @@
-import type { Schema } from "@/internal/types.js";
+import type { Schema, Status } from "@/internal/types.js";
 import type { ReadonlyDrizzle } from "@/types/db.js";
 import { decodeCheckpoint } from "@/utils/checkpoint.js";
 import { promiseWithResolvers } from "@/utils/promiseWithResolvers.js";
@@ -124,14 +124,21 @@ export const client = ({
 
     if (c.req.path === "/sql/status") {
       const checkpoints = await globalThis.PONDER_DATABASE.getCheckpoints();
-      const statusResult = checkpoints.map(({ chainId, latestCheckpoint }) => ({
-        chainId,
-        block: {
-          number: Number(decodeCheckpoint(latestCheckpoint).blockNumber),
-          timestamp: Number(decodeCheckpoint(latestCheckpoint).blockTimestamp),
-        },
-      }));
-      return c.json(statusResult);
+
+      const status: Status = {};
+      for (const { chainName, chainId, latestCheckpoint } of checkpoints) {
+        status[chainName] = {
+          chainId,
+          block: {
+            number: Number(decodeCheckpoint(latestCheckpoint).blockNumber),
+            timestamp: Number(
+              decodeCheckpoint(latestCheckpoint).blockTimestamp,
+            ),
+          },
+        };
+      }
+
+      return c.json(status);
     }
 
     return next();

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -126,9 +126,8 @@ export const client = ({
       const checkpoints = await globalThis.PONDER_DATABASE.getCheckpoints();
 
       const status: Status = {};
-      for (const { chainName, chainId, latestCheckpoint } of checkpoints) {
+      for (const { chainName, latestCheckpoint } of checkpoints) {
         status[chainName] = {
-          chainId,
           block: {
             number: Number(decodeCheckpoint(latestCheckpoint).blockNumber),
             timestamp: Number(

--- a/packages/core/src/database/index.test.ts
+++ b/packages/core/src/database/index.test.ts
@@ -19,7 +19,7 @@ import {
   type Database,
   TABLES,
   createDatabase,
-  getPonderMeta,
+  getPonderMetaTable,
 } from "./index.js";
 
 beforeEach(setupCommon);
@@ -222,7 +222,7 @@ test("migrate() succeeds with crash recovery", async (context) => {
 
   const metadata = await databaseTwo.qb.drizzle
     .select()
-    .from(getPonderMeta("public"));
+    .from(getPonderMetaTable("public"));
 
   expect(metadata).toHaveLength(1);
 
@@ -417,7 +417,7 @@ test("migrate() with crash recovery reverts rows", async (context) => {
 
   const metadata = await databaseTwo.qb.drizzle
     .select()
-    .from(getPonderMeta("public"));
+    .from(getPonderMetaTable("public"));
 
   expect(metadata).toHaveLength(1);
 
@@ -511,14 +511,14 @@ test("heartbeat updates the heartbeat_at value", async (context) => {
 
   const row = await database.qb.drizzle
     .select()
-    .from(getPonderMeta("public"))
+    .from(getPonderMetaTable("public"))
     .then((result) => result[0]!.value);
 
   await wait(500);
 
   const rowAfterHeartbeat = await database.qb.drizzle
     .select()
-    .from(getPonderMeta("public"))
+    .from(getPonderMetaTable("public"))
     .then((result) => result[0]!.value);
 
   expect(BigInt(rowAfterHeartbeat!.heartbeat_at)).toBeGreaterThan(

--- a/packages/core/src/database/index.test.ts
+++ b/packages/core/src/database/index.test.ts
@@ -364,7 +364,7 @@ test("migrate() with crash recovery reverts rows", async (context) => {
     .insert(account)
     .values({ address: zeroAddress, balance: 10n });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 9n }),
     db: database.qb.drizzle,
   });
@@ -373,7 +373,7 @@ test("migrate() with crash recovery reverts rows", async (context) => {
     .insert(account)
     .values({ address: "0x0000000000000000000000000000000000000001" });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 11n }),
     db: database.qb.drizzle,
   });
@@ -545,7 +545,7 @@ test("finalize()", async (context) => {
     .insert(account)
     .values({ address: zeroAddress, balance: 10n });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 9n }),
     db: database.qb.drizzle,
   });
@@ -558,7 +558,7 @@ test("finalize()", async (context) => {
     .insert(account)
     .values({ address: "0x0000000000000000000000000000000000000001" });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 11n }),
     db: database.qb.drizzle,
   });
@@ -684,7 +684,7 @@ test("createTriggers() duplicate", async (context) => {
   await context.common.shutdown.kill();
 });
 
-test("complete()", async (context) => {
+test("commitBlock()", async (context) => {
   const database = await createDatabase({
     common: context.common,
     namespace: "public",
@@ -710,7 +710,7 @@ test("complete()", async (context) => {
     .insert(account)
     .values({ address: zeroAddress, balance: 10n });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 10n }),
     db: database.qb.drizzle,
   });
@@ -761,7 +761,7 @@ test("revert()", async (context) => {
     .insert(account)
     .values({ address: zeroAddress, balance: 10n });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 9n }),
     db: database.qb.drizzle,
   });
@@ -774,14 +774,14 @@ test("revert()", async (context) => {
     .insert(account)
     .values({ address: "0x0000000000000000000000000000000000000001" });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 10n }),
     db: database.qb.drizzle,
   });
 
   await indexingStore.delete(account, { address: zeroAddress });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 11n }),
     db: database.qb.drizzle,
   });
@@ -840,14 +840,14 @@ test("revert() with composite primary key", async (context) => {
 
   await indexingStore.insert(test).values({ a: 1, b: 1 });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 11n }),
     db: database.qb.drizzle,
   });
 
   await indexingStore.update(test, { a: 1, b: 1 }).set({ c: 1 });
 
-  await database.complete({
+  await database.commitBlock({
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 12n }),
     db: database.qb.drizzle,
   });

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -20,7 +20,6 @@ import * as ponderSyncSchema from "@/sync-store/schema.js";
 import type { Drizzle } from "@/types/db.js";
 import {
   MAX_CHECKPOINT_STRING,
-  ZERO_CHECKPOINT_STRING,
   decodeCheckpoint,
   min,
 } from "@/utils/checkpoint.js";
@@ -907,9 +906,8 @@ EXECUTE PROCEDURE "${namespace}".${notification};`),
 
             await this.revert({ checkpoint: revertCheckpoint, tx });
 
-            await tx
-              .update(PONDER_CHECKPOINT)
-              .set({ latestCheckpoint: ZERO_CHECKPOINT_STRING });
+            // Note: We don't update the `_ponder_checkpoint` table here, instead we wait for it to be updated
+            // in the runtime script.
 
             await tx.update(PONDER_META).set({ value: metadata });
             return { status: "success", crashRecoveryCheckpoint } as const;

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -780,15 +780,6 @@ EXECUTE PROCEDURE "${namespace}".${notification};`),
               } as const;
             }
 
-            // Note: ponder <=0.8 will evaluate this as true because the version is undefined
-            if (previousApp.version !== VERSION) {
-              const error = new NonRetryableError(
-                `Schema '${namespace}' was previously used by a Ponder app with a different minor version. Drop the schema first, or use a different schema. Read more: https://ponder.sh/docs/getting-started/database#database-schema`,
-              );
-              error.stack = undefined;
-              throw error;
-            }
-
             if (
               previousApp.is_dev === 1 ||
               (process.env.PONDER_EXPERIMENTAL_DB === "platform" &&
@@ -833,6 +824,15 @@ EXECUTE PROCEDURE "${namespace}".${notification};`),
                 status: "success",
                 crashRecoveryCheckpoint: undefined,
               } as const;
+            }
+
+            // Note: ponder <=0.8 will evaluate this as true because the version is undefined
+            if (previousApp.version !== VERSION) {
+              const error = new NonRetryableError(
+                `Schema '${namespace}' was previously used by a Ponder app with a different minor version. Drop the schema first, or use a different schema. Read more: https://ponder.sh/docs/getting-started/database#database-schema`,
+              );
+              error.stack = undefined;
+              throw error;
             }
 
             if (

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -674,7 +674,8 @@ CREATE TABLE IF NOT EXISTS "${namespace}"."_ponder_meta" (
           await qb.drizzle.execute(
             sql.raw(`
 CREATE TABLE IF NOT EXISTS "${namespace}"."_ponder_checkpoint" (
-  "chain_id" integer PRIMARY KEY,
+  "chain_name" text PRIMARY KEY,
+  "chain_id" integer NOT NULL,
   "safe_checkpoint" varchar(75) NOT NULL,
   "latest_checkpoint" varchar(75) NOT NULL
 )`),

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -56,8 +56,8 @@ import prometheus from "prom-client";
 export type Database = {
   driver: PostgresDriver | PGliteDriver;
   qb: QueryBuilder;
-  PONDER_META: ReturnType<typeof getPonderMeta>;
-  PONDER_CHECKPOINT: ReturnType<typeof getPonderCheckpoint>;
+  PONDER_META: ReturnType<typeof getPonderMetaTable>;
+  PONDER_CHECKPOINT: ReturnType<typeof getPonderCheckpointTable>;
   retry: <T>(fn: () => Promise<T>) => Promise<T>;
   record: <T>(
     options: { method: string; includeTraceLogs?: boolean },
@@ -163,7 +163,7 @@ type QueryBuilder = {
   drizzleReadonly: Drizzle<Schema>;
 };
 
-export const getPonderMeta = (namespace: NamespaceBuild) => {
+export const getPonderMetaTable = (namespace: NamespaceBuild) => {
   if (namespace === "public") {
     return pgTable("_ponder_meta", (t) => ({
       key: t.text().primaryKey().$type<"app">(),
@@ -177,7 +177,7 @@ export const getPonderMeta = (namespace: NamespaceBuild) => {
   }));
 };
 
-export const getPonderCheckpoint = (namespace: NamespaceBuild) => {
+export const getPonderCheckpointTable = (namespace: NamespaceBuild) => {
   if (namespace === "public") {
     return pgTable("_ponder_checkpoint", (t) => ({
       chainName: t.text().primaryKey(),
@@ -208,8 +208,8 @@ export const createDatabase = async ({
 }): Promise<Database> => {
   let heartbeatInterval: NodeJS.Timeout | undefined;
 
-  const PONDER_META = getPonderMeta(namespace);
-  const PONDER_CHECKPOINT = getPonderCheckpoint(namespace);
+  const PONDER_META = getPonderMetaTable(namespace);
+  const PONDER_CHECKPOINT = getPonderCheckpointTable(namespace);
 
   ////////
   // Create schema, drivers, roles, and query builders

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -20,6 +20,7 @@ import * as ponderSyncSchema from "@/sync-store/schema.js";
 import type { Drizzle } from "@/types/db.js";
 import {
   MAX_CHECKPOINT_STRING,
+  ZERO_CHECKPOINT_STRING,
   decodeCheckpoint,
   min,
 } from "@/utils/checkpoint.js";
@@ -897,10 +898,9 @@ EXECUTE PROCEDURE "${namespace}".${notification};`),
 
             await this.revert({ checkpoint: revertCheckpoint, tx });
 
-            // TODO(kyle) not sure if this is correct
             await tx
               .update(PONDER_CHECKPOINT)
-              .set({ latestCheckpoint: PONDER_CHECKPOINT.safeCheckpoint });
+              .set({ latestCheckpoint: ZERO_CHECKPOINT_STRING });
 
             await tx.update(PONDER_META).set({ value: metadata });
             return { status: "success", crashRecoveryCheckpoint } as const;

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -72,7 +72,11 @@ export type Database = {
   ) => Promise<T>;
   /** Migrate the `ponder_sync` schema. */
   migrateSync(): Promise<void>;
-  /** Migrate the user schema. */
+  /**
+   * Migrate the user schema.
+   *
+   * @returns The crash recovery checkpoint for each chain if there is a cache hit, else undefined.
+   */
   migrate({
     buildId,
   }: Pick<IndexingBuild, "buildId">): Promise<CrashRecoveryCheckpoint>;

--- a/packages/core/src/graphql/index.test.ts
+++ b/packages/core/src/graphql/index.test.ts
@@ -6,11 +6,7 @@ import {
 } from "@/_test/setup.js";
 import type { Database } from "@/database/index.js";
 import { onchainEnum, onchainTable, primaryKey } from "@/drizzle/onchain.js";
-import {
-  EVENT_TYPES,
-  decodeCheckpoint,
-  encodeCheckpoint,
-} from "@/utils/checkpoint.js";
+import { EVENT_TYPES, encodeCheckpoint } from "@/utils/checkpoint.js";
 import { relations } from "drizzle-orm";
 import { type GraphQLType, execute, parse } from "graphql";
 import { toBytes } from "viem";
@@ -28,16 +24,7 @@ function buildContextValue(database: Database) {
   return {
     drizzle,
     getDataLoader,
-    getStatus: async () => {
-      const checkpoints = await database.getCheckpoints();
-      return checkpoints.map(({ chainId, latestCheckpoint }) => ({
-        chainId,
-        block: {
-          number: Number(decodeCheckpoint(latestCheckpoint).blockNumber),
-          timestamp: Number(decodeCheckpoint(latestCheckpoint).blockTimestamp),
-        },
-      }));
-    },
+    getCheckpoints: () => database.getCheckpoints(),
   };
 }
 
@@ -91,8 +78,8 @@ test("metadata", async (context) => {
   expect(result.data).toMatchObject({
     _meta: {
       status: {
-        1: {
-          ready: true,
+        mainnet: {
+          chainId: 1,
           block: {
             number: 10,
             timestamp: 20,

--- a/packages/core/src/graphql/index.test.ts
+++ b/packages/core/src/graphql/index.test.ts
@@ -57,6 +57,7 @@ test("metadata", async (context) => {
     checkpoints: [
       {
         chainId: 1,
+        chainName: "mainnet",
         latestCheckpoint: encodeCheckpoint({
           blockNumber: 10n,
           chainId: 1n,

--- a/packages/core/src/graphql/index.test.ts
+++ b/packages/core/src/graphql/index.test.ts
@@ -79,7 +79,6 @@ test("metadata", async (context) => {
     _meta: {
       status: {
         mainnet: {
-          chainId: 1,
           block: {
             number: 10,
             timestamp: 20,

--- a/packages/core/src/graphql/index.ts
+++ b/packages/core/src/graphql/index.ts
@@ -3,6 +3,7 @@ import type { OnchainTable } from "@/drizzle/onchain.js";
 import { normalizeColumn } from "@/indexing-store/utils.js";
 import type { Schema } from "@/internal/types.js";
 import type { Drizzle, ReadonlyDrizzle } from "@/types/db.js";
+import { decodeCheckpoint } from "@/utils/checkpoint.js";
 import { never } from "@/utils/never.js";
 import { deserialize, serialize } from "@/utils/serialize.js";
 import DataLoader from "dataloader";
@@ -68,7 +69,7 @@ import { GraphQLJSON } from "./json.js";
 type Parent = Record<string, any>;
 type Context = {
   getDataLoader: ReturnType<typeof buildDataLoaderCache>;
-  getStatus: Database["getStatus"];
+  getCheckpoints: Database["getCheckpoints"];
   drizzle: Drizzle<{ [key: string]: OnchainTable }>;
 };
 
@@ -417,7 +418,14 @@ export function buildGraphQLSchema({
   queryFields._meta = {
     type: GraphQLMeta,
     resolve: async (_source, _args, context) => {
-      const status = await context.getStatus();
+      const checkpoints = await context.getCheckpoints();
+      const status = checkpoints.map(({ chainId, latestCheckpoint }) => ({
+        chainId,
+        block: {
+          number: Number(decodeCheckpoint(latestCheckpoint).blockNumber),
+          timestamp: Number(decodeCheckpoint(latestCheckpoint).blockTimestamp),
+        },
+      }));
       return { status };
     },
   };

--- a/packages/core/src/graphql/index.ts
+++ b/packages/core/src/graphql/index.ts
@@ -420,9 +420,8 @@ export function buildGraphQLSchema({
     resolve: async (_source, _args, context) => {
       const checkpoints = await context.getCheckpoints();
       const status: Status = {};
-      for (const { chainName, chainId, latestCheckpoint } of checkpoints) {
+      for (const { chainName, latestCheckpoint } of checkpoints) {
         status[chainName] = {
-          chainId,
           block: {
             number: Number(decodeCheckpoint(latestCheckpoint).blockNumber),
             timestamp: Number(

--- a/packages/core/src/graphql/middleware.ts
+++ b/packages/core/src/graphql/middleware.ts
@@ -57,7 +57,7 @@ export const graphql = (
 
       return {
         getDataLoader,
-        getStatus: () => globalThis.PONDER_DATABASE.getCheckpoints(),
+        getCheckpoints: () => globalThis.PONDER_DATABASE.getCheckpoints(),
         drizzle: db,
       };
     },

--- a/packages/core/src/graphql/middleware.ts
+++ b/packages/core/src/graphql/middleware.ts
@@ -57,7 +57,7 @@ export const graphql = (
 
       return {
         getDataLoader,
-        getStatus: () => globalThis.PONDER_DATABASE.getStatus(),
+        getStatus: () => globalThis.PONDER_DATABASE.getCheckpoints(),
         drizzle: db,
       };
     },

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -5,7 +5,12 @@ import { getColumnCasing } from "@/drizzle/kit/index.js";
 import { addErrorMeta, toErrorMeta } from "@/indexing/index.js";
 import type { Common } from "@/internal/common.js";
 import { FlushError } from "@/internal/errors.js";
-import type { Event, Schema, SchemaBuild } from "@/internal/types.js";
+import type {
+  CrashRecoveryCheckpoint,
+  Event,
+  Schema,
+  SchemaBuild,
+} from "@/internal/types.js";
 import type { Drizzle } from "@/types/db.js";
 import { dedupe } from "@/utils/dedupe.js";
 import { prettyPrint } from "@/utils/print.js";
@@ -284,7 +289,7 @@ export const createIndexingCache = ({
 }: {
   common: Common;
   schemaBuild: Pick<SchemaBuild, "schema">;
-  crashRecoveryCheckpoint: string | undefined;
+  crashRecoveryCheckpoint: CrashRecoveryCheckpoint;
   eventCount: { [eventName: string]: number };
 }): IndexingCache => {
   /**

--- a/packages/core/src/internal/options.ts
+++ b/packages/core/src/internal/options.ts
@@ -118,6 +118,6 @@ export const buildOptions = ({ cliOptions }: { cliOptions: CliOptions }) => {
           1_024 *
           1_024,
 
-    syncEventsQuerySize: 10_000,
+    syncEventsQuerySize: 18_000,
   } satisfies Options;
 };

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -353,13 +353,10 @@ export type ApiBuild = {
 
 // Status
 
-/** Closest-to-tip indexed block per network. */
 export type Status = {
-  [network: string]: {
-    block: { number: number; timestamp: number } | null;
-    ready: boolean;
-  };
-};
+  chainId: number;
+  block: { number: number; timestamp: number };
+}[];
 
 // Seconds
 

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -363,9 +363,11 @@ export type CrashRecoveryCheckpoint =
 // Status
 
 export type Status = {
-  chainId: number;
-  block: { number: number; timestamp: number };
-}[];
+  [chainName: string]: {
+    chainId: number;
+    block: { number: number; timestamp: number };
+  };
+};
 
 // Seconds
 

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -351,6 +351,15 @@ export type ApiBuild = {
   app: Hono;
 };
 
+// Crash recovery
+
+export type CrashRecoveryCheckpoint =
+  | {
+      chainId: number;
+      checkpoint: string;
+    }[]
+  | undefined;
+
 // Status
 
 export type Status = {

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -363,8 +363,7 @@ export type CrashRecoveryCheckpoint =
 // Status
 
 export type Status = {
-  [chainName: string]: {
-    chainId: number;
+  [networkName: string]: {
     block: { number: number; timestamp: number };
   };
 };

--- a/packages/core/src/server/index.test.ts
+++ b/packages/core/src/server/index.test.ts
@@ -81,15 +81,7 @@ test("ready", async (context) => {
     database,
   });
 
-  await database.setStatus({
-    1: {
-      ready: true,
-      block: {
-        number: 1,
-        timestamp: 1,
-      },
-    },
-  });
+  await database.setReady();
 
   const response = await server.hono.request("/ready");
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -94,9 +94,8 @@ export async function createServer({
     .get("/status", async (c) => {
       const checkpoints = await globalThis.PONDER_DATABASE.getCheckpoints();
       const status: Status = {};
-      for (const { chainName, chainId, latestCheckpoint } of checkpoints) {
+      for (const { chainName, latestCheckpoint } of checkpoints) {
         status[chainName] = {
-          chainId,
           block: {
             number: Number(decodeCheckpoint(latestCheckpoint).blockNumber),
             timestamp: Number(

--- a/packages/core/src/sync/index.test.ts
+++ b/packages/core/src/sync/index.test.ts
@@ -967,22 +967,34 @@ test("mergeAsyncGeneratorsWithEventOrder()", async () => {
   })();
 
   p1.resolve({
-    events: [{ checkpoint: "01" }, { checkpoint: "07" }] as Event[],
+    events: [
+      { checkpoint: "01", chainId: 1 },
+      { checkpoint: "07", chainId: 1 },
+    ] as Event[],
     checkpoint: "10",
   });
   p3.resolve({
-    events: [{ checkpoint: "02" }, { checkpoint: "05" }] as Event[],
+    events: [
+      { checkpoint: "02", chainId: 2 },
+      { checkpoint: "05", chainId: 2 },
+    ] as Event[],
     checkpoint: "06",
   });
 
   await new Promise((res) => setTimeout(res));
 
   p4.resolve({
-    events: [{ checkpoint: "08" }, { checkpoint: "11" }] as Event[],
+    events: [
+      { checkpoint: "08", chainId: 1 },
+      { checkpoint: "11", chainId: 1 },
+    ] as Event[],
     checkpoint: "20",
   });
   p2.resolve({
-    events: [{ checkpoint: "08" }, { checkpoint: "13" }] as Event[],
+    events: [
+      { checkpoint: "08", chainId: 2 },
+      { checkpoint: "13", chainId: 2 },
+    ] as Event[],
     checkpoint: "20",
   });
 
@@ -993,22 +1005,25 @@ test("mergeAsyncGeneratorsWithEventOrder()", async () => {
       {
         "checkpoints": [
           {
-            "chainId": undefined,
+            "chainId": 1,
             "checkpoint": "01",
           },
           {
-            "chainId": undefined,
+            "chainId": 2,
             "checkpoint": "05",
           },
         ],
         "events": [
           {
+            "chainId": 1,
             "checkpoint": "01",
           },
           {
+            "chainId": 2,
             "checkpoint": "02",
           },
           {
+            "chainId": 2,
             "checkpoint": "05",
           },
         ],
@@ -1016,19 +1031,21 @@ test("mergeAsyncGeneratorsWithEventOrder()", async () => {
       {
         "checkpoints": [
           {
-            "chainId": undefined,
+            "chainId": 1,
             "checkpoint": "07",
           },
           {
-            "chainId": undefined,
+            "chainId": 1,
             "checkpoint": "08",
           },
         ],
         "events": [
           {
+            "chainId": 1,
             "checkpoint": "07",
           },
           {
+            "chainId": 1,
             "checkpoint": "08",
           },
         ],
@@ -1036,22 +1053,25 @@ test("mergeAsyncGeneratorsWithEventOrder()", async () => {
       {
         "checkpoints": [
           {
-            "chainId": undefined,
+            "chainId": 2,
             "checkpoint": "13",
           },
           {
-            "chainId": undefined,
+            "chainId": 1,
             "checkpoint": "11",
           },
         ],
         "events": [
           {
+            "chainId": 2,
             "checkpoint": "08",
           },
           {
+            "chainId": 1,
             "checkpoint": "11",
           },
           {
+            "chainId": 2,
             "checkpoint": "13",
           },
         ],

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -850,7 +850,7 @@ export const createSync = async (params: {
           min(
             getOmnichainCheckpoint({ tag: "end" }),
             getOmnichainCheckpoint({ tag: "finalized" }),
-            crashRecoveryCheckpoint,
+            crashRecoveryCheckpoint ?? ZERO_CHECKPOINT_STRING,
           ),
         ).blockTimestamp,
       ),

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -77,8 +77,11 @@ export type RealtimeEvent =
   | {
       type: "block";
       network: Network;
-      checkpoint: string;
       events: Event[];
+      /**
+       * Closest-to-tip checkpoint for each chain,
+       * excluding chains that were not updated with this event.
+       */
       checkpoints: { chainId: number; checkpoint: string }[];
     }
   | {
@@ -94,6 +97,10 @@ export type RealtimeEvent =
 
 type EventGenerator = AsyncGenerator<{
   events: Event[];
+  /**
+   * Closest-to-tip checkpoint for each chain,
+   * excluding chains that were not updated with this batch of events.
+   */
   checkpoints: { chainId: number; checkpoint: string }[];
 }>;
 
@@ -526,7 +533,6 @@ export const createSync = async (params: {
             .onRealtimeEvent({
               type: "block",
               network,
-              checkpoint,
               events: readyEvents.sort((a, b) =>
                 a.checkpoint < b.checkpoint ? -1 : 1,
               ),
@@ -594,7 +600,6 @@ export const createSync = async (params: {
             params
               .onRealtimeEvent({
                 type: "block",
-                checkpoint: to,
                 events: readyEvents.sort((a, b) =>
                   a.checkpoint < b.checkpoint ? -1 : 1,
                 ),

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -379,6 +379,9 @@ export const createSync = async (params: {
           historicalSync,
         });
 
+        // In order to speed up the "extract" phase when there is a crash recovery,
+        // the beginning cursor is moved forwards. This only works when `crashRecoveryCheckpoint`
+        // is defined and `crashRecoveryCheckpoint` refers to the same chain as `network`.
         let from: string;
         if (
           crashRecoveryCheckpoint &&

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -64,8 +64,9 @@ import { isAddressFactory } from "./filter.js";
 export type Sync = {
   getEvents(): EventGenerator;
   startRealtime(): Promise<void>;
+  getStartCheckpoint(network: Network): string;
+  getFinalizedCheckpoint(network: Network): string;
   seconds: Seconds;
-  getFinalizedCheckpoint(): string;
 };
 
 export type RealtimeEvent =
@@ -866,11 +867,6 @@ export const createSync = async (params: {
           ({ filter }) => filter.chainId === network.chainId,
         );
         const filters = sources.map(({ filter }) => filter);
-        // status[network.name]!.block = {
-        //   number: hexToNumber(syncProgress.current!.number),
-        //   timestamp: hexToNumber(syncProgress.current!.timestamp),
-        // };
-        // status[network.name]!.ready = true;
 
         if (isSyncEnd(syncProgress)) {
           params.common.metrics.ponder_sync_is_complete.set(
@@ -936,8 +932,11 @@ export const createSync = async (params: {
       }
     },
     seconds,
-    getFinalizedCheckpoint() {
-      return getOmnichainCheckpoint({ tag: "finalized" })!;
+    getStartCheckpoint(network) {
+      return getMultichainCheckpoint({ tag: "start", network })!;
+    },
+    getFinalizedCheckpoint(network) {
+      return getMultichainCheckpoint({ tag: "finalized", network })!;
     },
   };
 };

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -9,7 +9,6 @@ import type {
   RawEvent,
   Seconds,
   Source,
-  Status,
   SyncBlock,
 } from "@/internal/types.js";
 import {
@@ -64,7 +63,7 @@ import { isAddressFactory } from "./filter.js";
 export type Sync = {
   getEvents(): AsyncGenerator<Event[]>;
   startRealtime(): Promise<void>;
-  getStatus(): Status;
+  // getStatus(): Status;
   seconds: Seconds;
   getFinalizedCheckpoint(): string;
 };

--- a/packages/core/src/utils/generators.test.ts
+++ b/packages/core/src/utils/generators.test.ts
@@ -74,7 +74,7 @@ test("mergeAsyncGenerators() yields all results", async () => {
 
   await new Promise((res) => setTimeout(res));
 
-  expect(results).toStrictEqual([1, 3, 2, 4]);
+  expect(results).toStrictEqual([1, 2, 3, 4]);
 });
 
 test("bufferAsyncGenerator() prefetches results", async () => {

--- a/packages/core/src/utils/generators.ts
+++ b/packages/core/src/utils/generators.ts
@@ -23,9 +23,25 @@ export async function* mergeAsyncGenerators<T>(
       generators.splice(index, 1);
       promises.splice(index, 1);
     } else {
-      yield result.value;
       promises[index] = generators[index]!.next();
+      yield result.value;
     }
+  }
+}
+
+/**
+ * Maps the results of an async generator.
+ *
+ * @param generators - The generator to map.
+ * @param fn - The function to map the generator.
+ * @returns An async generator that yields mapped results from the input generator.
+ */
+export async function* mapAsyncGenerator<T, R>(
+  generators: AsyncGenerator<T>,
+  fn: (value: T) => R,
+): AsyncGenerator<R> {
+  for await (const value of generators) {
+    yield fn(value);
   }
 }
 


### PR DESCRIPTION
## Overview
The primary feature this unlocks is multichain ordering during the historical backfill and more precise crash recoveries.
It also improves performance for "finalize" step during historical backfill (we noticed it was longer than expected).

## `_ponder_checkpoint`
- Replaced `_ponder_status` with `_ponder_checkpoint`
- removed `checkpoint` column from `_ponder_meta`
- `_ponder_checkpoint` has both "latest" and "safe" checkpoint for each chain
- Incremented  user schema `VERSION`  #1649 
https://github.com/ponder-sh/ponder/blob/42e9feec5f9b62fa4dce84f04e334eed30675d4f/packages/core/src/database/index.ts#L135

## multichain ordering
- Improved performance for "multichain" `getEvents` with better merging algorithm
- multichain crash recovery skips re-extracting events when possible

## other
- added `is_ready` column to `_ponder_meta`
- added index on `checkpoint` column for reorg tables
- removed `ready` property from `status` type
- increased max event batch size to 18000 https://github.com/ponder-sh/ponder/blob/80536244268af646b7941d9fe525133f277cd04a/packages/core/src/internal/options.ts#L121
