### PR TITLE
fix: batch transfers have duplicate transferEvent ids

### DIFF
--- a/examples/reference-erc1155/src/index.ts
+++ b/examples/reference-erc1155/src/index.ts
@@ -83,7 +83,7 @@ ponder.on("ERC1155:TransferBatch", async ({ event, context }) => {
       }));
 
     await context.db.insert(schema.transferEvent).values({
-      id: event.id,
+      id: `${event.id}-${i}`,
       from: event.args.from,
       to: event.args.to,
       token: id,


### PR DESCRIPTION
Running an example erc1155, I got a duplicate primary key error for batch transfers, this concatenates the index (but you may prefer a different approach)