### PR TITLE
fix: ERC20 example produces incorrect balances

### DIFF
--- a/examples/reference-erc20/src/index.ts
+++ b/examples/reference-erc20/src/index.ts
@@ -16,7 +16,7 @@ ponder.on("ERC20:Transfer", async ({ event, context }) => {
 
   await context.db
     .insert(account)
-    .values({ address: event.args.to, balance: 0n, isOwner: false })
+    .values({ address: event.args.to, balance: event.args.amount, isOwner: false })
     .onConflictDoUpdate((row) => ({
       balance: row.balance + event.args.amount,
     }));


### PR DESCRIPTION
When a user is newly added, their balance should start at `amount` as they are given that from the event