### PR TITLE
fix: handle nonconvetional schema names. e.g. - in schema name

### DIFF
--- a/packages/core/src/bin/commands/prune.ts
+++ b/packages/core/src/bin/commands/prune.ts
@@ -213,7 +213,9 @@ export async function prune({ cliOptions }: { cliOptions: CliOptions }) {
 
   if (schemasToDrop.length > 0) {
     await database.qb.drizzle.execute(
-      sql.raw(`DROP SCHEMA IF EXISTS ${schemasToDrop.join(", ")} CASCADE`),
+      sql.raw(
+        `DROP SCHEMA IF EXISTS ${schemasToDrop.map((s) => `"${s}"`).join(", ")} CASCADE`,
+      ),
     );
 
     logger.warn({


### PR DESCRIPTION
I found an issue with the prune command when I tried to clean the created schemas during ongoing deployments. It appears the schema names are not wrapped with quotes when doing the `DROP SCHEMA IF EXISTS` which causes errors like `syntax error at or near "-" at character 28`

this to happen if you are using dashes in the schema names for example