### PR TITLE
feat: typecheck empty `onchainTable` name

### DIFF
--- a/packages/core/src/drizzle/onchain.ts
+++ b/packages/core/src/drizzle/onchain.ts
@@ -1,4 +1,4 @@
-import type { NonEmptyString } from "@/types/utils.js";
+import type { PonderTypeError } from "@/types/utils.js";
 import {
   type BuildColumns,
   type ColumnBuilderBase,
@@ -192,7 +192,7 @@ export const onchainTable = <
   columns extends Record<string, PgColumnBuilderBase>,
   extra extends PgTableExtraConfig | undefined = undefined,
 >(
-  name: NonEmptyString<name>,
+  name: name extends "" ? PonderTypeError<`Table name cannot be empty`> : name,
   columns: columns | ((columnTypes: PgColumnsBuilders) => columns),
   extraConfig?: (self: BuildExtraConfigColumns<columns>) => extra,
 ): OnchainTable<{

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -32,8 +32,3 @@ export type DeepPartial<T> = {
  */
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
   Partial<Pick<T, K>>;
-
-/**
- * @description Creates a string type that excludes empty strings.
- */
-export type NonEmptyString<T extends string> = T extends "" ? never : T;


### PR DESCRIPTION
This PR adds a type check to the `name` parameter of the `onchainTable` function by throwing a type error if the table name is empty. Currently, the `onchainTable` function accepts empty strings and only throws an error at runtime, since PGlite and Postgres don't accept empty table names.