### PR TITLE
refactor realtime sync pipeline to use async generator pattern

### DIFF
--- a/integration-test/src/index.ts
+++ b/integration-test/src/index.ts
@@ -1315,35 +1315,11 @@ const onBuild = async (app: PonderApp) => {
         let isAccepted: boolean;
 
         for await (block of getRealtimeBlockGenerator(chain.id)) {
-          isAccepted = await onBlock(block).then(async (result) => {
-            if (result.type === "accepted") {
-              await result.blockPromise;
-              return true;
-            }
-
-            if (result.type === "reorg") {
-              await result.reorgPromise;
-              return false;
-            }
-
-            return false;
-          });
+          isAccepted = await onBlock(block);
         }
         // Note: last block must be accepted before shutdown
         while (isAccepted! === false) {
-          isAccepted = await onBlock(block!).then(async (result) => {
-            if (result.type === "accepted") {
-              await result.blockPromise;
-              return true;
-            }
-
-            if (result.type === "reorg") {
-              await result.reorgPromise;
-              return false;
-            }
-
-            return false;
-          });
+          isAccepted = await onBlock(block!);
         }
 
         app.common.logger.warn({

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -665,7 +665,6 @@ EXECUTE PROCEDURE "${namespaceBuild.viewsSchema}".${notification};`),
           });
 
           break;
-
         case "finalize":
           await database.userQB.transaction(async (tx) => {
             await tx.wrap((tx) =>
@@ -695,7 +694,6 @@ EXECUTE PROCEDURE "${namespaceBuild.viewsSchema}".${notification};`),
           });
 
           break;
-
         default:
           never(event);
       }

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -639,7 +639,7 @@ EXECUTE PROCEDURE "${namespaceBuild.viewsSchema}".${notification};`),
               .where(eq(PONDER_CHECKPOINT.chainName, event.chain.name)),
           );
 
-          event.callback?.(true);
+          event.blockCallback?.(true);
 
           break;
         }

--- a/packages/core/src/bin/utils/run.ts
+++ b/packages/core/src/bin/utils/run.ts
@@ -639,6 +639,8 @@ EXECUTE PROCEDURE "${namespaceBuild.viewsSchema}".${notification};`),
               .where(eq(PONDER_CHECKPOINT.chainName, event.chain.name)),
           );
 
+          event.callback?.(true);
+
           break;
         }
         case "reorg":

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -1,7 +1,6 @@
 import url from "node:url";
 import type { Common } from "@/internal/common.js";
 import type { Chain, SyncBlock, SyncBlockHeader } from "@/internal/types.js";
