### PR TITLE
feat: support Harmony, Moonriver, and Aurora retry ranges

### DIFF
--- a/packages/utils/src/_test/aurora.test.ts
+++ b/packages/utils/src/_test/aurora.test.ts
@@ -1,0 +1,68 @@
+import { LimitExceededRpcError, numberToHex } from "viem";
+import { aurora } from "viem/chains";
+import { expect, test } from "vitest";
+import { getLogsRetryHelper } from "../getLogsRetryHelper.js";
+import { type Params, getRequest } from "./utils.js";
+
+const request = getRequest("https://mainnet.aurora.dev", aurora);
+const fromBlock = 57_600_000n;
+const maxBlockRange = 2000n;
+
+test(
+  "aurora success",
+  async () => {
+    const logs = await request({
+      method: "eth_getLogs",
+      params: [
+        {
+          fromBlock: numberToHex(fromBlock),
+          toBlock: numberToHex(fromBlock + maxBlockRange),
+        },
+      ],
+    });
+
+    expect(logs).toBeDefined();
+  },
+  { timeout: 15_000 },
+);
+
+test(
+  "aurora block range",
+  async () => {
+    const params: Params = [
+      {
+        fromBlock: numberToHex(fromBlock),
+        toBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+      },
+    ];
+
+    const error = await request({
+      method: "eth_getLogs",
+      params,
+    }).catch((error) => error);
+
+    expect(error).toBeInstanceOf(LimitExceededRpcError);
+    expect(JSON.stringify(error)).includes("up to a 2000 block range");
+
+    const retry = getLogsRetryHelper({
+      params,
+      error,
+    });
+
+    expect(retry).toStrictEqual({
+      shouldRetry: true,
+      isSuggestedRange: true,
+      ranges: [
+        {
+          fromBlock: numberToHex(fromBlock),
+          toBlock: numberToHex(fromBlock + maxBlockRange),
+        },
+        {
+          fromBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+          toBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+        },
+      ],
+    });
+  },
+  { timeout: 15_000 },
+);

--- a/packages/utils/src/_test/harmony.test.ts
+++ b/packages/utils/src/_test/harmony.test.ts
@@ -1,0 +1,70 @@
+import { InvalidInputRpcError, numberToHex } from "viem";
+import { harmonyOne } from "viem/chains";
+import { expect, test } from "vitest";
+import { getLogsRetryHelper } from "../getLogsRetryHelper.js";
+import { type Params, getRequest } from "./utils.js";
+
+const request = getRequest("https://api.harmony.one", harmonyOne);
+const fromBlock = 70_000_000n;
+const maxBlockRange = 1024n;
+
+test(
+  "harmony success",
+  async () => {
+    const logs = await request({
+      method: "eth_getLogs",
+      params: [
+        {
+          fromBlock: numberToHex(fromBlock),
+          toBlock: numberToHex(fromBlock + maxBlockRange),
+        },
+      ],
+    });
+
+    expect(logs).toHaveLength(703);
+  },
+  { timeout: 15_000 },
+);
+
+test(
+  "harmony block range",
+  async () => {
+    const params: Params = [
+      {
+        fromBlock: numberToHex(fromBlock),
+        toBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+      },
+    ];
+
+    const error = await request({
+      method: "eth_getLogs",
+      params,
+    }).catch((error) => error);
+
+    expect(error).toBeInstanceOf(InvalidInputRpcError);
+    expect(JSON.stringify(error)).includes(
+      "query must be smaller than size 1024",
+    );
+
+    const retry = getLogsRetryHelper({
+      params,
+      error,
+    });
+
+    expect(retry).toStrictEqual({
+      shouldRetry: true,
+      isSuggestedRange: true,
+      ranges: [
+        {
+          fromBlock: numberToHex(fromBlock),
+          toBlock: numberToHex(fromBlock + maxBlockRange),
+        },
+        {
+          fromBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+          toBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+        },
+      ],
+    });
+  },
+  { timeout: 15_000 },
+);

