### PR TITLE
fix view creation

### DIFF
--- a/.changeset/cute-points-rush.md
+++ b/.changeset/cute-points-rush.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a regression introduced in `v0.11.33` where creating views would cause the error: `cannot change data type of view column "chain_id" from integer to bigint`.

--- a/packages/core/src/bin/commands/createViews.ts
+++ b/packages/core/src/bin/commands/createViews.ts
@@ -123,14 +123,24 @@ export async function createViews({
   });
 
   await database.qb.drizzle.execute(
+    sql.raw(`DROP VIEW IF EXISTS "${cliOptions.viewsSchema}"."_ponder_meta"`),
+  );
+
+  await database.qb.drizzle.execute(
     sql.raw(
-      `CREATE OR REPLACE VIEW "${cliOptions.viewsSchema}"."_ponder_meta" AS SELECT * FROM "${cliOptions.schema}"."_ponder_meta"`,
+      `DROP VIEW IF EXISTS "${cliOptions.viewsSchema}"."_ponder_checkpoint"`,
     ),
   );
 
   await database.qb.drizzle.execute(
     sql.raw(
-      `CREATE OR REPLACE VIEW "${cliOptions.viewsSchema}"."_ponder_checkpoint" AS SELECT * FROM "${cliOptions.schema}"."_ponder_checkpoint"`,
+      `CREATE VIEW "${cliOptions.viewsSchema}"."_ponder_meta" AS SELECT * FROM "${cliOptions.schema}"."_ponder_meta"`,
+    ),
+  );
+
+  await database.qb.drizzle.execute(
+    sql.raw(
+      `CREATE VIEW "${cliOptions.viewsSchema}"."_ponder_checkpoint" AS SELECT * FROM "${cliOptions.schema}"."_ponder_checkpoint"`,
     ),
   );
 

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -435,13 +435,25 @@ export async function run({
 
       await database.qb.drizzle.execute(
         sql.raw(
-          `CREATE OR REPLACE VIEW "${namespaceBuild.viewsSchema}"."_ponder_meta" AS SELECT * FROM "${namespaceBuild.schema}"."_ponder_meta"`,
+          `DROP VIEW IF EXISTS "${namespaceBuild.viewsSchema}"."_ponder_meta"`,
         ),
       );
 
       await database.qb.drizzle.execute(
         sql.raw(
-          `CREATE OR REPLACE VIEW "${namespaceBuild.viewsSchema}"."_ponder_checkpoint" AS SELECT * FROM "${namespaceBuild.schema}"."_ponder_checkpoint"`,
+          `DROP VIEW IF EXISTS "${namespaceBuild.viewsSchema}"."_ponder_checkpoint"`,
+        ),
+      );
+
+      await database.qb.drizzle.execute(
+        sql.raw(
+          `CREATE VIEW "${namespaceBuild.viewsSchema}"."_ponder_meta" AS SELECT * FROM "${namespaceBuild.schema}"."_ponder_meta"`,
+        ),
+      );
+
+      await database.qb.drizzle.execute(
+        sql.raw(
+          `CREATE VIEW "${namespaceBuild.viewsSchema}"."_ponder_checkpoint" AS SELECT * FROM "${namespaceBuild.schema}"."_ponder_checkpoint"`,
         ),
       );
 


### PR DESCRIPTION
#1894 introduced a regression when creating a view for a `_ponder_checkpoint` table that previously had `chain_id` of type `INTEGER`.