### PR TITLE
fix `ponder_realtime_latency` metric

### DIFF
--- a/packages/core/src/utils/generators.test.ts
+++ b/packages/core/src/utils/generators.test.ts
@@ -164,18 +164,16 @@ test("bufferAsyncGenerator() yields all results", async () => {
 });
 
 test("createCallbackGenerator()", async () => {
-  const { callback, generator } = createCallbackGenerator<number, number>();
+  const { callback, generator } = createCallbackGenerator<number>();
 
   (async () => {
     for (let i = 0; i < 5; i++) {
-      await callback(i);
-      await new Promise((res) => setTimeout(res, 1000));
+      callback(i);
+      await new Promise((res) => setTimeout(res, 100));
     }
   })();
 
-  for await (const { value, onComplete } of generator) {
-    onComplete(value + 1);
-
+  for await (const value of generator) {
     if (value === 4) break;
   }
 });

--- a/packages/core/src/utils/generators.ts
+++ b/packages/core/src/utils/generators.ts
@@ -124,29 +124,22 @@ export async function* recordAsyncGenerator<T>(
 /**
  * Creates an async generator that yields values from a callback.
  */
-export function createCallbackGenerator<T, P>(): {
-  callback: (value: T) => Promise<P>;
-  generator: AsyncGenerator<
-    { value: T; onComplete: (value: P) => void },
-    void,
-    unknown
-  >;
+export function createCallbackGenerator<T>(): {
+  callback: (value: T) => void;
+  generator: AsyncGenerator<T, void, unknown>;
 } {
-  const buffer: { value: T; onComplete: (value: P) => void }[] = [];
+  const buffer: T[] = [];
   let pwr = promiseWithResolvers<void>();
 
-  const callback = async (value: T) => {
-    const { resolve, promise } = promiseWithResolvers<P>();
-    buffer.push({ value, onComplete: resolve });
+  const callback = (value: T) => {
+    buffer.push(value);
     pwr.resolve();
-    return promise;
   };
 
   async function* generator() {
     while (true) {
       if (buffer.length > 0) {
-        const { value, onComplete } = buffer.shift()!;
-        yield { value, onComplete };
+        yield buffer.shift()!;
       } else {
         await pwr.promise;
         pwr = promiseWithResolvers<void>();


### PR DESCRIPTION
This fixes `ponder_realtime_latency` metric values.

### Bug description
`ponder_realtime_latency` measures the number of milliseconds between Ponder receiving a block and indexing it. Currently, it is being underreported because of a bug in the collection logic. The `endClock` callback that records the "start" time, is called within an `AsyncGenerator`, which isn't guaranteed to be called immediately when a block is received.

This chart is a clear example of the incorrect behavior. This app uses "omnichain" ordering, where the chain with the slowest blocks (Ethereum) is expected to have the lowest realtime latency.
<img width="635" height="374" alt="image" src="https://github.com/user-attachments/assets/f2b53f9d-7662-41bf-975b-2c3082b27d5d" />

### Fix implementation
The `endClock` callback is instantiated outside of any `AsyncGenerator` logic that may be dependent on yield values being consumed.

See #2126 for a more detailed description of why our realtime pipeline of `AsyncGenerator`s may behave this way.