-import type { RealtimeSync } from "@/sync-realtime/index.js";
 import { createQueue } from "@/utils/queue.js";
 import {
   _eth_getBlockByHash,
@@ -42,9 +41,7 @@ export type Rpc = {
     parameters: TParameters,
   ) => Promise<RequestReturnType<TParameters["method"]>>;
   subscribe: (params: {
-    onBlock: (
-      block: SyncBlock | SyncBlockHeader,
-    ) => ReturnType<RealtimeSync["sync"]>;
+    onBlock: (block: SyncBlock | SyncBlockHeader) => Promise<boolean>;
     onError: (error: Error) => void;
     polling?: boolean;
   }) => void;

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -278,7 +278,7 @@ test("handleBlock() block event with log", async (context) => {
   expect(syncResult).toHaveLength(1);
   expect(syncResult[0]).toStrictEqual({
     type: "block",
-    callback: undefined,
+    blockCallback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -368,7 +368,7 @@ test("handleBlock() block event with log factory", async (context) => {
 
   expect(data[0]).toStrictEqual({
     type: "block",
-    callback: undefined,
+    blockCallback: undefined,
     hasMatchedFilter: false,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -380,7 +380,7 @@ test("handleBlock() block event with log factory", async (context) => {
 
   expect(data[1]).toStrictEqual({
     type: "block",
-    callback: undefined,
+    blockCallback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -472,7 +472,7 @@ test("handleBlock() block event with block", async (context) => {
   expect(syncResult).toHaveLength(1);
   expect(syncResult[0]).toStrictEqual({
     type: "block",
-    callback: undefined,
+    blockCallback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -533,7 +533,7 @@ test("handleBlock() block event with transaction", async (context) => {
   expect(syncResult).toHaveLength(1);
   expect(syncResult[0]).toStrictEqual({
     type: "block",
-    callback: undefined,
+    blockCallback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -620,7 +620,7 @@ test("handleBlock() block event with transfer", async (context) => {
   expect(syncResult).toHaveLength(1);
   expect(syncResult[0]).toStrictEqual({
     type: "block",
-    callback: undefined,
+    blockCallback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -278,6 +278,7 @@ test("handleBlock() block event with log", async (context) => {
   expect(syncResult).toHaveLength(1);
   expect(syncResult[0]).toStrictEqual({
     type: "block",
+    callback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -367,6 +368,7 @@ test("handleBlock() block event with log factory", async (context) => {
 
   expect(data[0]).toStrictEqual({
     type: "block",
+    callback: undefined,
     hasMatchedFilter: false,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -378,6 +380,7 @@ test("handleBlock() block event with log factory", async (context) => {
 
   expect(data[1]).toStrictEqual({
     type: "block",
+    callback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -469,6 +472,7 @@ test("handleBlock() block event with block", async (context) => {
   expect(syncResult).toHaveLength(1);
   expect(syncResult[0]).toStrictEqual({
     type: "block",
+    callback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -529,6 +533,7 @@ test("handleBlock() block event with transaction", async (context) => {
   expect(syncResult).toHaveLength(1);
   expect(syncResult[0]).toStrictEqual({
     type: "block",
+    callback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),
@@ -615,6 +620,7 @@ test("handleBlock() block event with transfer", async (context) => {
   expect(syncResult).toHaveLength(1);
   expect(syncResult[0]).toStrictEqual({
     type: "block",
+    callback: undefined,
     hasMatchedFilter: true,
     block: expect.any(Object),
     logs: expect.any(Object),

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -27,6 +27,7 @@ import {
 import { buildConfigAndIndexingFunctions } from "@/build/config.js";
 import type { LogFactory, LogFilter } from "@/internal/types.js";
 import { createRpc } from "@/rpc/index.js";
+import { drainAsyncGenerator } from "@/utils/generators.js";
 import { _eth_getBlockByNumber } from "@/utils/rpc.js";
 import {
   encodeFunctionData,
@@ -65,16 +66,15 @@ test("createRealtimeSync()", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent: vi.fn(() => Promise.resolve({ promise: Promise.resolve() })),
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   expect(realtimeSync).toBeDefined();
 });
 
-test("start() handles block", async (context) => {
+test("sync() handles block", async (context) => {
   const { common } = context;
   await setupDatabaseServices(context);
 
@@ -97,19 +97,18 @@ test("start() handles block", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent: vi.fn(() => Promise.resolve({ promise: Promise.resolve() })),
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   await testClient.mine({ blocks: 1 });
   const block = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
-  const syncResult = await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
-  expect(syncResult.type).toBe("accepted");
-
+  expect(syncResult).toHaveLength(1);
+  expect(syncResult[0]!.type).toBe("block");
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
 });
 
@@ -136,19 +135,19 @@ test("sync() no-op when receiving same block twice", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent: vi.fn(() => Promise.resolve({ promise: Promise.resolve() })),
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   await testClient.mine({ blocks: 1 });
   const block = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
-  await realtimeSync.sync(block);
-  const syncResult = await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
-  expect(syncResult.type).toBe("rejected");
+  expect(syncResult).toHaveLength(0);
+
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
 });
 
@@ -175,18 +174,21 @@ test("sync() gets missing block", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent: vi.fn(() => Promise.resolve({ promise: Promise.resolve() })),
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   await testClient.mine({ blocks: 2 });
   const block = await _eth_getBlockByNumber(rpc, { blockNumber: 2 });
 
-  const syncResult = await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
-  expect(syncResult.type).toBe("accepted");
+  expect(syncResult).toHaveLength(2);
+
+  expect(syncResult[0]!.type).toBe("block");
+  expect(syncResult[1]!.type).toBe("block");
+
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(2);
 });
 
@@ -213,10 +215,9 @@ test("sync() catches error", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent: vi.fn(() => Promise.resolve({ promise: Promise.resolve() })),
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   await testClient.mine({ blocks: 1 });
@@ -225,9 +226,9 @@ test("sync() catches error", async (context) => {
   const requestSpy = vi.spyOn(rpc, "request");
   requestSpy.mockRejectedValueOnce(new Error());
 
-  const syncResult = await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
-  expect(syncResult.type).toBe("rejected");
+  expect(syncResult).toHaveLength(0);
 
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(0);
 });
@@ -256,13 +257,6 @@ test("handleBlock() block event with log", async (context) => {
     rawIndexingFunctions,
   });
 
-  const data: Extract<RealtimeSyncEvent, { type: "block" }>[] = [];
-
-  const onEvent = vi.fn(async (_data) => {
-    data.push(_data);
-    return { promise: Promise.resolve() };
-  });
-
   const finalizedBlock = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
   const realtimeSync = createRealtimeSync({
@@ -270,20 +264,19 @@ test("handleBlock() block event with log", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent,
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   const block = await _eth_getBlockByNumber(rpc, { blockNumber: 2 });
 
-  await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
 
-  expect(onEvent).toHaveBeenCalledTimes(1);
-  expect(onEvent).toHaveBeenCalledWith({
+  expect(syncResult).toHaveLength(1);
+  expect(syncResult[0]).toStrictEqual({
     type: "block",
     hasMatchedFilter: true,
     block: expect.any(Object),
@@ -294,10 +287,20 @@ test("handleBlock() block event with log", async (context) => {
     childAddresses: expect.any(Object),
   });
 
-  expect(data[0]?.block.number).toBe("0x2");
-  expect(data[0]?.logs).toHaveLength(1);
-  expect(data[0]?.traces).toHaveLength(0);
-  expect(data[0]?.transactions).toHaveLength(1);
+  expect(
+    (syncResult[0] as Extract<RealtimeSyncEvent, { type: "block" }>)?.block
+      .number,
+  ).toBe("0x2");
+  expect(
+    (syncResult[0] as Extract<RealtimeSyncEvent, { type: "block" }>)?.logs,
+  ).toHaveLength(1);
+  expect(
+    (syncResult[0] as Extract<RealtimeSyncEvent, { type: "block" }>)?.traces,
+  ).toHaveLength(0);
+  expect(
+    (syncResult[0] as Extract<RealtimeSyncEvent, { type: "block" }>)
+      ?.transactions,
+  ).toHaveLength(1);
 });
 
 test("handleBlock() block event with log factory", async (context) => {
@@ -332,13 +335,6 @@ test("handleBlock() block event with log factory", async (context) => {
 
   const filter = sources[0]!.filter as LogFilter<LogFactory>;
 
-  const data: Extract<RealtimeSyncEvent, { type: "block" }>[] = [];
-
-  const onEvent = vi.fn(async (_data) => {
-    data.push(_data);
-    return { promise: Promise.resolve() };
-  });
-
   const finalizedBlock = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
   const realtimeSync = createRealtimeSync({
@@ -346,24 +342,41 @@ test("handleBlock() block event with log factory", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent,
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map([[filter.address.id, new Map()]]),
+    childAddresses: new Map([[filter.address.id, new Map()]]),
   });
 
   let block = await _eth_getBlockByNumber(rpc, { blockNumber: 2 });
 
-  await realtimeSync.sync(block);
+  const syncResult1 = await drainAsyncGenerator(realtimeSync.sync(block));
 
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 3 });
 
-  await realtimeSync.sync(block);
+  const syncResult2 = await drainAsyncGenerator(realtimeSync.sync(block));
 
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(2);
 
-  expect(onEvent).toHaveBeenCalledTimes(2);
-  expect(onEvent).toHaveBeenCalledWith({
+  expect(syncResult1).toHaveLength(1);
+  expect(syncResult2).toHaveLength(1);
+
+  const data = [...syncResult1, ...syncResult2] as Extract<
+    RealtimeSyncEvent,
+    { type: "block" }
+  >[];
+
+  expect(data[0]).toStrictEqual({
+    type: "block",
+    hasMatchedFilter: false,
+    block: expect.any(Object),
+    logs: expect.any(Object),
+    transactions: expect.any(Object),
+    traces: expect.any(Object),
+    transactionReceipts: expect.any(Object),
+    childAddresses: expect.any(Object),
+  });
+
+  expect(data[1]).toStrictEqual({
     type: "block",
     hasMatchedFilter: true,
     block: expect.any(Object),
@@ -434,13 +447,6 @@ test("handleBlock() block event with block", async (context) => {
     rawIndexingFunctions,
   });
 
-  const data: Extract<RealtimeSyncEvent, { type: "block" }>[] = [];
-
-  const onEvent = vi.fn(async (_data) => {
-    data.push(_data);
-    return { promise: Promise.resolve() };
-  });
-
   const finalizedBlock = await _eth_getBlockByNumber(rpc, { blockNumber: 0 });
 
   const realtimeSync = createRealtimeSync({
@@ -448,21 +454,20 @@ test("handleBlock() block event with block", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent,
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   await testClient.mine({ blocks: 1 });
   const block = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
-  await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
 
-  expect(onEvent).toHaveBeenCalledTimes(1);
-  expect(onEvent).toHaveBeenCalledWith({
+  expect(syncResult).toHaveLength(1);
+  expect(syncResult[0]).toStrictEqual({
     type: "block",
     hasMatchedFilter: true,
     block: expect.any(Object),
@@ -473,6 +478,7 @@ test("handleBlock() block event with block", async (context) => {
     childAddresses: expect.any(Object),
   });
 
+  const data = syncResult as Extract<RealtimeSyncEvent, { type: "block" }>[];
   expect(data[0]?.block.number).toBe("0x1");
   expect(data[0]?.logs).toHaveLength(0);
   expect(data[0]?.traces).toHaveLength(0);
@@ -502,13 +508,6 @@ test("handleBlock() block event with transaction", async (context) => {
     rawIndexingFunctions,
   });
 
-  const data: Extract<RealtimeSyncEvent, { type: "block" }>[] = [];
-
-  const onEvent = vi.fn(async (_data) => {
-    data.push(_data);
-    return { promise: Promise.resolve() };
-  });
-
   const finalizedBlock = await _eth_getBlockByNumber(rpc, { blockNumber: 0 });
 
   const realtimeSync = createRealtimeSync({
@@ -516,20 +515,19 @@ test("handleBlock() block event with transaction", async (context) => {
     chain,
     rpc,
     sources: sources.filter(({ filter }) => filter.type === "transaction"),
-    onEvent,
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   const block = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
-  await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
 
-  expect(onEvent).toHaveBeenCalledTimes(1);
-  expect(onEvent).toHaveBeenCalledWith({
+  expect(syncResult).toHaveLength(1);
+  expect(syncResult[0]).toStrictEqual({
     type: "block",
     hasMatchedFilter: true,
     block: expect.any(Object),
@@ -540,6 +538,7 @@ test("handleBlock() block event with transaction", async (context) => {
     childAddresses: expect.any(Object),
   });
 
+  const data = syncResult as Extract<RealtimeSyncEvent, { type: "block" }>[];
   expect(data[0]?.block.number).toBe("0x1");
   expect(data[0]?.logs).toHaveLength(0);
   expect(data[0]?.traces).toHaveLength(0);
@@ -592,13 +591,6 @@ test("handleBlock() block event with transfer", async (context) => {
     return rpc.request(request);
   };
 
-  const data: Extract<RealtimeSyncEvent, { type: "block" }>[] = [];
-
-  const onEvent = vi.fn(async (_data) => {
-    data.push(_data);
-    return { promise: Promise.resolve() };
-  });
-
   const finalizedBlock = await _eth_getBlockByNumber(rpc, { blockNumber: 0 });
 
   const realtimeSync = createRealtimeSync({
@@ -609,20 +601,19 @@ test("handleBlock() block event with transfer", async (context) => {
       request,
     },
     sources,
-    onEvent,
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   const block = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
-  await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
 
-  expect(onEvent).toHaveBeenCalledTimes(1);
-  expect(onEvent).toHaveBeenCalledWith({
+  expect(syncResult).toHaveLength(1);
+  expect(syncResult[0]).toStrictEqual({
     type: "block",
     hasMatchedFilter: true,
     block: expect.any(Object),
@@ -633,6 +624,7 @@ test("handleBlock() block event with transfer", async (context) => {
     childAddresses: expect.any(Object),
   });
 
+  const data = syncResult as Extract<RealtimeSyncEvent, { type: "block" }>[];
   expect(data[0]?.block.number).toBe("0x1");
   expect(data[0]?.logs).toHaveLength(0);
   expect(data[0]?.traces).toHaveLength(1);
@@ -725,13 +717,6 @@ test("handleBlock() block event with trace", async (context) => {
     return rpc.request(request);
   };
 
-  const data: Extract<RealtimeSyncEvent, { type: "block" }>[] = [];
-
-  const onEvent = vi.fn(async (_data) => {
-    data.push(_data);
-    return { promise: Promise.resolve() };
-  });
-
   const finalizedBlock = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
   const realtimeSync = createRealtimeSync({
@@ -743,28 +728,23 @@ test("handleBlock() block event with trace", async (context) => {
       request,
     },
     sources,
-    onEvent,
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
-  await realtimeSync.sync(block2);
-  await realtimeSync.sync(block3);
+  const syncResult1 = await drainAsyncGenerator(realtimeSync.sync(block2));
+  const syncResult2 = await drainAsyncGenerator(realtimeSync.sync(block3));
 
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(2);
 
-  expect(onEvent).toHaveBeenCalledTimes(2);
-  expect(onEvent).toHaveBeenCalledWith({
-    type: "block",
-    hasMatchedFilter: true,
-    block: expect.any(Object),
-    logs: expect.any(Object),
-    transactions: expect.any(Object),
-    traces: expect.any(Object),
-    transactionReceipts: expect.any(Object),
-    childAddresses: expect.any(Object),
-  });
+  expect(syncResult1).toHaveLength(1);
+  expect(syncResult2).toHaveLength(1);
+
+  const data = [...syncResult1, ...syncResult2] as Extract<
+    RealtimeSyncEvent,
+    { type: "block" }
+  >[];
 
   expect(data[0]?.block.number).toBe("0x2");
   expect(data[1]?.block.number).toBe("0x3");
@@ -803,50 +783,46 @@ test("handleBlock() finalize event", async (context) => {
 
   const finalizedBlock = await _eth_getBlockByNumber(rpc, { blockNumber: 0 });
 
-  const data: Extract<RealtimeSyncEvent, { type: "finalize" }>[] = [];
-
-  const onEvent = vi.fn(async (_data) => {
-    if (_data.type === "finalize") data.push(_data);
-    return { promise: Promise.resolve() };
-  });
-
   const realtimeSync = createRealtimeSync({
     common,
     chain,
     rpc,
     sources,
-    onEvent,
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   await testClient.mine({ blocks: 4 });
 
   let block = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 2 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 3 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 4 });
 
-  await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
-  expect(onEvent).toHaveBeenCalledWith({
+  expect(syncResult).toHaveLength(2);
+  expect(syncResult[1]).toStrictEqual({
     type: "finalize",
     block: expect.any(Object),
   });
 
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(2);
 
-  expect(data[0]?.block.number).toBe("0x2");
+  expect(
+    (syncResult[1] as Extract<RealtimeSyncEvent, { type: "finalize" }>).block
+      .number,
+  ).toBe("0x2");
 });
 
 test("handleReorg() finds common ancestor", async (context) => {
@@ -870,39 +846,37 @@ test("handleReorg() finds common ancestor", async (context) => {
 
   const finalizedBlock = await _eth_getBlockByNumber(rpc, { blockNumber: 0 });
 
-  const onEvent = vi.fn(() => Promise.resolve({ promise: Promise.resolve() }));
-
   const realtimeSync = createRealtimeSync({
     common,
     chain,
     rpc,
     sources,
-    onEvent,
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   await testClient.mine({ blocks: 1 });
   let block = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   await testClient.mine({ blocks: 1 });
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 2 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   await testClient.mine({ blocks: 1 });
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 3 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 2 });
 
-  await realtimeSync.sync(block);
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(block));
 
-  expect(onEvent).toHaveBeenCalledWith({
+  expect(syncResult).toHaveLength(1);
+  expect(syncResult[0]).toStrictEqual({
     type: "reorg",
     block: expect.any(Object),
     reorgedBlocks: [expect.any(Object), expect.any(Object)],
@@ -937,35 +911,36 @@ test("handleReorg() throws error for deep reorg", async (context) => {
     chain,
     rpc,
     sources,
-    onEvent: vi.fn(() => Promise.resolve({ promise: Promise.resolve() })),
     onFatalError: vi.fn(),
     syncProgress: { finalized: finalizedBlock },
-    initialChildAddresses: new Map(),
+    childAddresses: new Map(),
   });
 
   await testClient.mine({ blocks: 1 });
   let block = await _eth_getBlockByNumber(rpc, { blockNumber: 1 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   await testClient.mine({ blocks: 1 });
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 2 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   await testClient.mine({ blocks: 1 });
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 3 });
 
-  await realtimeSync.sync(block);
+  await drainAsyncGenerator(realtimeSync.sync(block));
 
   block = await _eth_getBlockByNumber(rpc, { blockNumber: 3 });
 
-  await realtimeSync.sync({
-    ...block,
-    number: "0x4",
-    hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-    parentHash: realtimeSync.unfinalizedBlocks[1]!.hash,
-  });
+  await drainAsyncGenerator(
+    realtimeSync.sync({
+      ...block,
+      number: "0x4",
+      hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+      parentHash: realtimeSync.unfinalizedBlocks[1]!.hash,
+    }),
+  );
 
   // block 4 is not added to `unfinalizedBlocks`
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(3);

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -33,7 +33,6 @@ import {
   shouldGetTransactionReceipt,
 } from "@/sync/filter.js";
 import { type SyncProgress, syncBlockToLightBlock } from "@/sync/index.js";
-import { mutex } from "@/utils/mutex.js";
 import { range } from "@/utils/range.js";
 import {
   _debug_traceBlockByHash,
@@ -57,27 +56,11 @@ export type RealtimeSync = {
    *
    * @param block - The block to reconcile.
    */
-  sync(block: SyncBlock | SyncBlockHeader): Promise<SyncResult>;
+  sync(block: SyncBlock | SyncBlockHeader): AsyncGenerator<RealtimeSyncEvent>;
   onError(error: Error): void;
-  /**
-   * Local chain of blocks that have not been finalized.
-   */
+  /** Local chain of blocks that have not been finalized. */
   unfinalizedBlocks: LightBlock[];
-  childAddresses: Map<FactoryId, Map<Address, number>>;
 };
-
-/**
- * @dev Each "promise" property resolves when the corresponding
- * event is fully processed.
- */
-type SyncResult =
-  | { type: "rejected" }
-  | { type: "reorg"; reorgPromise: Promise<void> }
-  | {
-      type: "accepted";
-      blockPromise: Promise<void>;
-      finalizePromise?: Promise<void>;
-    };
 
 export type BlockWithEventData = {
   block: SyncBlock | SyncBlockHeader;
@@ -109,13 +92,7 @@ type CreateRealtimeSyncParameters = {
   rpc: Rpc;
   sources: Source[];
   syncProgress: Pick<SyncProgress, "finalized">;
-  initialChildAddresses: Map<FactoryId, Map<Address, number>>;
-  /**
-   * Handle a realtime sync event.
-   *
-   * @returns An unchained promise that resolves when the event is fully processed.
-   */
-  onEvent: (event: RealtimeSyncEvent) => Promise<{ promise: Promise<void> }>;
+  childAddresses: Map<FactoryId, Map<Address, number>>;
   onFatalError: (error: Error) => void;
 };
 
@@ -129,12 +106,9 @@ const MAX_QUEUED_BLOCKS = 25;
 export const createRealtimeSync = (
   args: CreateRealtimeSyncParameters,
 ): RealtimeSync => {
-  ////////
-  // state
-  ////////
   let isBlockReceipts = true;
   let finalizedBlock: LightBlock = args.syncProgress.finalized;
-  const childAddresses = args.initialChildAddresses;
+  const childAddresses = args.childAddresses;
   /** Annotates `childAddresses` for efficient lookup by block number */
   const childAddressesPerBlock = new Map<
     number,
@@ -714,7 +688,7 @@ export const createRealtimeSync = (
    */
   const reconcileReorg = async (
     block: SyncBlock | SyncBlockHeader,
-  ): Promise<{ promise: Promise<void> }> => {
+  ): Promise<Extract<RealtimeSyncEvent, { type: "reorg" }>> => {
     args.common.logger.warn({
       service: "realtime",
       msg: `Detected forked '${args.chain.name}' block at height ${hexToNumber(block.number)}`,
@@ -762,12 +736,6 @@ export const createRealtimeSync = (
 
     const commonAncestor = getLatestUnfinalizedBlock();
 
-    const reorgPromise = args.onEvent({
-      type: "reorg",
-      block: commonAncestor,
-      reorgedBlocks,
-    });
-
     args.common.logger.warn({
       service: "realtime",
       msg: `Reconciled ${reorgedBlocks.length}-block '${
@@ -788,54 +756,11 @@ export const createRealtimeSync = (
       childAddressesPerBlock.delete(hexToNumber(block.number));
     }
 
-    return reorgPromise;
-  };
-
-  /**
-   * Start syncing the latest block.
-   */
-  const fetchAndReconcileLatestBlock = async (
-    block: SyncBlock | SyncBlockHeader,
-  ): Promise<SyncResult> => {
-    try {
-      args.common.logger.debug({
-        service: "realtime",
-        msg: `Received latest '${args.chain.name}' block ${hexToNumber(block.number)}`,
-      });
-
-      const latestBlock = getLatestUnfinalizedBlock();
-
-      // We already saw and handled this block. No-op.
-      if (latestBlock.hash === block.hash) {
-        args.common.logger.trace({
-          service: "realtime",
-          msg: `Skipped processing '${args.chain.name}' block ${hexToNumber(block.number)}, already synced`,
-        });
-
-        return { type: "rejected" };
-      }
-
-      const blockWithEventData = await fetchBlockEventData(block);
-
-      fetchAndReconcileLatestBlockErrorCount = 0;
-
-      const result = await reconcileBlock(blockWithEventData);
-
-      return resolvePending(result);
-    } catch (_error) {
-      onError(_error as Error);
-      return { type: "rejected" };
-    }
-  };
-
-  const resolvePending = async (
-    result: Awaited<ReturnType<typeof reconcileBlock>>,
-  ): Promise<SyncResult> => {
-    if (result.type === "pending") {
-      return result.promise.then(resolvePending);
-    }
-
-    return result;
+    return {
+      type: "reorg",
+      block: commonAncestor,
+      reorgedBlocks,
+    };
   };
 
   /**
@@ -861,249 +786,227 @@ export const createRealtimeSync = (
    * - `accepted` for case 4 with promises for the "block" and "finalize" events
    *   that resolve when each event is applied.
    */
-  const reconcileBlock = mutex(
-    async (
-      blockWithEventData: BlockWithEventData,
-    ): Promise<
-      SyncResult | { type: "pending"; promise: Promise<SyncResult> }
-    > => {
-      const latestBlock = getLatestUnfinalizedBlock();
-      const block = blockWithEventData.block;
+  const reconcileBlock = async function* (
+    blockWithEventData: BlockWithEventData,
+  ): AsyncGenerator<RealtimeSyncEvent> {
+    const latestBlock = getLatestUnfinalizedBlock();
+    const block = blockWithEventData.block;
 
-      // We already saw and handled this block. No-op.
-      if (latestBlock.hash === block.hash) {
-        args.common.logger.trace({
-          service: "realtime",
-          msg: `Skipped processing '${args.chain.name}' block ${hexToNumber(block.number)}, already synced`,
-        });
+    // We already saw and handled this block. No-op.
+    if (latestBlock.hash === block.hash) {
+      args.common.logger.trace({
+        service: "realtime",
+        msg: `Skipped processing '${args.chain.name}' block ${hexToNumber(block.number)}, already synced`,
+      });
 
-        return { type: "rejected" };
+      return;
+    }
+
+    try {
+      // Quickly check for a reorg by comparing block numbers. If the block
+      // number has not increased, a reorg must have occurred.
+      if (hexToNumber(latestBlock.number) >= hexToNumber(block.number)) {
+        const reorgEvent = await reconcileReorg(block);
+
+        yield reorgEvent;
+        return;
       }
 
-      try {
-        // Quickly check for a reorg by comparing block numbers. If the block
-        // number has not increased, a reorg must have occurred.
-        if (hexToNumber(latestBlock.number) >= hexToNumber(block.number)) {
-          const reorgPromise = await reconcileReorg(block);
+      // Blocks are missing. They should be fetched and enqueued.
+      if (hexToNumber(latestBlock.number) + 1 < hexToNumber(block.number)) {
+        // Retrieve missing blocks, but only fetch a certain amount.
+        const missingBlockRange = range(
+          hexToNumber(latestBlock.number) + 1,
+          Math.min(
+            hexToNumber(block.number),
+            hexToNumber(latestBlock.number) + MAX_QUEUED_BLOCKS,
+          ),
+        );
 
-          return { type: "reorg", reorgPromise: reorgPromise.promise };
-        }
+        const pendingBlocks = await Promise.all(
+          missingBlockRange.map((blockNumber) =>
+            _eth_getBlockByNumber(args.rpc, {
+              blockNumber,
+            }).then((block) => fetchBlockEventData(block)),
+          ),
+        );
 
-        // Blocks are missing. They should be fetched and enqueued.
-        if (hexToNumber(latestBlock.number) + 1 < hexToNumber(block.number)) {
-          // Retrieve missing blocks, but only fetch a certain amount.
-          const missingBlockRange = range(
-            hexToNumber(latestBlock.number) + 1,
-            Math.min(
-              hexToNumber(block.number),
-              hexToNumber(latestBlock.number) + MAX_QUEUED_BLOCKS,
-            ),
-          );
-
-          const pendingBlocks = await Promise.all(
-            missingBlockRange.map((blockNumber) =>
-              _eth_getBlockByNumber(args.rpc, {
-                blockNumber,
-              }).then((block) => fetchBlockEventData(block)),
-            ),
-          );
-
-          args.common.logger.info({
-            service: "realtime",
-            msg: `Fetched ${missingBlockRange.length} missing '${
-              args.chain.name
-            }' blocks [${hexToNumber(latestBlock.number) + 1}, ${Math.min(
-              hexToNumber(block.number),
-              hexToNumber(latestBlock.number) + MAX_QUEUED_BLOCKS,
-            )}]`,
-          });
-
-          reconcileBlock.clear(({ resolve }) => resolve({ type: "rejected" }));
-          for (const pendingBlock of pendingBlocks) {
-            reconcileBlock(pendingBlock);
-          }
-
-          return {
-            type: "pending",
-            promise: reconcileBlock(blockWithEventData).then(resolvePending),
-          };
-        }
-
-        // Check if a reorg occurred by validating the chain of block hashes.
-        if (block.parentHash !== latestBlock.hash) {
-          const reorgPromise = await reconcileReorg(block);
-
-          return { type: "reorg", reorgPromise: reorgPromise.promise };
-        }
-
-        // New block is exactly one block ahead of the local chain.
-        // Attempt to ingest it.
-
-        const blockWithFilteredEventData =
-          filterBlockEventData(blockWithEventData);
-
-        if (
-          blockWithFilteredEventData.logs.length > 0 ||
-          blockWithFilteredEventData.traces.length > 0 ||
-          blockWithFilteredEventData.transactions.length > 0
-        ) {
-          const _text: string[] = [];
-
-          if (blockWithFilteredEventData.logs.length === 1) {
-            _text.push("1 log");
-          } else if (blockWithFilteredEventData.logs.length > 1) {
-            _text.push(`${blockWithFilteredEventData.logs.length} logs`);
-          }
-
-          if (blockWithFilteredEventData.traces.length === 1) {
-            _text.push("1 trace");
-          } else if (blockWithFilteredEventData.traces.length > 1) {
-            _text.push(`${blockWithFilteredEventData.traces.length} traces`);
-          }
-
-          if (blockWithFilteredEventData.transactions.length === 1) {
-            _text.push("1 transaction");
-          } else if (blockWithFilteredEventData.transactions.length > 1) {
-            _text.push(
-              `${blockWithFilteredEventData.transactions.length} transactions`,
-            );
-          }
-
-          const text = _text.filter((t) => t !== undefined).join(" and ");
-          args.common.logger.info({
-            service: "realtime",
-            msg: `Synced ${text} from '${args.chain.name}' block ${hexToNumber(block.number)}`,
-          });
-        } else {
-          args.common.logger.info({
-            service: "realtime",
-            msg: `Synced block ${hexToNumber(block.number)} from '${args.chain.name}' `,
-          });
-        }
-
-        unfinalizedBlocks.push(syncBlockToLightBlock(block));
-
-        // Make sure `transactions` can be garbage collected
-        blockWithEventData.block.transactions =
-          blockWithFilteredEventData.block.transactions;
-
-        const blockPromise = args.onEvent({
-          type: "block",
-          hasMatchedFilter: blockWithFilteredEventData.matchedFilters.size > 0,
-          block: blockWithFilteredEventData.block,
-          logs: blockWithFilteredEventData.logs,
-          transactions: blockWithFilteredEventData.transactions,
-          transactionReceipts: blockWithFilteredEventData.transactionReceipts,
-          traces: blockWithFilteredEventData.traces,
-          childAddresses: blockWithFilteredEventData.childAddresses,
+        args.common.logger.info({
+          service: "realtime",
+          msg: `Fetched ${missingBlockRange.length} missing '${
+            args.chain.name
+          }' blocks [${hexToNumber(latestBlock.number) + 1}, ${Math.min(
+            hexToNumber(block.number),
+            hexToNumber(latestBlock.number) + MAX_QUEUED_BLOCKS,
+          )}]`,
         });
 
-        // Determine if a new range has become finalized by evaluating if the
-        // latest block number is 2 * finalityBlockCount >= finalized block number.
-        // Essentially, there is a range the width of finalityBlockCount that is entirely
-        // finalized.
-
-        let finalizePromise: Promise<{ promise: Promise<void> }> | undefined;
-        const blockMovesFinality =
-          hexToNumber(block.number) >=
-          hexToNumber(finalizedBlock.number) +
-            2 * args.chain.finalityBlockCount;
-        if (blockMovesFinality) {
-          const pendingFinalizedBlock = unfinalizedBlocks.find(
-            (lb) =>
-              hexToNumber(lb.number) ===
-              hexToNumber(block.number) - args.chain.finalityBlockCount,
-          )!;
-
-          args.common.logger.debug({
-            service: "realtime",
-            msg: `Finalized ${hexToNumber(pendingFinalizedBlock.number) - hexToNumber(finalizedBlock.number) + 1} '${
-              args.chain.name
-            }' blocks [${hexToNumber(finalizedBlock.number) + 1}, ${hexToNumber(pendingFinalizedBlock.number)}]`,
-          });
-
-          const finalizedBlocks = unfinalizedBlocks.filter(
-            (lb) =>
-              hexToNumber(lb.number) <=
-              hexToNumber(pendingFinalizedBlock.number),
-          );
-
-          unfinalizedBlocks = unfinalizedBlocks.filter(
-            (lb) =>
-              hexToNumber(lb.number) >
-              hexToNumber(pendingFinalizedBlock.number),
-          );
-
-          for (const block of finalizedBlocks) {
-            childAddressesPerBlock.delete(hexToNumber(block.number));
+        for (const pendingBlock of pendingBlocks) {
+          for await (const event of reconcileBlock(pendingBlock)) {
+            yield event;
           }
-
-          finalizedBlock = pendingFinalizedBlock;
-
-          finalizePromise = args.onEvent({
-            type: "finalize",
-            block: pendingFinalizedBlock,
-          });
         }
 
-        // Reset the error state after successfully completing the happy path.
-        reconcileBlockErrorCount = 0;
+        for await (const event of reconcileBlock(blockWithEventData)) {
+          yield event;
+        }
+        return;
+      }
 
-        // Note: awaiting `indexedPromise` ensures that blocks are indexed immediately,
-        // handling backpressure during the realtime "catchup" phase.
-        const indexedPromise = blockPromise.then((result) => result.promise);
-        await indexedPromise;
+      // Check if a reorg occurred by validating the chain of block hashes.
+      if (block.parentHash !== latestBlock.hash) {
+        const reorgEvent = await reconcileReorg(block);
 
-        return {
-          type: "accepted",
-          blockPromise: indexedPromise,
-          finalizePromise: finalizePromise?.then((result) => result.promise),
-        };
-      } catch (_error) {
-        const error = _error as Error;
+        yield reorgEvent;
+        return;
+      }
 
-        if (args.common.shutdown.isKilled) {
-          throw new ShutdownError();
+      // New block is exactly one block ahead of the local chain.
+      // Attempt to ingest it.
+
+      const blockWithFilteredEventData =
+        filterBlockEventData(blockWithEventData);
+
+      if (
+        blockWithFilteredEventData.logs.length > 0 ||
+        blockWithFilteredEventData.traces.length > 0 ||
+        blockWithFilteredEventData.transactions.length > 0
+      ) {
+        const _text: string[] = [];
+
+        if (blockWithFilteredEventData.logs.length === 1) {
+          _text.push("1 log");
+        } else if (blockWithFilteredEventData.logs.length > 1) {
+          _text.push(`${blockWithFilteredEventData.logs.length} logs`);
         }
 
-        args.common.logger.warn({
+        if (blockWithFilteredEventData.traces.length === 1) {
+          _text.push("1 trace");
+        } else if (blockWithFilteredEventData.traces.length > 1) {
+          _text.push(`${blockWithFilteredEventData.traces.length} traces`);
+        }
+
+        if (blockWithFilteredEventData.transactions.length === 1) {
+          _text.push("1 transaction");
+        } else if (blockWithFilteredEventData.transactions.length > 1) {
+          _text.push(
+            `${blockWithFilteredEventData.transactions.length} transactions`,
+          );
+        }
+
+        const text = _text.filter((t) => t !== undefined).join(" and ");
+        args.common.logger.info({
           service: "realtime",
-          msg: `Failed to process '${args.chain.name}' block ${hexToNumber(block.number)}`,
+          msg: `Synced ${text} from '${args.chain.name}' block ${hexToNumber(block.number)}`,
+        });
+      } else {
+        args.common.logger.info({
+          service: "realtime",
+          msg: `Synced block ${hexToNumber(block.number)} from '${args.chain.name}' `,
+        });
+      }
+
+      unfinalizedBlocks.push(syncBlockToLightBlock(block));
+
+      // Make sure `transactions` can be garbage collected
+      blockWithEventData.block.transactions =
+        blockWithFilteredEventData.block.transactions;
+
+      yield {
+        type: "block",
+        hasMatchedFilter: blockWithFilteredEventData.matchedFilters.size > 0,
+        block: blockWithFilteredEventData.block,
+        logs: blockWithFilteredEventData.logs,
+        transactions: blockWithFilteredEventData.transactions,
+        transactionReceipts: blockWithFilteredEventData.transactionReceipts,
+        traces: blockWithFilteredEventData.traces,
+        childAddresses: blockWithFilteredEventData.childAddresses,
+      };
+
+      // Determine if a new range has become finalized by evaluating if the
+      // latest block number is 2 * finalityBlockCount >= finalized block number.
+      // Essentially, there is a range the width of finalityBlockCount that is entirely
+      // finalized.
+
+      const blockMovesFinality =
+        hexToNumber(block.number) >=
+        hexToNumber(finalizedBlock.number) + 2 * args.chain.finalityBlockCount;
+      if (blockMovesFinality) {
+        const pendingFinalizedBlock = unfinalizedBlocks.find(
+          (lb) =>
+            hexToNumber(lb.number) ===
+            hexToNumber(block.number) - args.chain.finalityBlockCount,
+        )!;
+
+        args.common.logger.debug({
+          service: "realtime",
+          msg: `Finalized ${hexToNumber(pendingFinalizedBlock.number) - hexToNumber(finalizedBlock.number) + 1} '${
+            args.chain.name
+          }' blocks [${hexToNumber(finalizedBlock.number) + 1}, ${hexToNumber(pendingFinalizedBlock.number)}]`,
+        });
+
+        const finalizedBlocks = unfinalizedBlocks.filter(
+          (lb) =>
+            hexToNumber(lb.number) <= hexToNumber(pendingFinalizedBlock.number),
+        );
+
+        unfinalizedBlocks = unfinalizedBlocks.filter(
+          (lb) =>
+            hexToNumber(lb.number) > hexToNumber(pendingFinalizedBlock.number),
+        );
+
+        for (const block of finalizedBlocks) {
+          childAddressesPerBlock.delete(hexToNumber(block.number));
+        }
+
+        finalizedBlock = pendingFinalizedBlock;
+
+        yield {
+          type: "finalize",
+          block: pendingFinalizedBlock,
+        };
+      }
+
+      // Reset the error state after successfully completing the happy path.
+      reconcileBlockErrorCount = 0;
+    } catch (_error) {
+      const error = _error as Error;
+
+      if (args.common.shutdown.isKilled) {
+        throw new ShutdownError();
+      }
+
+      args.common.logger.warn({
+        service: "realtime",
+        msg: `Failed to process '${args.chain.name}' block ${hexToNumber(block.number)}`,
+        error,
+      });
+
+      const duration = ERROR_TIMEOUT[reconcileBlockErrorCount]!;
+
+      args.common.logger.warn({
+        service: "realtime",
+        msg: `Retrying '${args.chain.name}' sync after ${duration} ${
+          duration === 1 ? "second" : "seconds"
+        }.`,
+      });
+
+      await wait(duration * 1_000);
+
+      reconcileBlockErrorCount += 1;
+
+      // After a certain number of attempts, emit a fatal error.
+      if (reconcileBlockErrorCount === ERROR_TIMEOUT.length) {
+        args.common.logger.error({
+          service: "realtime",
+          msg: `Fatal error: Unable to process '${args.chain.name}' block ${hexToNumber(block.number)} after ${ERROR_TIMEOUT.length} attempts.`,
           error,
         });
 
-        const duration = ERROR_TIMEOUT[reconcileBlockErrorCount]!;
-
-        args.common.logger.warn({
-          service: "realtime",
-          msg: `Retrying '${args.chain.name}' sync after ${duration} ${
-            duration === 1 ? "second" : "seconds"
-          }.`,
-        });
-
-        await wait(duration * 1_000);
-
-        // Remove all blocks from the queue. This protects against an
-        // erroneous block causing a fatal error.
-        reconcileBlock.clear(({ resolve }) => resolve({ type: "rejected" }));
-
-        reconcileBlockErrorCount += 1;
-
-        // After a certain number of attempts, emit a fatal error.
-        if (reconcileBlockErrorCount === ERROR_TIMEOUT.length) {
-          args.common.logger.error({
-            service: "realtime",
-            msg: `Fatal error: Unable to process '${args.chain.name}' block ${hexToNumber(block.number)} after ${ERROR_TIMEOUT.length} attempts.`,
-            error,
-          });
-
-          args.onFatalError(error);
-        }
-
-        return { type: "rejected" };
+        args.onFatalError(error);
       }
-    },
-  );
+    }
+  };
 
   const onError = (error: Error) => {
     if (args.common.shutdown.isKilled) {
@@ -1134,15 +1037,42 @@ export const createRealtimeSync = (
   };
 
   return {
-    sync(block) {
-      return fetchAndReconcileLatestBlock(block);
+    async *sync(block) {
+      try {
+        args.common.logger.debug({
+          service: "realtime",
+          msg: `Received latest '${args.chain.name}' block ${hexToNumber(block.number)}`,
+        });
+
+        const latestBlock = getLatestUnfinalizedBlock();
+
+        // We already saw and handled this block. No-op.
+        if (latestBlock.hash === block.hash) {
+          args.common.logger.trace({
+            service: "realtime",
+            msg: `Skipped processing '${args.chain.name}' block ${hexToNumber(block.number)}, already synced`,
+          });
+
+          return;
+        }
+
+        const blockWithEventData = await fetchBlockEventData(block);
+
+        fetchAndReconcileLatestBlockErrorCount = 0;
+
+        // Note: `reconcileBlock` must be called serially.
+
+        for await (const event of reconcileBlock(blockWithEventData)) {
+          yield event;
+        }
+        return;
+      } catch (_error) {
+        onError(_error as Error);
+      }
     },
     onError,
     get unfinalizedBlocks() {
       return unfinalizedBlocks;
-    },
-    get childAddresses() {
-      return childAddresses;
     },
   };
 };

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -843,14 +843,9 @@ export const createRealtimeSync = (
         });
 
         for (const pendingBlock of pendingBlocks) {
-          for await (const event of reconcileBlock(pendingBlock)) {
-            yield event;
-          }
+          yield* reconcileBlock(pendingBlock);
         }
-
-        for await (const event of reconcileBlock(blockWithEventData)) {
-          yield event;
-        }
+        yield* reconcileBlock(blockWithEventData);
         return;
       }
 
@@ -1067,9 +1062,7 @@ export const createRealtimeSync = (
 
         await realtimeSyncLock.lock();
 
-        for await (const event of reconcileBlock(blockWithEventData)) {
-          yield event;
-        }
+        yield* reconcileBlock(blockWithEventData);
 
         realtimeSyncLock.unlock();
       } catch (_error) {

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -59,7 +59,7 @@ export type RealtimeSync = {
    */
   sync(
     block: SyncBlock | SyncBlockHeader,
-    callback: (isAccepted: boolean) => void,
+    callback?: (isAccepted: boolean) => void,
   ): AsyncGenerator<RealtimeSyncEvent>;
   onError(error: Error): void;
   /** Local chain of blocks that have not been finalized. */
@@ -1061,7 +1061,7 @@ export const createRealtimeSync = (
             service: "realtime",
             msg: `Skipped processing '${args.chain.name}' block ${hexToNumber(block.number)}, already synced`,
           });
-          callback(false);
+          callback?.(false);
 
           return;
         }
@@ -1079,7 +1079,7 @@ export const createRealtimeSync = (
         realtimeSyncLock.unlock();
       } catch (_error) {
         onError(_error as Error);
-        callback(false);
+        callback?.(false);
       }
     },
     onError,

--- a/packages/core/src/sync/index.test.ts
+++ b/packages/core/src/sync/index.test.ts
@@ -1464,6 +1464,7 @@ test("getRealtimeEvents() kills realtime when finalized", async (context) => {
     }
   }
 
+  expect(checkpoint!).toBeDefined();
   expect(decodeCheckpoint(checkpoint!).blockNumber).toBe(1n);
 });
 

--- a/packages/core/src/sync/index.test.ts
+++ b/packages/core/src/sync/index.test.ts
@@ -1118,7 +1118,6 @@ test("createSync()", async (context) => {
       ],
     },
     syncStore,
-    onRealtimeEvent: async () => {},
     onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
@@ -1127,7 +1126,7 @@ test("createSync()", async (context) => {
   expect(sync).toBeDefined();
 });
 
-test("getEvents() multichain", async (context) => {
+test("getHistoricalEvents() multichain", async (context) => {
   const { syncStore } = await setupDatabaseServices(context);
 
   const chain = getChain();
@@ -1154,18 +1153,17 @@ test("getEvents() multichain", async (context) => {
         await _eth_getBlockByNumber(rpcs[0]!, { blockNumber: 1 }),
       ],
     },
-    onRealtimeEvent: async () => {},
     onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
-  const events = await drainAsyncGenerator(sync.getEvents());
+  const events = await drainAsyncGenerator(sync.getHistoricalEvents());
   expect(events.flatMap(({ events }) => events)).toHaveLength(2);
   expect(events.flatMap(({ checkpoints }) => checkpoints)).toHaveLength(1);
 });
 
-test("getEvents() omnichain", async (context) => {
+test("getHistoricalEvents() omnichain", async (context) => {
   const { syncStore } = await setupDatabaseServices(context);
 
   const chain = getChain();
@@ -1192,18 +1190,17 @@ test("getEvents() omnichain", async (context) => {
         await _eth_getBlockByNumber(rpcs[0]!, { blockNumber: 1 }),
       ],
     },
-    onRealtimeEvent: async () => {},
     onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "omnichain",
   });
 
-  const events = await drainAsyncGenerator(sync.getEvents());
+  const events = await drainAsyncGenerator(sync.getHistoricalEvents());
   expect(events.flatMap(({ events }) => events)).toHaveLength(2);
   expect(events.flatMap(({ checkpoints }) => checkpoints)).toHaveLength(1);
 });
 
-test("getEvents() with crash recovery checkpoint", async (context) => {
+test("getHistoricalEvents() with crash recovery checkpoint", async (context) => {
   const { syncStore } = await setupDatabaseServices(context);
   const chain = getChain();
 
@@ -1230,7 +1227,6 @@ test("getEvents() with crash recovery checkpoint", async (context) => {
         await _eth_getBlockByNumber(rpcs[0]!, { blockNumber: 2 }),
       ],
     },
-    onRealtimeEvent: async () => {},
     onFatalError: () => {},
     crashRecoveryCheckpoint: [
       { chainId: 1, checkpoint: MAX_CHECKPOINT_STRING },
@@ -1238,7 +1234,7 @@ test("getEvents() with crash recovery checkpoint", async (context) => {
     ordering: "multichain",
   });
 
-  const events = await drainAsyncGenerator(sync.getEvents());
+  const events = await drainAsyncGenerator(sync.getHistoricalEvents());
   expect(events.flatMap(({ events }) => events)).toHaveLength(0);
 });
 
@@ -1272,18 +1268,17 @@ test.skip("startRealtime()", async (context) => {
         await _eth_getBlockByNumber(rpcs[0]!, { blockNumber: 0 }),
       ],
     },
-    onRealtimeEvent: async () => {},
     onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
-  await drainAsyncGenerator(sync.getEvents());
+  await drainAsyncGenerator(sync.getHistoricalEvents());
 
-  await sync.startRealtime();
+  sync.getRealtimeEvents();
 });
 
-test("onEvent() multichain handles block", async (context) => {
+test("getRealtimeEvents() multichain handles block", async (context) => {
   const { syncStore } = await setupDatabaseServices(context);
 
   const chain = getChain();
@@ -1296,9 +1291,6 @@ test("onEvent() multichain handles block", async (context) => {
     config,
     rawIndexingFunctions,
   });
-
-  const promise = promiseWithResolvers<void>();
-  const events: Event[] = [];
 
   await testClient.mine({ blocks: 1 });
 
@@ -1313,27 +1305,24 @@ test("onEvent() multichain handles block", async (context) => {
         await _eth_getBlockByNumber(rpcs[0]!, { blockNumber: 0 }),
       ],
     },
-    onRealtimeEvent: async (event) => {
-      if (event.type === "block") {
-        events.push(...event.events);
-        promise.resolve();
-      }
-    },
     onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
-  await drainAsyncGenerator(sync.getEvents());
+  await drainAsyncGenerator(sync.getHistoricalEvents());
 
-  await sync.startRealtime();
+  const syncResult = sync.getRealtimeEvents();
 
-  await promise.promise;
-
-  expect(events).toHaveLength(1);
+  for await (const event of syncResult) {
+    if (event.type === "block") {
+      expect(event.events).toHaveLength(1);
+      break;
+    }
+  }
 });
 
-test("onEvent() omnichain handles block", async (context) => {
+test("getRealtimeEvents() omnichain handles block", async (context) => {
   const { syncStore } = await setupDatabaseServices(context);
 
   const { config, rawIndexingFunctions } = getBlocksConfigAndIndexingFunctions({
@@ -1344,8 +1333,6 @@ test("onEvent() omnichain handles block", async (context) => {
     config,
     rawIndexingFunctions,
   });
-
-  const promise = promiseWithResolvers<void>();
 
   const sync = await createSync({
     common: context.common,
@@ -1358,11 +1345,6 @@ test("onEvent() omnichain handles block", async (context) => {
       ],
     },
     syncStore,
-    onRealtimeEvent: async (event) => {
-      if (event.type === "block") {
-        promise.resolve();
-      }
-    },
     onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "omnichain",
@@ -1370,14 +1352,19 @@ test("onEvent() omnichain handles block", async (context) => {
 
   await testClient.mine({ blocks: 1 });
 
-  await drainAsyncGenerator(sync.getEvents());
+  await drainAsyncGenerator(sync.getHistoricalEvents());
 
-  await sync.startRealtime();
+  const syncResult = sync.getRealtimeEvents();
 
-  await promise.promise;
+  for await (const event of syncResult) {
+    if (event.type === "block") {
+      expect(event.events).toHaveLength(1);
+      break;
+    }
+  }
 });
 
-test("onEvent() handles finalize", async (context) => {
+test("getRealtimeEvents() handles finalize", async (context) => {
   const { syncStore } = await setupDatabaseServices(context);
 
   const chain = getChain();
@@ -1390,9 +1377,6 @@ test("onEvent() handles finalize", async (context) => {
     config,
     rawIndexingFunctions,
   });
-
-  const promise = promiseWithResolvers<void>();
-  let checkpoint: string;
 
   chain.finalityBlockCount = 2;
 
@@ -1407,12 +1391,6 @@ test("onEvent() handles finalize", async (context) => {
         await _eth_getBlockByNumber(rpcs[0]!, { blockNumber: 0 }),
       ],
     },
-    onRealtimeEvent: async (event) => {
-      if (event.type === "finalize") {
-        checkpoint = event.checkpoint;
-        promise.resolve();
-      }
-    },
     onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
@@ -1420,16 +1398,23 @@ test("onEvent() handles finalize", async (context) => {
 
   await testClient.mine({ blocks: 4 });
 
-  await drainAsyncGenerator(sync.getEvents());
+  await drainAsyncGenerator(sync.getHistoricalEvents());
 
-  await sync.startRealtime();
+  const syncResult = sync.getRealtimeEvents();
 
-  await promise.promise;
+  let checkpoint: string;
+
+  for await (const event of syncResult) {
+    if (event.type === "finalize") {
+      checkpoint = event.checkpoint;
+      break;
+    }
+  }
 
   expect(decodeCheckpoint(checkpoint!).blockNumber).toBe(2n);
 });
 
-test("onEvent() kills realtime when finalized", async (context) => {
+test("getRealtimeEvents() kills realtime when finalized", async (context) => {
   const { syncStore } = await setupDatabaseServices(context);
 
   const chain = getChain();
@@ -1447,9 +1432,6 @@ test("onEvent() kills realtime when finalized", async (context) => {
     rawIndexingFunctions,
   });
 
-  const promise = promiseWithResolvers<void>();
-  let checkpoint: string;
-
   chain.finalityBlockCount = 0;
 
   const sync = await createSync({
@@ -1463,12 +1445,6 @@ test("onEvent() kills realtime when finalized", async (context) => {
         await _eth_getBlockByNumber(rpcs[0]!, { blockNumber: 0 }),
       ],
     },
-    onRealtimeEvent: async (event) => {
-      if (event.type === "finalize") {
-        checkpoint = event.checkpoint;
-        promise.resolve();
-      }
-    },
     onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
@@ -1476,18 +1452,24 @@ test("onEvent() kills realtime when finalized", async (context) => {
 
   await testClient.mine({ blocks: 4 });
 
-  await drainAsyncGenerator(sync.getEvents());
+  await drainAsyncGenerator(sync.getHistoricalEvents());
 
-  await sync.startRealtime();
+  const syncResult = sync.getRealtimeEvents();
 
-  await promise.promise;
+  let checkpoint: string;
+  for await (const event of syncResult) {
+    if (event.type === "finalize") {
+      checkpoint = event.checkpoint;
+      break;
+    }
+  }
 
   expect(decodeCheckpoint(checkpoint!).blockNumber).toBe(1n);
 });
 
 test.todo("onEvent() handles reorg");
 
-test("onEvent() handles errors", async (context) => {
+test("getRealtimeEvents() handles errors", async (context) => {
   const { syncStore } = await setupDatabaseServices(context);
 
   const chain = getChain();
@@ -1501,8 +1483,6 @@ test("onEvent() handles errors", async (context) => {
     rawIndexingFunctions,
   });
 
-  const promise = promiseWithResolvers<void>();
-
   const sync = await createSync({
     syncStore,
     common: context.common,
@@ -1514,24 +1494,21 @@ test("onEvent() handles errors", async (context) => {
         await _eth_getBlockByNumber(rpcs[0]!, { blockNumber: 0 }),
       ],
     },
-    onRealtimeEvent: async () => {},
-    onFatalError: () => {
-      promise.resolve();
-    },
+    onFatalError: () => {},
     crashRecoveryCheckpoint: undefined,
     ordering: "multichain",
   });
 
   await testClient.mine({ blocks: 4 });
 
-  await drainAsyncGenerator(sync.getEvents());
+  await drainAsyncGenerator(sync.getHistoricalEvents());
 
   const spy = vi.spyOn(syncStore, "insertTransactions");
   spy.mockRejectedValue(new Error());
 
-  await sync.startRealtime();
+  const syncResult = sync.getRealtimeEvents();
 
-  await promise.promise;
+  await expect(() => drainAsyncGenerator(syncResult)).rejects.toThrow();
 });
 
 test("historical events match realtime events", async (context) => {

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -81,7 +81,7 @@ export type RealtimeEvent =
       events: Event[];
       chain: Chain;
       checkpoint: string;
-      callback?: (isAccepted: boolean) => void;
+      blockCallback?: (isAccepted: boolean) => void;
     }
   | {
       type: "reorg";
@@ -732,7 +732,7 @@ export const createSync = async (params: {
             events: readyEvents,
             chain,
             checkpoint,
-            callback: event.callback,
+            blockCallback: event.blockCallback,
           };
         } else {
           const checkpoint = getOmnichainCheckpoint({ tag: "current" });
@@ -756,7 +756,7 @@ export const createSync = async (params: {
             events: readyEvents,
             chain,
             checkpoint,
-            callback: event.callback,
+            blockCallback: event.blockCallback,
           };
         }
       }

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -38,6 +38,7 @@ import {
 import { formatPercentage } from "@/utils/format.js";
 import {
   bufferAsyncGenerator,
+  createCallbackGenerator,
   mapAsyncGenerator,
   mergeAsyncGenerators,
 } from "@/utils/generators.js";
@@ -50,10 +51,7 @@ import {
   sortIntervals,
 } from "@/utils/interval.js";
 import { intervalUnion } from "@/utils/interval.js";
-import { createMutex } from "@/utils/mutex.js";
-import { never } from "@/utils/never.js";
 import { partition } from "@/utils/partition.js";
-import { promiseWithResolvers } from "@/utils/promiseWithResolvers.js";
 import { _eth_getBlockByNumber } from "@/utils/rpc.js";
 import { startClock } from "@/utils/timer.js";
 import { zipperMany } from "@/utils/zipper.js";
@@ -71,8 +69,8 @@ import { isAddressFactory } from "./filter.js";
 import { initGenerator, initSyncProgress } from "./init.js";
 
 export type Sync = {
-  getEvents(): EventGenerator;
-  startRealtime(): Promise<void>;
+  getHistoricalEvents(): EventGenerator;
+  getRealtimeEvents(): AsyncGenerator<RealtimeEvent>;
   getStartCheckpoint(chain: Chain): string;
   seconds: Seconds;
 };
@@ -80,13 +78,9 @@ export type Sync = {
 export type RealtimeEvent =
   | {
       type: "block";
-      chain: Chain;
       events: Event[];
-      /**
-       * Closest-to-tip checkpoint for each chain,
-       * excluding chains that were not updated with this event.
-       */
-      checkpoints: { chainId: number; checkpoint: string }[];
+      chain: Chain;
+      checkpoint: string;
     }
   | {
       type: "reorg";
@@ -246,7 +240,6 @@ export const createSync = async (params: {
     "sources" | "chains" | "rpcs" | "finalizedBlocks"
   >;
   syncStore: SyncStore;
-  onRealtimeEvent(event: RealtimeEvent): Promise<void>;
   onFatalError(error: Error): void;
   crashRecoveryCheckpoint: CrashRecoveryCheckpoint;
   ordering: "omnichain" | "multichain";
@@ -322,7 +315,7 @@ export const createSync = async (params: {
       : string;
   };
 
-  async function* getEvents() {
+  async function* getHistoricalEvents() {
     const to = min(
       getOmnichainCheckpoint({ tag: "finalized" }),
       getOmnichainCheckpoint({ tag: "end" }),
@@ -520,39 +513,165 @@ export const createSync = async (params: {
     }
   }
 
+  async function* getRealtimeEvents(): AsyncGenerator<RealtimeEvent> {
+    const eventGenerators = await Promise.all(
+      Array.from(perChainSync.entries()).map(async function* ([
+        chain,
+        { syncProgress, childAddresses },
+      ]) {
+        const rpc =
+          params.indexingBuild.rpcs[
+            params.indexingBuild.chains.indexOf(chain)
+          ]!;
+        const sources = params.indexingBuild.sources.filter(
+          ({ filter }) => filter.chainId === chain.id,
+        );
+        if (isSyncEnd(syncProgress)) {
+          params.common.metrics.ponder_sync_is_complete.set(
+            { chain: chain.name },
+            1,
+          );
+        } else {
+          params.common.metrics.ponder_sync_is_realtime.set(
+            { chain: chain.name },
+            1,
+          );
+
+          const perChainOnRealtimeSyncEvent = getPerChainOnRealtimeSyncEvent({
+            common: params.common,
+            chain,
+            sources,
+            syncStore: params.syncStore,
+            syncProgress,
+          });
+
+          const realtimeSync = createRealtimeSync({
+            common: params.common,
+            chain,
+            rpc,
+            sources,
+            syncProgress,
+            childAddresses,
+            onFatalError: params.onFatalError,
+          });
+
+          perChainSync.get(chain)!.realtimeSync = realtimeSync;
+
+          let childCount = 0;
+          for (const [, factoryChildAddresses] of childAddresses) {
+            childCount += factoryChildAddresses.size;
+          }
+
+          params.common.logger.debug({
+            service: "sync",
+            msg: `Initialized '${chain.name}' realtime sync with ${childCount} factory child addresses`,
+          });
+
+          const { callback, generator } = createCallbackGenerator<
+            SyncBlock | SyncBlockHeader,
+            boolean
+          >();
+
+          rpc.subscribe({ onBlock: callback, onError: realtimeSync.onError });
+
+          for await (const { value: block, onComplete } of generator) {
+            const arrivalMs = Date.now();
+
+            const endClock = startClock();
+
+            const generator = realtimeSync.sync(block);
+
+            let isAccepted = false;
+            for await (const event of generator) {
+              if (event.type === "block") {
+                isAccepted = true;
+              }
+              await perChainOnRealtimeSyncEvent(event);
+
+              if (isSyncFinalized(syncProgress) && isSyncEnd(syncProgress)) {
+                // The realtime service can be killed if `endBlock` is
+                // defined has become finalized.
+
+                params.common.metrics.ponder_sync_is_realtime.set(
+                  { chain: chain.name },
+                  0,
+                );
+                params.common.metrics.ponder_sync_is_complete.set(
+                  { chain: chain.name },
+                  1,
+                );
+                params.common.logger.info({
+                  service: "sync",
+                  msg: `Killing '${chain.name}' live indexing because the end block ${hexToNumber(syncProgress.end!.number)} has been finalized`,
+                });
+                rpc.unsubscribe();
+              }
+
+              yield { chain, event };
+            }
+
+            if (isAccepted) {
+              params.common.metrics.ponder_realtime_block_arrival_latency.observe(
+                { chain: chain.name },
+                arrivalMs - hexToNumber(block.timestamp) * 1_000,
+              );
+
+              params.common.metrics.ponder_realtime_latency.observe(
+                { chain: chain.name },
+                endClock(),
+              );
+            }
+
+            onComplete(isAccepted);
+          }
+        }
+      }),
+    );
+
+    for await (const { chain, event } of mergeAsyncGeneratorsWithRealtimeOrder(
+      eventGenerators,
+      params.ordering,
+    )) {
+      const { syncProgress, childAddresses } = perChainSync.get(chain)!;
+
+      const sources = params.indexingBuild.sources.filter(
+        ({ filter }) => filter.chainId === chain.id,
+      );
+
+      const result = onRealtimeSyncEvent(event, {
+        chain,
+        sources,
+        syncProgress,
+        childAddresses,
+      });
+
+      if (result === undefined) {
+        continue;
+      }
+
+      yield result;
+    }
+  }
+
   /** Events that have been executed but not finalized. */
   let executedEvents: Event[] = [];
   /** Events that have not been executed. */
   let pendingEvents: Event[] = [];
 
-  const realtimeMutex = createMutex();
-
-  const checkpoints = {
-    // Note: `checkpoints.current` not used in multichain ordering
-    current: ZERO_CHECKPOINT_STRING,
-    finalized: ZERO_CHECKPOINT_STRING,
-  };
-
-  // Note: `omnichainCheckpointHooks` not used in multichain ordering
-  let omnichainHooks: {
-    checkpoint: string;
-    callback: () => void;
-  }[] = [];
-
-  const onRealtimeSyncEvent = async (
+  const onRealtimeSyncEvent = (
     event: RealtimeSyncEvent,
     {
       chain,
       sources,
-      syncProgress,
-      realtimeSync,
+      // syncProgress,
+      childAddresses,
     }: {
       chain: Chain;
       sources: Source[];
       syncProgress: SyncProgress;
-      realtimeSync: RealtimeSync;
+      childAddresses: Map<FactoryId, Map<Address, number>>;
     },
-  ): Promise<void> => {
+  ): RealtimeEvent | undefined => {
     switch (event.type) {
       case "block": {
         const events = buildEvents({
@@ -578,7 +697,7 @@ export const createSync = async (params: {
               }),
             ),
           },
-          childAddresses: realtimeSync.childAddresses,
+          childAddresses,
         });
 
         params.common.logger.debug({
@@ -593,7 +712,6 @@ export const createSync = async (params: {
         });
 
         if (params.ordering === "multichain") {
-          // Note: `checkpoints.current` not used in multichain ordering
           const checkpoint = getMultichainCheckpoint({ tag: "current", chain });
 
           const readyEvents = decodedEvents
@@ -607,120 +725,63 @@ export const createSync = async (params: {
             msg: `Sequenced ${readyEvents.length} '${chain.name}' events for block ${hexToNumber(event.block.number)}`,
           });
 
-          await params.onRealtimeEvent({
+          return {
             type: "block",
-            chain,
             events: readyEvents,
-            checkpoints: [{ chainId: chain.id, checkpoint }],
-          });
+            chain,
+            checkpoint,
+          };
         } else {
-          const from = checkpoints.current;
-          checkpoints.current = getOmnichainCheckpoint({ tag: "current" });
-          const to = getOmnichainCheckpoint({ tag: "current" });
+          const checkpoint = getOmnichainCheckpoint({ tag: "current" });
 
-          const pwr = promiseWithResolvers<void>();
-          omnichainHooks.push({
-            checkpoint: encodeCheckpoint(
-              blockToCheckpoint(event.block, chain.id, "down"),
-            ),
-            callback: () => pwr.resolve(),
+          const readyEvents = pendingEvents
+            .concat(decodedEvents)
+            .filter((e) => e.checkpoint < checkpoint)
+            .sort((a, b) => (a.checkpoint < b.checkpoint ? -1 : 1));
+          pendingEvents = pendingEvents
+            .concat(decodedEvents)
+            .filter((e) => e.checkpoint > checkpoint);
+          executedEvents = executedEvents.concat(readyEvents);
+
+          params.common.logger.debug({
+            service: "sync",
+            msg: `Sequenced ${readyEvents.length} events`,
           });
 
-          if (to > from) {
-            // Move ready events from pending to executed
-
-            const readyEvents = pendingEvents
-              .concat(decodedEvents)
-              .filter(({ checkpoint }) => checkpoint < to)
-              .sort((a, b) => (a.checkpoint < b.checkpoint ? -1 : 1));
-            pendingEvents = pendingEvents
-              .concat(decodedEvents)
-              .filter(({ checkpoint }) => checkpoint > to);
-            executedEvents = executedEvents.concat(readyEvents);
-
-            params.common.logger.debug({
-              service: "sync",
-              msg: `Sequenced ${readyEvents.length} events`,
-            });
-
-            const checkpoints: { chainId: number; checkpoint: string }[] = [];
-            for (const chain of params.indexingBuild.chains) {
-              const localBlock = perChainSync
-                .get(chain)!
-                .realtimeSync!.unfinalizedBlocks.findLast((block) => {
-                  const checkpoint = encodeCheckpoint(
-                    blockToCheckpoint(block, chain.id, "up"),
-                  );
-                  return checkpoint > from && checkpoint <= to;
-                });
-
-              if (localBlock) {
-                const checkpoint = encodeCheckpoint(
-                  blockToCheckpoint(localBlock, chain.id, "up"),
-                );
-
-                checkpoints.push({ chainId: chain.id, checkpoint });
-              }
-            }
-
-            await params.onRealtimeEvent({
-              type: "block",
-              events: readyEvents,
-              chain,
-              checkpoints,
-            });
-
-            const completedHooks = omnichainHooks.filter(
-              ({ checkpoint }) => checkpoint > from && checkpoint <= to,
-            );
-            omnichainHooks = omnichainHooks.filter(
-              ({ checkpoint }) =>
-                (checkpoint > from && checkpoint <= to) === false,
-            );
-            for (const { callback } of completedHooks) {
-              callback();
-            }
-          } else {
-            pendingEvents = pendingEvents.concat(decodedEvents);
-          }
-
-          return pwr.promise;
+          return {
+            type: "block",
+            events: readyEvents,
+            chain,
+            checkpoint,
+          };
         }
-
-        break;
       }
 
       case "finalize": {
-        const from = checkpoints.finalized;
-        checkpoints.finalized = getOmnichainCheckpoint({ tag: "finalized" });
-        const to = getOmnichainCheckpoint({ tag: "finalized" });
+        const checkpoint = getOmnichainCheckpoint({ tag: "finalized" });
 
-        if (
-          params.ordering === "omnichain" &&
-          getChainCheckpoint({ syncProgress, chain, tag: "finalized" }) >
-            getOmnichainCheckpoint({ tag: "current" })
-        ) {
-          const chainId = Number(
-            decodeCheckpoint(getOmnichainCheckpoint({ tag: "current" }))
-              .chainId,
-          );
-          const chain = params.indexingBuild.chains.find(
-            (chain) => chain.id === chainId,
-          )!;
-          params.common.logger.warn({
-            service: "sync",
-            msg: `'${chain.name}' is lagging behind other chains`,
-          });
-        }
-
-        if (to <= from) {
-          break;
-        }
+        // if (
+        //   params.ordering === "omnichain" &&
+        //   getChainCheckpoint({ syncProgress, chain, tag: "finalized" }) >
+        //     getOmnichainCheckpoint({ tag: "current" })
+        // ) {
+        //   const chainId = Number(
+        //     decodeCheckpoint(getOmnichainCheckpoint({ tag: "current" }))
+        //       .chainId,
+        //   );
+        //   const chain = params.indexingBuild.chains.find(
+        //     (chain) => chain.id === chainId,
+        //   )!;
+        //   params.common.logger.warn({
+        //     service: "sync",
+        //     msg: `'${chain.name}' is lagging behind other chains`,
+        //   });
+        // }
 
         // index of the first unfinalized event
         let finalizeIndex: number | undefined = undefined;
         for (const [index, event] of executedEvents.entries()) {
-          if (event.checkpoint > to) {
+          if (event.checkpoint > checkpoint) {
             finalizeIndex = index;
             break;
           }
@@ -736,15 +797,12 @@ export const createSync = async (params: {
           executedEvents = executedEvents.slice(finalizeIndex);
         }
 
-        // Raise event to parent function (runtime)
-        params.onRealtimeEvent({ type: "finalize", chain, checkpoint: to });
-
         params.common.logger.debug({
           service: "sync",
           msg: `Finalized ${finalizedEvents.length} executed events`,
         });
 
-        break;
+        return { type: "finalize", chain, checkpoint };
       }
 
       case "reorg": {
@@ -759,7 +817,6 @@ export const createSync = async (params: {
         };
 
         if (params.ordering === "multichain") {
-          // Note: `checkpoints.current` not used in multichain ordering
           const checkpoint = getMultichainCheckpoint({ tag: "current", chain });
 
           // index of the first reorged event
@@ -772,7 +829,7 @@ export const createSync = async (params: {
           }
 
           if (reorgIndex === undefined) {
-            break;
+            return;
           }
 
           // Move events from executed to pending
@@ -786,24 +843,22 @@ export const createSync = async (params: {
             msg: `Rescheduled ${reorgedEvents.length} reorged events`,
           });
 
-          params.onRealtimeEvent({ type: "reorg", chain, checkpoint });
-
           pendingEvents = pendingEvents.filter(
             (e) => isReorgedEvent(e) === false,
           );
-        } else {
-          const from = checkpoints.current;
-          checkpoints.current = getOmnichainCheckpoint({ tag: "current" });
-          const to = getOmnichainCheckpoint({ tag: "current" });
 
-          if (to >= from) {
-            break;
-          }
+          return { type: "reorg", chain, checkpoint };
+        } else {
+          const checkpoint = getOmnichainCheckpoint({ tag: "current" });
 
           // Move events from executed to pending
 
-          const reorgedEvents = executedEvents.filter((e) => e.checkpoint > to);
-          executedEvents = executedEvents.filter((e) => e.checkpoint < to);
+          const reorgedEvents = executedEvents.filter(
+            (e) => e.checkpoint > checkpoint,
+          );
+          executedEvents = executedEvents.filter(
+            (e) => e.checkpoint < checkpoint,
+          );
           pendingEvents = pendingEvents.concat(reorgedEvents);
 
           params.common.logger.debug({
@@ -811,18 +866,13 @@ export const createSync = async (params: {
             msg: `Rescheduled ${reorgedEvents.length} reorged events`,
           });
 
-          params.onRealtimeEvent({ type: "reorg", chain, checkpoint: to });
-
           pendingEvents = pendingEvents.filter(
             (e) => isReorgedEvent(e) === false,
           );
+
+          return { type: "reorg", chain, checkpoint };
         }
-
-        break;
       }
-
-      default:
-        never(event);
     }
   };
 
@@ -986,133 +1036,8 @@ export const createSync = async (params: {
   }
 
   return {
-    getEvents,
-    async startRealtime() {
-      for (let index = 0; index < params.indexingBuild.chains.length; index++) {
-        const chain = params.indexingBuild.chains[index]!;
-        const rpc = params.indexingBuild.rpcs[index]!;
-
-        const { syncProgress, childAddresses } = perChainSync.get(chain)!;
-
-        const sources = params.indexingBuild.sources.filter(
-          ({ filter }) => filter.chainId === chain.id,
-        );
-
-        if (isSyncEnd(syncProgress)) {
-          params.common.metrics.ponder_sync_is_complete.set(
-            { chain: chain.name },
-            1,
-          );
-        } else {
-          params.common.metrics.ponder_sync_is_realtime.set(
-            { chain: chain.name },
-            1,
-          );
-
-          const initialChildAddresses = childAddresses;
-
-          const perChainOnRealtimeSyncEvent = getPerChainOnRealtimeSyncEvent({
-            common: params.common,
-            chain,
-            sources,
-            syncStore: params.syncStore,
-            syncProgress,
-          });
-
-          const realtimeSync = createRealtimeSync({
-            common: params.common,
-            chain,
-            rpc,
-            sources,
-            syncProgress,
-            initialChildAddresses,
-            onEvent: realtimeMutex(async (event) => {
-              try {
-                await perChainOnRealtimeSyncEvent(event);
-                // Note: `promise` resolves when the event is fully processed, however,
-                // awaiting it will cause a deadlock in "omnichain" ordering.
-                const promise = onRealtimeSyncEvent(event, {
-                  chain,
-                  sources,
-                  syncProgress,
-                  realtimeSync,
-                });
-
-                if (isSyncFinalized(syncProgress) && isSyncEnd(syncProgress)) {
-                  // The realtime service can be killed if `endBlock` is
-                  // defined has become finalized.
-
-                  params.common.metrics.ponder_sync_is_realtime.set(
-                    { chain: chain.name },
-                    0,
-                  );
-                  params.common.metrics.ponder_sync_is_complete.set(
-                    { chain: chain.name },
-                    1,
-                  );
-                  params.common.logger.info({
-                    service: "sync",
-                    msg: `Killing '${chain.name}' live indexing because the end block ${hexToNumber(syncProgress.end!.number)} has been finalized`,
-                  });
-                  rpc.unsubscribe();
-                }
-
-                return { promise };
-              } catch (error) {
-                params.common.logger.error({
-                  service: "sync",
-                  msg: `Fatal error: Unable to process ${event.type} event`,
-                  error: error as Error,
-                });
-                params.onFatalError(error as Error);
-                return { promise: Promise.resolve() };
-              }
-            }),
-            onFatalError: params.onFatalError,
-          });
-
-          perChainSync.get(chain)!.realtimeSync = realtimeSync;
-
-          let childCount = 0;
-          for (const [, childAddresses] of initialChildAddresses) {
-            childCount += childAddresses.size;
-          }
-
-          params.common.logger.debug({
-            service: "sync",
-            msg: `Initialized '${chain.name}' realtime sync with ${childCount} factory child addresses`,
-          });
-
-          rpc.subscribe({
-            onBlock: async (block) => {
-              const arrivalMs = Date.now();
-
-              const endClock = startClock();
-              const syncResult = await realtimeSync.sync(block);
-
-              if (syncResult.type === "accepted") {
-                syncResult.blockPromise.then(() => {
-                  params.common.metrics.ponder_realtime_block_arrival_latency.observe(
-                    { chain: chain.name },
-                    arrivalMs - hexToNumber(block.timestamp) * 1_000,
-                  );
-
-                  params.common.metrics.ponder_realtime_latency.observe(
-                    { chain: chain.name },
-                    endClock(),
-                  );
-                });
-              }
-
-              return syncResult;
-            },
-            onError: (error) => {
-              realtimeSync.onError(error);
-            },
-          });
-        }
-      }
-    },
+    getHistoricalEvents,
+    getRealtimeEvents,
     seconds,
     getStartCheckpoint(chain) {
       return getMultichainCheckpoint({ tag: "start", chain });
@@ -1124,14 +1049,14 @@ export const getPerChainOnRealtimeSyncEvent = ({
   common,
   chain,
   sources,
-  syncStore,
   syncProgress,
+  syncStore,
 }: {
   common: Common;
   chain: Chain;
   sources: Source[];
-  syncStore: SyncStore;
   syncProgress: SyncProgress;
+  syncStore: SyncStore;
 }) => {
   let unfinalizedBlocks: Omit<
     Extract<RealtimeSyncEvent, { type: "block" }>,
@@ -1843,6 +1768,64 @@ export async function* mergeAsyncGeneratorsWithEventOrder(
 
       yield { events, checkpoints };
     }
+    results[index] = await resultPromise;
+  }
+}
+
+export async function* mergeAsyncGeneratorsWithRealtimeOrder(
+  generators: AsyncGenerator<{ chain: Chain; event: RealtimeSyncEvent }>[],
+  ordering: "omnichain" | "multichain",
+): AsyncGenerator<{ chain: Chain; event: RealtimeSyncEvent }> {
+  if (ordering === "omnichain") {
+    return mergeAsyncGenerators(generators);
+  }
+
+  const results = await Promise.all(generators.map((gen) => gen.next()));
+
+  // const finalizeResults = new Array(generators.length).fill(undefined) as (
+  //   | IteratorResult<{
+  //       chain: Chain;
+  //       event: Extract<RealtimeSyncEvent, { type: "finalize" }>;
+  //     }>
+  //   | undefined
+  // )[];
+
+  // Note: It is an invariant that every initial result is a block event.
+
+  while (results.some((res) => res.done !== true)) {
+    for (const result of results) {
+      if (result.done && result.value.event.type === "finalize") {
+        // TODO(kyle) this is wrong
+        yield result.value;
+      } else if (result.done && result.value.event.type === "reorg") {
+        yield result.value;
+      }
+    }
+
+    const blockCheckpoints = results.map((result) =>
+      result.done
+        ? undefined
+        : encodeCheckpoint(
+            blockToCheckpoint(
+              result.value.event.block,
+              result.value.chain.id,
+              "up",
+            ),
+          ),
+    );
+
+    const supremum = min(...blockCheckpoints);
+
+    const index = blockCheckpoints.findIndex(
+      (checkpoint) => checkpoint === supremum,
+    );
+
+    const resultPromise = generators[index]!.next();
+
+    yield {
+      chain: results[index]!.value.chain,
+      event: results[index]!.value.event,
+    };
     results[index] = await resultPromise;
   }
 }

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -599,6 +599,8 @@ export const createSync = async (params: {
             for await (const event of generator) {
               await perChainOnRealtimeSyncEvent(event);
 
+              yield { chain, event };
+
               if (isSyncFinalized(syncProgress) && isSyncEnd(syncProgress)) {
                 // The realtime service can be killed if `endBlock` is
                 // defined has become finalized.
@@ -616,9 +618,8 @@ export const createSync = async (params: {
                   msg: `Killing '${chain.name}' live indexing because the end block ${hexToNumber(syncProgress.end!.number)} has been finalized`,
                 });
                 rpc.unsubscribe();
+                return;
               }
-
-              yield { chain, event };
             }
           }
         }

--- a/packages/core/src/utils/generators.test.ts
+++ b/packages/core/src/utils/generators.test.ts
@@ -1,6 +1,10 @@
 import { promiseWithResolvers } from "@/utils/promiseWithResolvers.js";
 import { expect, test } from "vitest";
-import { bufferAsyncGenerator, mergeAsyncGenerators } from "./generators.js";
+import {
+  bufferAsyncGenerator,
+  createCallbackGenerator,
+  mergeAsyncGenerators,
+} from "./generators.js";
 
 test("mergeAsyncGenerators()", async () => {
   const p1 = promiseWithResolvers<number>();
@@ -157,4 +161,21 @@ test("bufferAsyncGenerator() yields all results", async () => {
 
   result = await generator.next();
   expect(result.done).toBe(true);
+});
+
+test("createCallbackGenerator()", async () => {
+  const { callback, generator } = createCallbackGenerator<number, number>();
+
+  (async () => {
+    for (let i = 0; i < 5; i++) {
+      await callback(i);
+      await new Promise((res) => setTimeout(res, 1000));
+    }
+  })();
+
+  for await (const { value, onComplete } of generator) {
+    onComplete(value + 1);
+
+    if (value === 4) break;
+  }
 });

--- a/packages/core/src/utils/generators.ts
+++ b/packages/core/src/utils/generators.ts
@@ -137,6 +137,9 @@ export async function* recordAsyncGenerator<T>(
   }
 }
 
+/**
+ * Creates an async generator that yields values from a callback.
+ */
 export function createCallbackGenerator<T, P>(): {
   callback: (value: T) => Promise<P>;
   generator: AsyncGenerator<

--- a/packages/core/src/utils/generators.ts
+++ b/packages/core/src/utils/generators.ts
@@ -40,15 +40,15 @@ export async function* mergeAsyncGenerators<T>(
 /**
  * Maps the results of an async generator.
  *
- * @param generators - The generator to map.
+ * @param generator - The generator to map.
  * @param fn - The function to map the generator.
  * @returns An async generator that yields mapped results from the input generator.
  */
 export async function* mapAsyncGenerator<T, R>(
-  generators: AsyncGenerator<T>,
+  generator: AsyncGenerator<T>,
   fn: (value: T) => R,
 ): AsyncGenerator<R> {
-  for await (const value of generators) {
+  for await (const value of generator) {
     yield fn(value);
   }
 }
@@ -135,4 +135,37 @@ export async function* recordAsyncGenerator<T>(
     });
     endClockTotal = startClock();
   }
+}
+
+export function createCallbackGenerator<T, P>(): {
+  callback: (value: T) => Promise<P>;
+  generator: AsyncGenerator<
+    { value: T; onComplete: (value: P) => void },
+    void,
+    unknown
+  >;
+} {
+  const buffer: { value: T; onComplete: (value: P) => void }[] = [];
+  let pwr = promiseWithResolvers<void>();
+
+  const callback = async (value: T) => {
+    const { resolve, promise } = promiseWithResolvers<P>();
+    buffer.push({ value, onComplete: resolve });
+    pwr.resolve();
+    return promise;
+  };
+
+  async function* generator() {
+    while (true) {
+      if (buffer.length > 0) {
+        const { value, onComplete } = buffer.shift()!;
+        yield { value, onComplete };
+      } else {
+        await pwr.promise;
+        pwr = promiseWithResolvers<void>();
+      }
+    }
+  }
+
+  return { callback, generator: generator() };
 }


### PR DESCRIPTION
Update several functions in the realtime sync pipeline to use async generators rather than callbacks.

```ts
type Sync = {
  // ... other properties (including "getHistoricalEvents")
  getRealtimeEvents: () => AsyncGenerator<RealtimeEvent>;
}

type SyncRealtime = {
  // ... other properties
  sync: () => AsyncGenerator<RealtimeSyncEvent>;
}
```