### PR TITLE
Rewrite `decodeAbiParameters` from viem

### DIFF
--- a/packages/core/src/sync/events.ts
+++ b/packages/core/src/sync/events.ts
@@ -22,6 +22,7 @@ import {
   ZERO_CHECKPOINT,
   encodeCheckpoint,
 } from "@/utils/checkpoint.js";
+import { decodeAbiParameters } from "@/utils/decodeAbiParameters.js";
 import { never } from "@/utils/never.js";
 import type { AbiEvent, AbiParameter } from "abitype";
 import {
@@ -30,7 +31,6 @@ import {
   DecodeLogTopicsMismatch,
   type Hex,
   checksumAddress,
-  decodeAbiParameters,
   decodeFunctionData,
   decodeFunctionResult,
   hexToBigInt,

--- a/packages/core/src/utils/cursor.ts
+++ b/packages/core/src/utils/cursor.ts
@@ -1,0 +1,110 @@
+import { BaseError, type Hex, size } from "viem";
+
+export type Cursor = {
+  data: Hex;
+  position: number;
+
+  positionReadCount: Map<number, number>;
+  recursiveReadCount: number;
+  recursiveReadLimit: number;
+};
+
+type CursorConfig = { recursiveReadLimit?: number | undefined };
+
+export const createCursor = (
+  data: Hex,
+  { recursiveReadLimit = 8_192 }: CursorConfig = {},
+): Cursor => {
+  return {
+    data,
+    position: 0,
+    recursiveReadCount: 0,
+    positionReadCount: new Map(),
+    recursiveReadLimit,
+  };
+};
+
+export type PositionOutOfBoundsErrorType = PositionOutOfBoundsError & {
+  name: "PositionOutOfBoundsError";
+};
+export class PositionOutOfBoundsError extends BaseError {
+  constructor({ length, position }: { length: number; position: number }) {
+    super(
+      `Position \`${position}\` is out of bounds (\`0 < position < ${length}\`).`,
+      { name: "PositionOutOfBoundsError" },
+    );
+  }
+}
+
+function assertPosition(cursor: Cursor, position: number) {
+  if (position < 0 || position > size(cursor.data) - 1)
+    throw new PositionOutOfBoundsError({
+      length: size(cursor.data),
+      position,
+    });
+}
+
+export type RecursiveReadLimitExceededErrorType =
+  RecursiveReadLimitExceededError & {
+    name: "RecursiveReadLimitExceededError";
+  };
+export class RecursiveReadLimitExceededError extends BaseError {
+  constructor({ count, limit }: { count: number; limit: number }) {
+    super(
+      `Recursive read limit of \`${limit}\` exceeded (recursive read count: \`${count}\`).`,
+      { name: "RecursiveReadLimitExceededError" },
+    );
+  }
+}
+
+function assertReadLimit(cursor: Cursor): void {
+  if (cursor.recursiveReadCount >= cursor.recursiveReadLimit)
+    throw new RecursiveReadLimitExceededError({
+      count: cursor.recursiveReadCount + 1,
+      limit: cursor.recursiveReadLimit,
+    });
+}
+
+function _touch(cursor: Cursor) {
+  if (cursor.recursiveReadLimit === Number.POSITIVE_INFINITY) return;
+  const count = getReadCount(cursor);
+  cursor.positionReadCount.set(cursor.position, count + 1);
+  if (count > 0) cursor.recursiveReadCount++;
+}
+
+function getReadCount(cursor: Cursor, position?: number) {
+  return cursor.positionReadCount.get(position || cursor.position) || 0;
+}
+
+function convertPosition(position: number) {
+  return position * 2 + 2;
+}
+
+export function setPosition(cursor: Cursor, position: number) {
+  const oldPosition = cursor.position;
+  assertPosition(cursor, position);
+  cursor.position = position;
+  return () => (cursor.position = oldPosition);
+}
+
+export function readBytes(cursor: Cursor, length: number, size?: number): Hex {
+  assertReadLimit(cursor);
+  _touch(cursor);
+  const value = inspectBytes(cursor, length);
+  cursor.position += size ?? length;
+  return `0x${value}`;
+}
+
+function inspectBytes(
+  cursor: Cursor,
+  length: number,
+  position_?: number,
+): string {
+  const position = position_ ?? cursor.position;
+  assertPosition(cursor, position + length - 1);
+
+  return cursor.data.substring(
+    convertPosition(position),
+    convertPosition(position + length),
+  );
+}

--- a/packages/core/src/utils/decodeAbiParameters.ts
+++ b/packages/core/src/utils/decodeAbiParameters.ts
@@ -1,0 +1,328 @@
+import {
+  AbiDecodingDataSizeTooSmallError,
+  AbiDecodingZeroDataError,
+  type AbiParameter,
+  type DecodeAbiParametersReturnType,
+  type Hex,
+  InvalidAbiDecodingTypeError,
+  checksumAddress,
+  hexToBigInt,
+  hexToBool,
+  hexToNumber,
+  hexToString,
+  size,
+  trim,
+} from "viem";
+import { type Cursor, createCursor, readBytes, setPosition } from "./cursor.js";
+
+export function decodeAbiParameters<
+  const params extends readonly AbiParameter[],
+>(params: params, data: Hex): DecodeAbiParametersReturnType<params> {
+  if (size(data) === 0 && params.length > 0)
+    throw new AbiDecodingZeroDataError();
+  if (size(data) && size(data) < 32)
+    throw new AbiDecodingDataSizeTooSmallError({
+      data,
+      params: params as readonly AbiParameter[],
+      size: size(data),
+    });
+
+  const cursor = createCursor(data);
+
+  let consumed = 0;
+  const values = [];
+  for (let i = 0; i < params.length; ++i) {
+    const param = params[i]!;
+    setPosition(cursor, consumed);
+    const [data, consumed_] = decodeParameter(cursor, param, {
+      staticPosition: 0,
+    });
+    consumed += consumed_;
+    values.push(data);
+  }
+  return values as DecodeAbiParametersReturnType<params>;
+}
+
+function decodeParameter(
+  cursor: Cursor,
+  param: AbiParameter,
+  { staticPosition }: { staticPosition: number },
+) {
+  const arrayComponents = getArrayComponents(param.type);
+  if (arrayComponents) {
+    const [length, type] = arrayComponents;
+    return decodeArray(cursor, { ...param, type }, { length, staticPosition });
+  }
+  if (param.type === "tuple")
+    return decodeTuple(cursor, param as TupleAbiParameter, { staticPosition });
+
+  if (param.type === "address") return decodeAddress(cursor);
+  if (param.type === "bool") return decodeBool(cursor);
+  if (param.type.startsWith("bytes"))
+    return decodeBytes(cursor, param, { staticPosition });
+  if (param.type.startsWith("uint") || param.type.startsWith("int"))
+    return decodeNumber(cursor, param);
+  if (param.type === "string") return decodeString(cursor, { staticPosition });
+  throw new InvalidAbiDecodingTypeError(param.type, {
+    docsPath: "/docs/contract/decodeAbiParameters",
+  });
+}
+
+export function getArrayComponents(
+  type: string,
+): [length: number | null, innerType: string] | undefined {
+  const matches = type.match(/^(.*)\[(\d+)?\]$/);
+  return matches
+    ? // Return `null` if the array is dynamic.
+      [matches[2] ? Number(matches[2]) : null, matches[1]!]
+    : undefined;
+}
+
+////////////////////////////////////////////////////////////////////
+// Type Decoders
+
+const sizeOfLength = 32;
+const sizeOfOffset = 32;
+
+function decodeAddress(cursor: Cursor) {
+  const value = readBytes(cursor, 32);
+
+  return [checksumAddress(`0x${value.slice(-40)}`), 32];
+}
+
+function decodeArray(
+  cursor: Cursor,
+  param: AbiParameter,
+  { length, staticPosition }: { length: number | null; staticPosition: number },
+) {
+  // If the length of the array is not known in advance (dynamic array),
+  // this means we will need to wonder off to the pointer and decode.
+  if (!length) {
+    // Dealing with a dynamic type, so get the offset of the array data.
+
+    const offset = hexToNumber(readBytes(cursor, sizeOfOffset));
+    //const offset = bytesToNumber(cursor.readBytes(sizeOfOffset));
+
+    // Start is the static position of current slot + offset.
+    const start = staticPosition + offset;
+    const startOfData = start + sizeOfLength;
+
+    // Get the length of the array from the offset.
+    setPosition(cursor, start);
+    const length = hexToNumber(readBytes(cursor, sizeOfLength));
+    //const length = bytesToNumber(cursor.readBytes(sizeOfLength));
+
+    // Check if the array has any dynamic children.
+    const dynamicChild = hasDynamicChild(param);
+
+    let consumed = 0;
+    const value: unknown[] = [];
+    for (let i = 0; i < length; ++i) {
+      // If any of the children is dynamic, then all elements will be offset pointer, thus size of one slot (32 bytes).
+      // Otherwise, elements will be the size of their encoding (consumed bytes).
+      setPosition(cursor, startOfData + (dynamicChild ? i * 32 : consumed));
+      const [data, consumed_] = decodeParameter(cursor, param, {
+        staticPosition: startOfData,
+      });
+      consumed += consumed_;
+      value.push(data);
+    }
+
+    // As we have gone wondering, restore to the original position + next slot.
+    setPosition(cursor, staticPosition + 32);
+    return [value, 32];
+  }
+
+  // If the length of the array is known in advance,
+  // and the length of an element deeply nested in the array is not known,
+  // we need to decode the offset of the array data.
+  if (hasDynamicChild(param)) {
+    // Dealing with dynamic types, so get the offset of the array data.
+    const offset = hexToNumber(readBytes(cursor, sizeOfOffset));
+    //const offset = bytesToNumber(cursor.readBytes(sizeOfOffset));
+
+    // Start is the static position of current slot + offset.
+    const start = staticPosition + offset;
+
+    const value: unknown[] = [];
+    for (let i = 0; i < length; ++i) {
+      // Move cursor along to the next slot (next offset pointer).
+      setPosition(cursor, start + i * 32);
+      const [data] = decodeParameter(cursor, param, {
+        staticPosition: start,
+      });
+      value.push(data);
+    }
+
+    // As we have gone wondering, restore to the original position + next slot.
+    setPosition(cursor, staticPosition + 32);
+    return [value, 32];
+  }
+
+  // If the length of the array is known in advance and the array is deeply static,
+  // then we can just decode each element in sequence.
+  let consumed = 0;
+  const value: unknown[] = [];
+  for (let i = 0; i < length; ++i) {
+    const [data, consumed_] = decodeParameter(cursor, param, {
+      staticPosition: staticPosition + consumed,
+    });
+    consumed += consumed_;
+    value.push(data);
+  }
+  return [value, consumed];
+}
+
+function decodeBool(cursor: Cursor) {
+  return [hexToBool(readBytes(cursor, 32), { size: 32 }), 32];
+}
+
+function decodeBytes(
+  cursor: Cursor,
+  param: AbiParameter,
+  { staticPosition }: { staticPosition: number },
+) {
+  const [_, size] = param.type.split("bytes");
+  if (!size) {
+    // Dealing with dynamic types, so get the offset of the bytes data.
+    const offset = hexToNumber(readBytes(cursor, 32));
+    // const offset = bytesToNumber(cursor.readBytes(32));
+
+    // Set position of the cursor to start of bytes data.
+    setPosition(cursor, staticPosition + offset);
+
+    const length = hexToNumber(readBytes(cursor, 32));
+    // const length = bytesToNumber(cursor.readBytes(32));
+
+    // If there is no length, we have zero data.
+    if (length === 0) {
+      // As we have gone wondering, restore to the original position + next slot.
+      setPosition(cursor, staticPosition + 32);
+      return ["0x", 32];
+    }
+
+    const data = readBytes(cursor, length);
+
+    // As we have gone wondering, restore to the original position + next slot.
+    setPosition(cursor, staticPosition + 32);
+    return [data, 32];
+  }
+
+  const value = readBytes(cursor, Number.parseInt(size), 32);
+  return [value, 32];
+}
+
+function decodeNumber(cursor: Cursor, param: AbiParameter) {
+  const signed = param.type.startsWith("int");
+  const size = Number.parseInt(param.type.split("int")[1] || "256");
+  const value = readBytes(cursor, 32);
+  return [
+    size > 48 ? hexToBigInt(value, { signed }) : hexToNumber(value, { signed }),
+    32,
+  ];
+}
+
+type TupleAbiParameter = AbiParameter & { components: readonly AbiParameter[] };
+
+function decodeTuple(
+  cursor: Cursor,
+  param: TupleAbiParameter,
+  { staticPosition }: { staticPosition: number },
+) {
+  // Tuples can have unnamed components (i.e. they are arrays), so we must
+  // determine whether the tuple is named or unnamed. In the case of a named
+  // tuple, the value will be an object where each property is the name of the
+  // component. In the case of an unnamed tuple, the value will be an array.
+  const hasUnnamedChild =
+    param.components.length === 0 || param.components.some(({ name }) => !name);
+
+  // Initialize the value to an object or an array, depending on whether the
+  // tuple is named or unnamed.
+  const value: any = hasUnnamedChild ? [] : {};
+  let consumed = 0;
+
+  // If the tuple has a dynamic child, we must first decode the offset to the
+  // tuple data.
+  if (hasDynamicChild(param)) {
+    // Dealing with dynamic types, so get the offset of the tuple data.
+    const offset = hexToNumber(readBytes(cursor, sizeOfOffset));
+    // const offset = bytesToNumber(cursor.readBytes(sizeOfOffset));
+
+    // Start is the static position of referencing slot + offset.
+    const start = staticPosition + offset;
+
+    for (let i = 0; i < param.components.length; ++i) {
+      const component = param.components[i]!;
+      setPosition(cursor, start + consumed);
+      const [data, consumed_] = decodeParameter(cursor, component, {
+        staticPosition: start,
+      });
+      consumed += consumed_;
+      value[hasUnnamedChild ? i : component?.name!] = data;
+    }
+
+    // As we have gone wondering, restore to the original position + next slot.
+    setPosition(cursor, staticPosition + 32);
+    return [value, 32];
+  }
+
+  // If the tuple has static children, we can just decode each component
+  // in sequence.
+  for (let i = 0; i < param.components.length; ++i) {
+    const component = param.components[i]!;
+    const [data, consumed_] = decodeParameter(cursor, component, {
+      staticPosition,
+    });
+    value[hasUnnamedChild ? i : component?.name!] = data;
+    consumed += consumed_;
+  }
+  return [value, consumed];
+}
+
+function decodeString(
+  cursor: Cursor,
+  { staticPosition }: { staticPosition: number },
+) {
+  // Get offset to start of string data.
+  const offset = hexToNumber(readBytes(cursor, 32));
+  // const offset = bytesToNumber(cursor.readBytes(32));
+
+  // Start is the static position of current slot + offset.
+  const start = staticPosition + offset;
+  setPosition(cursor, start);
+
+  const length = hexToNumber(readBytes(cursor, 32));
+  // const length = bytesToNumber(cursor.readBytes(32));
+
+  // If there is no length, we have zero data (empty string).
+  if (length === 0) {
+    setPosition(cursor, staticPosition + 32);
+    return ["", 32];
+  }
+
+  const data = readBytes(cursor, length, 32);
+  const value = hexToString(trim(data));
+
+  // As we have gone wondering, restore to the original position + next slot.
+  setPosition(cursor, staticPosition + 32);
+
+  return [value, 32];
+}
+
+function hasDynamicChild(param: AbiParameter) {
+  const { type } = param;
+  if (type === "string") return true;
+  if (type === "bytes") return true;
+  if (type.endsWith("[]")) return true;
+
+  if (type === "tuple") return (param as any).components?.some(hasDynamicChild);
+
+  const arrayComponents = getArrayComponents(param.type);
+  if (
+    arrayComponents &&
+    hasDynamicChild({ ...param, type: arrayComponents[1] } as AbiParameter)
+  )
+    return true;
+
+  return false;
+}


### PR DESCRIPTION
Rewrote `decodeAbiParameters` for string input only removing unnecessary conversions. This rewrite has passed all `decodeAbiParameters` tests. Relates to #1798 