--- a/packages/utils/src/_test/moonriver.test.ts
+++ b/packages/utils/src/_test/moonriver.test.ts
@@ -1,0 +1,73 @@
+import { InternalRpcError, numberToHex } from "viem";
+import { moonriver } from "viem/chains";
+import { expect, test } from "vitest";
+import { getLogsRetryHelper } from "../getLogsRetryHelper.js";
+import { type Params, getRequest } from "./utils.js";
+
+const request = getRequest(
+  "https://rpc.api.moonriver.moonbeam.network",
+  moonriver,
+);
+const fromBlock = 12_000_000n;
+const maxBlockRange = 1024n;
+
+test(
+  "moonriver success",
+  async () => {
+    const logs = await request({
+      method: "eth_getLogs",
+      params: [
+        {
+          fromBlock: numberToHex(fromBlock),
+          toBlock: numberToHex(fromBlock + maxBlockRange),
+        },
+      ],
+    });
+
+    expect(logs).toBeDefined();
+  },
+  { timeout: 15_000 },
+);
+
+test(
+  "moonriver block range",
+  async () => {
+    const params: Params = [
+      {
+        fromBlock: numberToHex(fromBlock),
+        toBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+      },
+    ];
+
+    const error = await request({
+      method: "eth_getLogs",
+      params,
+    }).catch((error) => error);
+
+    expect(error).toBeInstanceOf(InternalRpcError);
+    expect(JSON.stringify(error)).includes(
+      "block range is too wide (maximum 1024)",
+    );
+
+    const retry = getLogsRetryHelper({
+      params,
+      error,
+    });
+
+    expect(retry).toStrictEqual({
+      shouldRetry: true,
+      isSuggestedRange: true,
+      ranges: [
+        {
+          fromBlock: numberToHex(fromBlock),
+          toBlock: numberToHex(fromBlock + maxBlockRange),
+        },
+        {
+          fromBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+          toBlock: numberToHex(fromBlock + maxBlockRange + 1n),
+        },
+      ],
+    });
+  },
+  { timeout: 15_000 },
+);

--- a/packages/utils/src/getLogsRetryHelper.ts
+++ b/packages/utils/src/getLogsRetryHelper.ts
@@ -512,6 +512,25 @@ export const getLogsRetryHelper = ({
     } as const;
   }
 
+  // harmony
+  match = sError.match(/query must be smaller than size ([\d,.]+)/);
+  if (match !== null) {
+    const ranges = chunk({
+      params,
+      range: BigInt(match[1]!.replace(/[,.]/g, "")),
+    });
+
+    if (isRangeUnchanged(params, ranges)) {
+      return { shouldRetry: false } as const;
+    }
+
+    return {
+      shouldRetry: true,
+      ranges,
+      isSuggestedRange: true,
+    } as const;
+  }
+
   // No match found
   return {
     shouldRetry: false,

--- a/packages/utils/src/getLogsRetryHelper.ts
+++ b/packages/utils/src/getLogsRetryHelper.ts
@@ -531,6 +531,44 @@ export const getLogsRetryHelper = ({
     } as const;
   }
 
+  // moonriver
+  match = sError.match(/block range is too wide \(maximum ([\d,.]+)\)/);
+  if (match !== null) {
+    const ranges = chunk({
+      params,
+      range: BigInt(match[1]!.replace(/[,.]/g, "")),
+    });
+
+    if (isRangeUnchanged(params, ranges)) {
+      return { shouldRetry: false } as const;
+    }
+
+    return {
+      shouldRetry: true,
+      ranges,
+      isSuggestedRange: true,
+    } as const;
+  }
+
+  // aurora
+  match = sError.match(/up to a ([\d,.]+) block range/);
+  if (match !== null) {
+    const ranges = chunk({
+      params,
+      range: BigInt(match[1]!.replace(/[,.]/g, "")),
+    });
+
+    if (isRangeUnchanged(params, ranges)) {
+      return { shouldRetry: false } as const;
+    }
+
+    return {
+      shouldRetry: true,
+      ranges,
+      isSuggestedRange: true,
+    } as const;
+  }
+
   // No match found
   return {
     shouldRetry: false,


### PR DESCRIPTION
Adds Harmony, Moonriver, and Aurora RPC support to `getLogsRetryHelper`.

  When these RPCs return block range errors, the helper now extracts the limit and
   automatically chunks requests accordingly:
  - **Harmony**: _"query must be smaller than size X"_ (limit: 1024)
  - **Moonriver**: _"block range is too wide (maximum X)"_ (limit: 1024)
  - **Aurora**: _"up to a X block range"_ (limit: 2000)

  Includes tests to verify the new functionality works as expected for all three
  chains.