### PR TITLE
build: update setup-node to v4

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
         version: 9.10.0
 
     - name: Set up node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         cache: pnpm
         node-version: 20

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -23,7 +23,7 @@ jobs:
           version: 9.10.0
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: pnpm
           node-version: latest


### PR DESCRIPTION
Updated actions/setup-node to v4 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/actions/setup-node/releases/tag/v4.0.0