### PR TITLE
fix: no pending sorting on multichain ordering

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -403,7 +403,7 @@ export const createSync = async (params: {
               // finalized checkpoint and add them to pendingEvents. These events are synced during
               // the historical phase, but must be indexed in the realtime phase because events
               // synced in realtime on other chains might be ordered before them.
-              if (checkpoint > to) {
+              if (params.ordering === "omnichain" && checkpoint > to) {
                 const [left, right] = partition(
                   events,
                   (event) => event.checkpoint <= to,


### PR DESCRIPTION
There is no need to sort out events into pending and waiting for other chains' realtime, since the event execution order is not guaranteed to be sequential across chains in multichain ordering. 

If you have two chains, A and B and their timeline in checkpoint terms as follows: 
A:   -------------------------------------|(finalized A)--------------------|(latest)|
B:   --------------|(finalized B)|-------------------------------------------|(latest)|
Currently, the events for chain A between finalized A and finalized B checkpoints are sorted out to be pending, since there is a need for realtime behavior on chain B. This is only valid for omnichain. 

In multichain, we can fearlessly execute those events and do not wait for chain B to switch to realtime. This pr adds this condition. 