### PR TITLE
fix transaction proxy

### DIFF
--- a/.changeset/gentle-cars-change.md
+++ b/.changeset/gentle-cars-change.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug with `event.transaction` that caused `TypeError: Cannot read properties of undefined (reading 'hash')`.

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -597,13 +597,13 @@ export const createIndexing = ({
             blockProxy.underlying = event.event.block as Block;
             proxyEvent.block = blockProxy.proxy;
 
-            transactionProxy.eventName = event.name;
             if (event.event.transaction !== undefined) {
+              transactionProxy.eventName = event.name;
               transactionProxy.underlying = event.event
                 .transaction as Transaction;
+              // @ts-expect-error
+              proxyEvent.transaction = transactionProxy.proxy;
             }
-            // @ts-expect-error
-            proxyEvent.transaction = transactionProxy.proxy;
 
             if (event.event.transactionReceipt !== undefined) {
               transactionReceiptProxy.eventName = event.name;


### PR DESCRIPTION
I don't think this fixes any known bug but it improves the error message when `transaction` is undefined unexpectedly.