### PR TITLE
docs: fix type error in custom transport example

### DIFF
--- a/docs/pages/docs/config/chains.mdx
+++ b/docs/pages/docs/config/chains.mdx
@@ -111,7 +111,7 @@ export default createConfig({
   chains: {
     mainnet: {
       id: 1,
-      transport: fallback([ // [!code focus]
+      rpc: fallback([ // [!code focus]
         http("https://eth-mainnet.g.alchemy.com/v2/..."), // [!code focus]
         http("https://quaint-large-card.quiknode.pro/..."), // [!code focus]
       ]), // [!code focus]


### PR DESCRIPTION
Fixes a type error in the chain config's custom transport example - there is no `transport` field, it's just `rpc`, which also accepts a `Transform` type value.