### PR TITLE
chore: add package links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ If you're interested in contributing to Ponder, please read the [contribution gu
 
 ## Packages
 
-- `ponder`
-- `@ponder/client`
-- `@ponder/react`
-- `@ponder/utils`
-- `create-ponder`
-- `eslint-config-ponder`
+- [`ponder`](https://www.npmjs.com/package/ponder)
+- [`@ponder/client`](https://www.npmjs.com/package/@ponder/client)
+- [`@ponder/react`](https://www.npmjs.com/package/@ponder/react)
+- [`@ponder/utils`](https://www.npmjs.com/package/@ponder/utils)
+- [`create-ponder`](https://www.npmjs.com/package/create-ponder)
+- [`eslint-config-ponder`](https://www.npmjs.com/package/eslint-config-ponder)
 
 ## About
 


### PR DESCRIPTION
## Add package links to README

Added npm links for all packages in the Packages section to make it easier for users to learn about and navigate to each package.

### Changes
- Added npm package links for all 6 packages

