### PR TITLE
Add primary key update validation

### DIFF
--- a/.changeset/little-pillows-push.md
+++ b/.changeset/little-pillows-push.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Added validations against updating primary key columns in `db.update().set()` and `db.insert().values().onConflictDoNothing()`.

--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -14,6 +14,7 @@ import {
   type IndexingStore,
   checkOnchainTable,
   parseSqlError,
+  validateUpdateSet,
 } from "./index.js";
 
 export const createHistoricalIndexingStore = ({
@@ -113,12 +114,14 @@ export const createHistoricalIndexingStore = ({
 
                   if (row) {
                     if (typeof valuesU === "function") {
-                      for (const [key, value] of Object.entries(valuesU(row))) {
+                      const set = validateUpdateSet(table, valuesU(row));
+                      for (const [key, value] of Object.entries(set)) {
                         if (value === undefined) continue;
                         row[key] = value;
                       }
                     } else {
-                      for (const [key, value] of Object.entries(valuesU)) {
+                      const set = validateUpdateSet(table, valuesU);
+                      for (const [key, value] of Object.entries(set)) {
                         if (value === undefined) continue;
                         row[key] = value;
                       }
@@ -144,20 +147,18 @@ export const createHistoricalIndexingStore = ({
                 }
                 return rows;
               } else {
-                const row = await indexingCache.get({
-                  table,
-                  key: values,
-                  db,
-                });
+                const row = await indexingCache.get({ table, key: values, db });
 
                 if (row) {
                   if (typeof valuesU === "function") {
-                    for (const [key, value] of Object.entries(valuesU(row))) {
+                    const set = validateUpdateSet(table, valuesU(row));
+                    for (const [key, value] of Object.entries(set)) {
                       if (value === undefined) continue;
                       row[key] = value;
                     }
                   } else {
-                    for (const [key, value] of Object.entries(valuesU)) {
+                    const set = validateUpdateSet(table, valuesU);
+                    for (const [key, value] of Object.entries(set)) {
                       if (value === undefined) continue;
                       row[key] = value;
                     }
@@ -255,23 +256,20 @@ export const createHistoricalIndexingStore = ({
           }
 
           if (typeof values === "function") {
-            for (const [key, value] of Object.entries(values(row))) {
+            const set = validateUpdateSet(table, values(row));
+            for (const [key, value] of Object.entries(set)) {
               if (value === undefined) continue;
               row[key] = value;
             }
           } else {
-            for (const [key, value] of Object.entries(values)) {
+            const set = validateUpdateSet(table, values);
+            for (const [key, value] of Object.entries(set)) {
               if (value === undefined) continue;
               row[key] = value;
             }
           }
 
-          return indexingCache.set({
-            table,
-            key,
-            row,
-            isUpdate: true,
-          });
+          return indexingCache.set({ table, key, row, isUpdate: true });
         },
       };
     },

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -1,8 +1,10 @@
+import { getPrimaryKeyColumns } from "@/drizzle/index.js";
 import { onchain } from "@/drizzle/onchain.js";
 import {
   BigIntSerializationError,
   CheckConstraintError,
   InvalidStoreMethodError,
+  NonRetryableError,
   NotNullConstraintError,
   UndefinedTableError,
   UniqueConstraintError,
@@ -34,6 +36,19 @@ export const parseSqlError = (e: any): Error => {
   }
 
   return error;
+};
+
+export const validateUpdateSet = (table: Table, set: Object): Object => {
+  const primaryKeys = getPrimaryKeyColumns(table);
+
+  for (const { js } of primaryKeys) {
+    if (js in set) {
+      throw new NonRetryableError(
+        `Primary key column '${js}' cannot be updated`,
+      );
+    }
+  }
+  return set;
 };
 
 /** Throw an error if `table` is not an `onchainTable`. */

--- a/packages/core/src/indexing-store/realtime.test.ts
+++ b/packages/core/src/indexing-store/realtime.test.ts
@@ -1,3 +1,4 @@
+import { ALICE } from "@/_test/constants.js";
 import {
   setupCleanup,
   setupCommon,
@@ -7,6 +8,7 @@ import {
 import { onchainEnum, onchainTable } from "@/drizzle/onchain.js";
 import {
   BigIntSerializationError,
+  NonRetryableError,
   NotNullConstraintError,
   UniqueConstraintError,
 } from "@/internal/errors.js";
@@ -278,6 +280,50 @@ test("update", async (context) => {
     address: zeroAddress,
     balance: 22n,
   });
+});
+
+test("update throw error when primary key is updated", async (context) => {
+  const schema = {
+    account: onchainTable("account", (p) => ({
+      address: p.hex().primaryKey(),
+      balance: p.bigint().notNull(),
+    })),
+  };
+
+  const { database } = await setupDatabaseServices(context, {
+    schemaBuild: { schema },
+  });
+
+  const indexingStore = createRealtimeIndexingStore({
+    common: context.common,
+    database,
+    schemaBuild: { schema },
+  });
+
+  // setup
+
+  await indexingStore
+    .insert(schema.account)
+    .values({ address: zeroAddress, balance: 10n });
+
+  // no function
+
+  let error: any = await indexingStore
+    .update(schema.account, { address: zeroAddress })
+    // @ts-expect-error
+    .set({ address: ALICE })
+    .catch((error) => error);
+
+  expect(error).toBeInstanceOf(NonRetryableError);
+
+  // function
+
+  error = await indexingStore
+    .update(schema.account, { address: zeroAddress })
+    .set(() => ({ address: ALICE }))
+    .catch((error) => error);
+
+  expect(error).toBeInstanceOf(NonRetryableError);
 });
 
 test("delete", async (context) => {

--- a/packages/core/src/indexing-store/realtime.ts
+++ b/packages/core/src/indexing-store/realtime.ts
@@ -11,6 +11,7 @@ import {
   type IndexingStore,
   checkOnchainTable,
   parseSqlError,
+  validateUpdateSet,
 } from "./index.js";
 import { getCacheKey, getWhereCondition } from "./utils.js";
 
@@ -103,6 +104,7 @@ export const createRealtimeIndexingStore = ({
 
                 if (typeof valuesU === "object") {
                   try {
+                    const set = validateUpdateSet(table, valuesU);
                     return await database.qb.drizzle
                       .insert(table)
                       .values(values)
@@ -111,7 +113,7 @@ export const createRealtimeIndexingStore = ({
                           // @ts-ignore
                           ({ js }) => table[js],
                         ),
-                        set: valuesU,
+                        set,
                       })
                       .returning()
                       .then((res) => (Array.isArray(values) ? res : res[0]));
@@ -139,10 +141,11 @@ export const createRealtimeIndexingStore = ({
                       }
                     } else {
                       try {
+                        const set = validateUpdateSet(table, valuesU(row));
                         rows.push(
                           await database.qb.drizzle
                             .update(table)
-                            .set(valuesU(row))
+                            .set(set)
                             .where(getWhereCondition(table, value))
                             .returning()
                             .then((res) => res[0]),
@@ -168,9 +171,10 @@ export const createRealtimeIndexingStore = ({
                     }
                   } else {
                     try {
+                      const set = validateUpdateSet(table, valuesU(row));
                       return await database.qb.drizzle
                         .update(table)
-                        .set(valuesU(row))
+                        .set(set)
                         .where(getWhereCondition(table, values))
                         .returning()
                         .then((res) => res[0]);
@@ -243,9 +247,10 @@ export const createRealtimeIndexingStore = ({
               }
 
               try {
+                const set = validateUpdateSet(table, values(row));
                 return await database.qb.drizzle
                   .update(table)
-                  .set(values(row))
+                  .set(set)
                   .where(getWhereCondition(table, key))
                   .returning()
                   .then((res) => res[0]);
@@ -254,9 +259,10 @@ export const createRealtimeIndexingStore = ({
               }
             } else {
               try {
+                const set = validateUpdateSet(table, values);
                 return await database.qb.drizzle
                   .update(table)
-                  .set(values)
+                  .set(set)
                   .where(getWhereCondition(table, key))
                   .returning()
                   .then((res) => res[0]);


### PR DESCRIPTION
Add validations so that primary keys cannot be updated in `db.update().set` and `db.insert().values().onConflictDoUpdate()`