### PR TITLE
Fix factory caching

### DIFF
--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -243,6 +243,8 @@ export type Fragment =
       address: Address | null;
       eventSelector: Factory["eventSelector"];
       childAddressLocation: Factory["childAddressLocation"];
+      fromBlock: number | null;
+      toBlock: number | null;
     };
 
 /** Minimum slice of a {@link Filter} */
@@ -257,8 +259,8 @@ export type FragmentId =
   | `log_${number}_${FragmentAddressId}_${FragmentTopic}_${FragmentTopic}_${FragmentTopic}_${FragmentTopic}_${0 | 1}`
   /** transfer_{chainId}_{fromAddress}_{toAddress}_{includeReceipts} */
   | `transfer_${number}_${FragmentAddressId}_${FragmentAddressId}_${0 | 1}`
-  /** factory_log_{chainId}_{address}_{eventSelector}_{childAddressLocation} */
-  | `factory_log_${number}_${Address | null}_${Factory["eventSelector"]}_${Factory["childAddressLocation"]}`;
+  /** factory_log_{chainId}_{address}_{eventSelector}_{childAddressLocation}_{fromBlock}_{toBlock} */
+  | `factory_log_${number}_${Address | null}_${Factory["eventSelector"]}_${Factory["childAddressLocation"]}_${number | null}_${number | null}`;
 
 // Contract
 export type Contract = {

--- a/packages/core/src/runtime/fragments.ts
+++ b/packages/core/src/runtime/fragments.ts
@@ -56,6 +56,8 @@ export const getFactoryFragments = (factory: Factory): Fragment[] => {
       address: fragmentAddress ?? null,
       eventSelector: factory.eventSelector,
       childAddressLocation: factory.childAddressLocation,
+      fromBlock: factory.fromBlock ?? null,
+      toBlock: factory.toBlock ?? null,
     } satisfies Fragment;
 
     fragments.push(fragment);
@@ -333,7 +335,7 @@ export const encodeFragment = (fragment: Fragment): FragmentId => {
     case "transfer":
       return `transfer_${fragment.chainId}_${fragmentAddressToId(fragment.fromAddress)}_${fragmentAddressToId(fragment.toAddress)}_${fragment.includeTransactionReceipts ? 1 : 0}`;
     case "factory_log":
-      return `factory_log_${fragment.chainId}_${fragment.address}_${fragment.eventSelector}_${fragment.childAddressLocation}`;
+      return `factory_log_${fragment.chainId}_${fragment.address}_${fragment.eventSelector}_${fragment.childAddressLocation}_${fragment.fromBlock}_${fragment.toBlock}`;
   }
 };
 
@@ -526,8 +528,15 @@ export const decodeFragment = (fragmentId: FragmentId): Fragment => {
       };
     }
     case "factory_log": {
-      const [, chainId, address, eventSelector, childAddressLocation] =
-        fragmentId.split("_");
+      const [
+        ,
+        chainId,
+        address,
+        eventSelector,
+        childAddressLocation,
+        fromBlock,
+        toBlock,
+      ] = fragmentId.split("_");
       return {
         type: "factory_log",
         chainId: Number(chainId),
@@ -535,6 +544,8 @@ export const decodeFragment = (fragmentId: FragmentId): Fragment => {
         eventSelector: eventSelector as Factory["eventSelector"],
         childAddressLocation:
           childAddressLocation as Factory["childAddressLocation"],
+        fromBlock: fromBlock ? Number(fromBlock) : null,
+        toBlock: toBlock ? Number(toBlock) : null,
       };
     }
   }

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -364,6 +364,8 @@ test("getIntervals() 0.15 migration", async (context) => {
             "chainId": 1,
             "childAddressLocation": "topic1",
             "eventSelector": "0x02c69be41d0b7e40352fc85be1cd65eb03d40ef8427a0ca4596b1ead9a00e9fc",
+            "fromBlock": 10,
+            "toBlock": 20,
             "type": "factory_log",
           },
           "intervals": [


### PR DESCRIPTION
## Background
Ponder internally uses the `intervals` table to determine which data can be served from a cache, and what data must be fetched remotely. As of #2173, factories are also tracked in the `intervals` table. This solves issues with `Factory`s that have different `fromBlock` or `toBlock` than the parent `Filter`. 

Once a `Factory` is determined to be fetched and inserted in the database for a range of blocks, the `factory_addresses` table is queried to get the child addresses (address + block number where the address was emitted) for a `Factory`. As an optimization for factories that may emit the same child address more than once, Ponder does its best to only story addresses + the block number where it first appears.

## Bug description
The issue is the different unique constraints used by the `intervals` table and the `factory_addresses` table. The `factory_addresses` table correctly uses `fromBlock` and `toBlock` in the unique constraint. This is necessary because moving the `fromBlock` forward may cause isn't compatible with the deduplication optimization, it may cause missed child addresses.

However, the `intervals` table current doesn't have `fromBlock` and `toBlock` in the unique constraint. With the tables using two different unique constraints, it's possible that the `intervals` table will consider a `Factory` to be fetched and inserted into the database, but querying the `child_addresses` table will result in 0 rows.

## Implementation
To fix this, the primary key for `Factories` in the interval table must include `fromBlock` and `toBlock`. This will cause a complete re-fetch of block data when the `fromBlock` moves forwards, which is the correct behavior.

The migration path is handled by the same logic invalid in the `0.15` migration.

https://github.com/ponder-sh/ponder/blob/6d4ad1a76458269220ef8c6b7d2a86b42b92de8f/packages/core/src/sync-store/index.ts#L425-L448