### PR TITLE
fix: realtime sync not properly caching child addresses

### DIFF
--- a/.changeset/curvy-elephants-flow.md
+++ b/.changeset/curvy-elephants-flow.md
@@ -1,0 +1,11 @@
+---
+"ponder": patch
+---
+
+Fixed a bug causing events from sources with factories to be missed.
+
+Any users that were affected by this bug can removed corrupted `ponder_sync` rows with the query:
+
+```sql
+DELETE FROM ponder_sync.intervals WHERE fragment_id like '%offset%' OR fragment_id like '%topic%';
+```

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -1472,7 +1472,6 @@ export const getLocalSyncProgress = async ({
     0,
     hexToNumber(diagnostics[1].number) - network.finalityBlockCount,
   );
-  // const finalized = 25095586;
   syncProgress.finalized = await _eth_getBlockByNumber(requestQueue, {
     blockNumber: finalized,
   });

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -1010,7 +1010,9 @@ export const getPerChainOnRealtimeSyncEvent = ({
 
         for (const block of finalizedBlocks) {
           for (const [factory, addresses] of block.childAddresses) {
-            childAddresses.set(factory, new Map());
+            if (childAddresses.has(factory) === false) {
+              childAddresses.set(factory, new Map());
+            }
             for (const address of addresses) {
               if (childAddresses.get(factory)!.has(address) === false) {
                 childAddresses
@@ -1470,6 +1472,7 @@ export const getLocalSyncProgress = async ({
     0,
     hexToNumber(diagnostics[1].number) - network.finalityBlockCount,
   );
+  // const finalized = 25095586;
   syncProgress.finalized = await _eth_getBlockByNumber(requestQueue, {
     blockNumber: finalized,
   });


### PR DESCRIPTION
There is a bug in the `sync-realtime` factory logic, causing child addresses to not be written to the database while the corresponding interval is, leading to a corrupted ponder_sync. This causes missed events on the following instances, as reported by several users.

In order to remove only the corrupted cache intervals without dropping the entire ponder_sync schema, drop only factory intervals.
https://github.com/ponder-sh/ponder/blob/d17043f7788edd50ec96543bdfdd1f2db4ccb639/packages/core/src/sync-store/migrations.ts#L1672-L1681