### PR TITLE
docs: `transport` -> `rpc` in `createConfig`

### DIFF
--- a/docs/pages/docs/api-reference/ponder-utils.mdx
+++ b/docs/pages/docs/api-reference/ponder-utils.mdx
@@ -189,7 +189,7 @@ export default createConfig({
   chains: {
     mainnet: {
       id: 1,
-      transport: loadBalance([ // [!code focus]
+      rpc: loadBalance([ // [!code focus]
         http("https://cloudflare-eth.com"), // [!code focus]
         http("https://eth-mainnet.public.blastapi.io"), // [!code focus]
         webSocket("wss://ethereum-rpc.publicnode.com"), // [!code focus]
@@ -241,7 +241,7 @@ export default createConfig({
   chains: {
     mainnet: {
       id: 1,
-      transport: rateLimit(http(process.env.PONDER_RPC_URL_1), {
+      rpc: rateLimit(http(process.env.PONDER_RPC_URL_1), {
         requestsPerSecond: 25,
       }),
     },


### PR DESCRIPTION
I think this currently is a mistake: according to the [current code](https://github.com/ponder-sh/ponder/blob/bbc4317b41f7b477baa05c361b61497dd32ec3ba/packages/core/src/config/index.ts#L95), `createConfig` accepts a `rpc` config being a `Transport`, but no separate `transport` property.