### PR TITLE
feat: add disableCache disable-writes mode

### DIFF
--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -305,7 +305,7 @@ export type Chain = {
   ws?: string;
   pollingInterval: number;
   finalityBlockCount: number;
-  disableCache: boolean;
+  disableCache: boolean | "disable-writes";
   viemChain: ViemChain | undefined;
 };
 

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -216,7 +216,7 @@ export async function getCachedIntervals(params: {
    * Note: `intervalsCache` is not updated after a new interval is synced.
    */
   let cachedIntervals: CachedIntervals;
-  if (params.chain.disableCache) {
+  if (params.chain.disableCache === true) {
     cachedIntervals = new Map();
     for (const { filter } of params.sources) {
       cachedIntervals.set(filter, []);


### PR DESCRIPTION
I use [Pandvil](https://github.com/morpho-org/pandvil) to test Ponder with forked anvil instances. Pandvil needs to read from `ponder_sync` to avoid backfilling the forked chain state, but it shouldn't write to it -- otherwise multiple test instances aren't independent.

This seems to work as-is as long as all Pandvil/Ponder instances are spawned around the same time. If, on the other hand, instance A reaches realtime, then you spawn instance B, `ponder_sync` has already been written to and B gets confused.

This simple change (hopefully) solves this problem for Pandvil.