### PR TITLE
docs: fix link to off-chain data example

### DIFF
--- a/docs/pages/docs/query/api-endpoints.mdx
+++ b/docs/pages/docs/query/api-endpoints.mdx
@@ -107,4 +107,4 @@ export default app;
 ## More examples
 
 - [**Basic usage**](https://github.com/ponder-sh/ponder/tree/main/examples/feature-api-functions/src/api/index.ts) - An app with custom endpoints serving ERC-20 data.
-- [**Usage with offchain data**](https://github.com/ponder-sh/ponder/tree/main/examples/with-offchain/src/api/index.ts) - An app that includes data from offchain sources.
+- [**Usage with offchain data**](https://github.com/ponder-sh/ponder/blob/main/examples/with-offchain/ponder/src/api/index.ts) - An app that includes data from offchain sources.


### PR DESCRIPTION
Fixes link to the off-chain data usage example on the API endpoints docs page