### PR TITLE
docs: fix incorrect type annotation syntax in Markdown

### DIFF
--- a/docs/pages/docs/utilities/replace-bigints.mdx
+++ b/docs/pages/docs/utilities/replace-bigints.mdx
@@ -89,9 +89,9 @@ Here are three common ways to replace `BigInt` values.
 
 | Encoding            | Replacer type                  | Replacer function                                                 |
 | :------------------ | :----------------------------- | :---------------------------------------------------------------- |
-| **Hex**             | `` `0x${string}` {:ts}``       | [`numberToHex`](https://viem.sh/docs/utilities/toHex#numbertohex) |
+| **Hex**             | `` `0x${string}` `` {:ts}      | [`numberToHex`](https://viem.sh/docs/utilities/toHex#numbertohex) |
 | **String**          | `string`                       | `String`                                                          |
-| **Lossless string** | `` `#bigint.${string}` {:ts}`` | `` (x) => `#bigint.${String(x)}` {:ts}``                          |
+| **Lossless string** | `` `#bigint.${string}` ``{:ts} | `` (x) => `#bigint.${String(x)}``` {:ts}                          |
 
 See the [Wagmi FAQ](https://wagmi.sh/react/guides/faq#bigint-serialization) for more information on `BigInt` serialization.
 


### PR DESCRIPTION
fixed an issue where the `{:ts}` type annotation was incorrectly placed *inside* the code block. It should be placed *outside* to work properly with Nextra/MDX.  

now it’s written like this:  

```markdown
`0x${string}` {:ts}
```  

instead of  

```markdown
`0x${string} {:ts}`
```  
