### PR TITLE
allow for creating database indexes before indexing

### DIFF
--- a/.changeset/wild-symbols-unite.md
+++ b/.changeset/wild-symbols-unite.md
@@ -2,4 +2,4 @@
 "ponder": patch
 ---
 
-add PONDER_DATABASE_CREATE_INDEXES_EARLY option
+Added `DATABASE_INDEXES_EARLY` environment variable and `--indexes-early` CLI flag for creating database indexes immediately rather than after the completion of the historical backfill.

--- a/docs/pages/docs/schema/tables.mdx
+++ b/docs/pages/docs/schema/tables.mdx
@@ -204,17 +204,23 @@ export const dogsRelations = relations(dogs, ({ one }) => ({
 
 The `index(){:ts}` function supports specifying multiple columns, ordering, and custom index types like GIN and GIST. Read more in the [Drizzle](https://orm.drizzle.team/docs/indexes-constraints#indexes) and [PostgreSQL](https://www.postgresql.org/docs/current/indexes.html) documention.
 
-:::info
-  By default, the indexing engine creates database indexes _after_ historical
-  indexing is complete, just before the app becomes healthy.
+::::info
+  By default, Ponder creates database indexes _after_ the historical backfill is complete, just before transitioning to live indexing.
   
-  To create indexes _before_ historical indexing (which can improve query performance during sync for large datasets), 
-  set the `PONDER_DATABASE_CREATE_INDEXES_EARLY` environment variable.
+  To create indexes immediately when starting the app, use the `DATABASE_INDEXES_EARLY` environment variable or `--indexes-early` CLI flag.
   
-  ```js filename=".env.local"
-  PONDER_DATABASE_CREATE_INDEXES_EARLY=true
+  :::code-group
+
+  ```bash [.env.local]
+    DATABASE_INDEXES_EARLY=true
   ```
-:::
+
+  ```bash [CLI]
+    ponder start --indexes-early
+  ```
+
+  :::
+::::
 
 ## Best practices
 

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -89,6 +89,11 @@ const startCommand = new Command("start")
   .description("Start the production server")
   .option("--schema <SCHEMA>", "Database schema", String)
   .option("--views-schema <SCHEMA>", "Views database schema", String)
+  .option(
+    "--indexes-early",
+    "Create database indexes before historical backfill",
+    Boolean,
+  )
   .option("-p, --port <PORT>", "Port for the web server", Number, 42069)
   .option(
     "-H, --hostname <HOSTNAME>",
@@ -126,6 +131,11 @@ const createViewsCommand = new Command("create-views")
   .description("Create database views")
   .option("--schema <SCHEMA>", "Source database schema", String)
   .option("--views-schema <SCHEMA>", "Target database schema", String)
+  .option(
+    "--indexes-early",
+    "Create database indexes before historical backfill",
+    Boolean,
+  )
   .showHelpAfterError()
   .action(async (_, command) => {
     const cliOptions = {

--- a/packages/core/src/internal/options.ts
+++ b/packages/core/src/internal/options.ts
@@ -30,7 +30,7 @@ export type Options = {
   databaseHeartbeatInterval: number;
   databaseHeartbeatTimeout: number;
   databaseMaxQueryParameters: number;
-  databaseCreateIndexesEarly: boolean;
+  databaseIndexesEarly: boolean;
 
   factoryAddressCountThreshold: number;
 
@@ -104,8 +104,8 @@ export const buildOptions = ({ cliOptions }: { cliOptions: CliOptions }) => {
     // Half of the max query parameters for PGlite
     databaseMaxQueryParameters: 16_000,
     // Create indexes before historical sync for better query performance (default: false for backwards compatibility)
-    databaseCreateIndexesEarly: Boolean(
-      process.env.PONDER_DATABASE_CREATE_INDEXES_EARLY,
+    databaseIndexesEarly: Boolean(
+      cliOptions.indexesEarly ?? process.env.DATABASE_INDEXES_EARLY,
     ),
 
     factoryAddressCountThreshold: 1_000,

--- a/packages/core/src/runtime/multichain.ts
+++ b/packages/core/src/runtime/multichain.ts
@@ -277,8 +277,7 @@ export async function runMultichain({
     });
   }
 
-  // Create indexes early if configured to do so
-  if (common.options.databaseCreateIndexesEarly) {
+  if (common.options.databaseIndexesEarly) {
     await createIndexes(database.adminQB, {
       statements: schemaBuild.statements,
     });
@@ -492,8 +491,7 @@ export async function runMultichain({
 
   const tables = Object.values(schemaBuild.schema).filter(isTable);
 
-  // Create indexes after historical sync if not created early
-  if (!common.options.databaseCreateIndexesEarly) {
+  if (common.options.databaseIndexesEarly === false) {
     await createIndexes(database.adminQB, {
       statements: schemaBuild.statements,
     });

--- a/packages/core/src/runtime/omnichain.ts
+++ b/packages/core/src/runtime/omnichain.ts
@@ -282,8 +282,7 @@ export async function runOmnichain({
 
   let pendingEvents: Event[] = [];
 
-  // Create indexes early if configured to do so
-  if (common.options.databaseCreateIndexesEarly) {
+  if (common.options.databaseIndexesEarly) {
     await createIndexes(database.adminQB, {
       statements: schemaBuild.statements,
     });
@@ -510,8 +509,7 @@ export async function runOmnichain({
 
   const tables = Object.values(schemaBuild.schema).filter(isTable);
 
-  // Create indexes after historical sync if not created early
-  if (!common.options.databaseCreateIndexesEarly) {
+  if (common.options.databaseIndexesEarly === false) {
     await createIndexes(database.adminQB, {
       statements: schemaBuild.statements,
     });


### PR DESCRIPTION
Hi!

During historical sync, I need to perform many lookups. These lookups would benefit significantly from custom indices. However, since Ponder creates indexes after the historical sync, my syncs take much longer than necessary.

I understand the reasoning behind adding indexes after sync, but for my use case where I frequently query non-indexed columns on tables with more than 500k rows, I think the benefits of having indexes available during sync outweigh the downsides.

I believe this should be available as a configurable option.

I've done my best to provide a minimal implementation + docs, let me know what you think and if you need anything else!