### PR TITLE
fix: improve cache bytes accuracy

### DIFF
--- a/.changeset/new-poems-argue.md
+++ b/.changeset/new-poems-argue.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improve historical backfill memory usage.

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -208,13 +208,17 @@ const getBytes = (value: unknown) => {
   } else if (value === null || value === undefined) {
     size += 8;
   } else if (Array.isArray(value)) {
+    size += 24; // NodeJs object overhead (3 * 8 bytes)
+
     for (const e of value) {
-      size += getBytes(e);
+      // value + 8 bytes for the key
+      size += getBytes(e) + 8;
     }
   } else {
     size += 24; // NodeJs object overhead (3 * 8 bytes)
     for (const col of Object.values(value)) {
-      size += getBytes(col) + 8; // value + 8 bytes for the key
+      // value + 8 bytes for the key
+      size += getBytes(col) + 8;
     }
   }
 


### PR DESCRIPTION
Improve cache bytes accuracy:
- Keep track of cache keys in addition to cache rows
- Tune object bytes calculations:
  - Add object overhead based on this [V8 comment](https://stackoverflow.com/a/77315744):
  > Skipping over the details here, the upshot is that in V8, each JS object has 3 pointers in its internal header.
  > building Node they compile V8 with pointer compression turned off, so each object needs 3*8 bytes
  - Account object keys, assuming string key will leverage String Internal / String Inferring and thus account for a single pointer (8 bytes) according to this [V8 comment](https://stackoverflow.com/a/40612946)
  > V8 doesn't internalize strings most of the time - it internalizes string constants and identifier names that it finds during parsing, and strings that are used as object property keys,    
