### PR TITLE
chore: fix broken documentation link

### DIFF
--- a/packages/create-ponder/src/subgraph.ts
+++ b/packages/create-ponder/src/subgraph.ts
@@ -139,7 +139,7 @@ export const fromSubgraphId = async ({
   const warnings = [];
   if (manifest.templates?.length > 0) {
     warnings.push(
-      "Factory contract detected. Please see the factory contract documentation for more details: https://ponder.sh/docs/guides/add-contracts#factory-contracts",
+      "Factory contract detected. Please see the factory contract documentation for more details: https://ponder.sh/docs/indexing/read-contracts#factory-contracts",
     );
   }
 


### PR DESCRIPTION
the old link to the Ponder docs was returning a 404.
updated it to the correct page `https://ponder.sh/docs/indexing/read-contracts#factory-contracts`