### PR TITLE
docs: fix "Suggest changes" deep link

### DIFF
--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -101,7 +101,7 @@ export default defineConfig({
     // },
   ],
   editLink: {
-    pattern: "https://github.com/ponder-sh/ponder/edit/main/vocs/pages/:path",
+    pattern: "https://github.com/ponder-sh/ponder/edit/main/docs/pages/:path",
     text: "Suggest changes",
   },
   theme: {


### PR DESCRIPTION
Fixes the "Suggest changes" deep link at the bottom of each page in the docs. It appears the `vocs` directory was renamed to `docs` in the repo at some point.