### PR TITLE
feat: include primary keys in update

### DIFF
--- a/packages/core/src/indexing-store/historical.ts
+++ b/packages/core/src/indexing-store/historical.ts
@@ -97,6 +97,7 @@ export const createHistoricalIndexingStore = ({
               }
             },
             onConflictDoUpdate: async (valuesU: any) => {
+              ///
               common.metrics.ponder_indexing_store_queries_total.inc({
                 table: getTableName(table),
                 method: "insert",
@@ -114,13 +115,13 @@ export const createHistoricalIndexingStore = ({
 
                   if (row) {
                     if (typeof valuesU === "function") {
-                      const set = validateUpdateSet(table, valuesU(row));
+                      const set = validateUpdateSet(table, valuesU(row), row);
                       for (const [key, value] of Object.entries(set)) {
                         if (value === undefined) continue;
                         row[key] = value;
                       }
                     } else {
-                      const set = validateUpdateSet(table, valuesU);
+                      const set = validateUpdateSet(table, valuesU, row);
                       for (const [key, value] of Object.entries(set)) {
                         if (value === undefined) continue;
                         row[key] = value;
@@ -151,13 +152,13 @@ export const createHistoricalIndexingStore = ({
 
                 if (row) {
                   if (typeof valuesU === "function") {
-                    const set = validateUpdateSet(table, valuesU(row));
+                    const set = validateUpdateSet(table, valuesU(row), row);
                     for (const [key, value] of Object.entries(set)) {
                       if (value === undefined) continue;
                       row[key] = value;
                     }
                   } else {
-                    const set = validateUpdateSet(table, valuesU);
+                    const set = validateUpdateSet(table, valuesU, row);
                     for (const [key, value] of Object.entries(set)) {
                       if (value === undefined) continue;
                       row[key] = value;
@@ -238,6 +239,7 @@ export const createHistoricalIndexingStore = ({
     // @ts-ignore
     update(table: Table, key) {
       return {
+        ///
         set: async (values: any) => {
           common.metrics.ponder_indexing_store_queries_total.inc({
             table: getTableName(table),
@@ -256,13 +258,13 @@ export const createHistoricalIndexingStore = ({
           }
 
           if (typeof values === "function") {
-            const set = validateUpdateSet(table, values(row));
+            const set = validateUpdateSet(table, values(row), row);
             for (const [key, value] of Object.entries(set)) {
               if (value === undefined) continue;
               row[key] = value;
             }
           } else {
-            const set = validateUpdateSet(table, values);
+            const set = validateUpdateSet(table, values, row);
             for (const [key, value] of Object.entries(set)) {
               if (value === undefined) continue;
               row[key] = value;

--- a/packages/core/src/indexing-store/realtime.ts
+++ b/packages/core/src/indexing-store/realtime.ts
@@ -104,7 +104,7 @@ export const createRealtimeIndexingStore = ({
 
                 if (typeof valuesU === "object") {
                   try {
-                    const set = validateUpdateSet(table, valuesU);
+                    const set = validateUpdateSet(table, valuesU, null);
                     return await database.qb.drizzle
                       .insert(table)
                       .values(values)
@@ -141,7 +141,7 @@ export const createRealtimeIndexingStore = ({
                       }
                     } else {
                       try {
-                        const set = validateUpdateSet(table, valuesU(row));
+                        const set = validateUpdateSet(table, valuesU(row), row);
                         rows.push(
                           await database.qb.drizzle
                             .update(table)
@@ -171,7 +171,7 @@ export const createRealtimeIndexingStore = ({
                     }
                   } else {
                     try {
-                      const set = validateUpdateSet(table, valuesU(row));
+                      const set = validateUpdateSet(table, valuesU(row), row);
                       return await database.qb.drizzle
                         .update(table)
                         .set(set)
@@ -235,9 +235,8 @@ export const createRealtimeIndexingStore = ({
             });
             checkOnchainTable(table, "update");
 
+            const row = await find(table, key);
             if (typeof values === "function") {
-              const row = await find(table, key);
-
               if (row === null) {
                 const error = new RecordNotFoundError(
                   `No existing record found in table '${getTableName(table)}'`,
@@ -247,7 +246,7 @@ export const createRealtimeIndexingStore = ({
               }
 
               try {
-                const set = validateUpdateSet(table, values(row));
+                const set = validateUpdateSet(table, values(row), row);
                 return await database.qb.drizzle
                   .update(table)
                   .set(set)
@@ -259,7 +258,7 @@ export const createRealtimeIndexingStore = ({
               }
             } else {
               try {
-                const set = validateUpdateSet(table, values);
+                const set = validateUpdateSet(table, values, row);
                 return await database.qb.drizzle
                   .update(table)
                   .set(set)


### PR DESCRIPTION
Currently, we throw an error for an update args with primary keys. This solution tolerates including primary keys as log as they are identical to the previous row. Otherwise, it throws an error as before. 