### PR TITLE
docs: fixing incorrect wording for Ethereum JSON-RPC reference

### DIFF
--- a/docs/pages/docs/getting-started/new-project.mdx
+++ b/docs/pages/docs/getting-started/new-project.mdx
@@ -64,7 +64,7 @@ npm run dev
 
 ### Add an RPC URL
 
-Ponder fetches data using the standard Ethereum RPC API. To get started, you'll need an RPC URL from a provider like Alchemy or Infura.
+Ponder fetches data using the standard Ethereum JSON-RPC API. To get started, you'll need an RPC URL from a provider like Alchemy or Infura.
 
 Open `.env.local` and paste in RPC URLs for any networks that your project uses.
 


### PR DESCRIPTION
just a quick fix in the docs - changed "Ethereum RPC API" to "standard Ethereum JSON-RPC API" to keep things accurate. It's more in line with how Ethereum actually works.