### PR TITLE
Child Start Block Parameter

### DIFF
--- a/packages/core/src/config/address.ts
+++ b/packages/core/src/config/address.ts
@@ -22,6 +22,19 @@ export type Factory<event extends AbiEvent = AbiEvent> = {
   startBlock?: number | "latest";
   /** To block */
   endBlock?: number | "latest";
+  /**
+   * Static block number to start indexing child contract events from.
+   * If specified, all child contracts will be indexed from this block.
+   */
+  childStartBlock?: number;
+  /**
+   * Name of the factory event parameter that contains the block number
+   * to start indexing the child contract from.
+   */
+  startBlockParameter?: Exclude<
+    ParameterNames<event["inputs"][number]>,
+    undefined
+  >;
 };
 
 export const factory = <event extends AbiEvent>(factory: Factory<event>) =>

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -180,6 +180,21 @@ export type LogFactory = {
   childAddressLocation: "topic1" | "topic2" | "topic3" | `offset${number}`;
   fromBlock: number | undefined;
   toBlock: number | undefined;
+  /**
+   * Static block number to use as the start block for all child contracts.
+   * If set, overrides the factory event's block number.
+   */
+  childStartBlock?: number | undefined;
+  /**
+   * Location of the start block parameter in the factory event.
+   * Similar to childAddressLocation but for extracting the start block.
+   */
+  childStartBlockLocation?:
+    | "topic1"
+    | "topic2"
+    | "topic3"
+    | `offset${number}`
+    | undefined;
 };
 
 // Fragments

--- a/packages/core/src/runtime/realtime.ts
+++ b/packages/core/src/runtime/realtime.ts
@@ -944,15 +944,13 @@ export async function handleRealtimeSyncEvent(
       const childAddresses = new Map<Factory, Map<Address, number>>();
 
       for (const block of finalizedBlocks) {
-        for (const [factory, addresses] of block.childAddresses) {
+        for (const [factory, addressMap] of block.childAddresses) {
           if (childAddresses.has(factory) === false) {
             childAddresses.set(factory, new Map());
           }
-          for (const address of addresses) {
+          for (const [address, startBlockNumber] of addressMap) {
             if (childAddresses.get(factory)!.has(address) === false) {
-              childAddresses
-                .get(factory)!
-                .set(address, hexToNumber(block.block.number));
+              childAddresses.get(factory)!.set(address, startBlockNumber);
             }
           }
         }

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -28,6 +28,7 @@ import {
 import type { Rpc } from "@/rpc/index.js";
 import {
   getChildAddress,
+  getChildStartBlock,
   isAddressFactory,
   isAddressMatched,
   isBlockFilterMatched,
@@ -399,7 +400,9 @@ export const createHistoricalSync = (
           }
         }
         const existingBlockNumber = childAddressesRecord.get(address);
-        const newBlockNumber = hexToNumber(log.blockNumber);
+        // Use childStartBlock from event field or static config, fall back to log's block number
+        const childStartBlock = getChildStartBlock({ log, factory });
+        const newBlockNumber = childStartBlock ?? hexToNumber(log.blockNumber);
 
         if (
           existingBlockNumber === undefined ||


### PR DESCRIPTION
## Summary

This PR adds support for specifying a custom start block when indexing child contracts created by a factory pattern. Previously, child contracts were always indexed starting from the block where the factory event was emitted. This change allows backfilling events from child contracts that occurred before the factory event.

## Motivation

In some use cases, a factory contract may emit events about child contracts that were created earlier, or you may want to index child contract events from a specific historical block regardless of when the factory event occurred. This was previously not possible with Ponder's factory pattern.

## New Features

### 1. `childStartBlock` - Static Start Block

Specify a fixed block number to start indexing all child contract events from:

export default createConfig({
  contracts: {
    ChildContract: {
      abi: childAbi,
      address: factory({
        address: "0xFactoryAddress",
        event: parseAbiEvent("event ChildCreated(address indexed child)"),
        parameter: "child",
        childStartBlock: 14645816, // All children indexed from this block
      }),
      network: "mainnet",
    },
  },
});### 2. `startBlockParameter` - Dynamic Start Block from Event

Extract the start block dynamically from a parameter in the factory event:

export default createConfig({
  contracts: {
    ChildContract: {
      abi: childAbi,
      address: factory({
        address: "0xFactoryAddress",
        event: parseAbiEvent("event ChildCreated(address indexed child, uint256 indexed startBlock)"),
        parameter: "child",
        startBlockParameter: "startBlock", // Start block extracted from event
      }),
      network: "mainnet",
    },
  },
});## Implementation Details

### Files Changed

- **`packages/core/src/config/address.ts`** - Added `childStartBlock` and `startBlockParameter` to the public `Factory` type
- **`packages/core/src/internal/types.ts`** - Added `childStartBlock` and `childStartBlockLocation` to internal `LogFactory` type
- **`packages/core/src/build/factory.ts`** - Updated `buildLogFactory` to process the new options and compute parameter locations
- **`packages/core/src/build/config.ts`** - Pass new options through config building
- **`packages/core/src/runtime/filter.ts`** - Added `getChildStartBlock()` helper function for extracting start blocks
- **`packages/core/src/sync-historical/index.ts`** - Updated historical sync to use custom start blocks for backfilling
- **`packages/core/src/sync-realtime/index.ts`** - Updated realtime sync to track start blocks per child address

### Tests Added

- `buildLogFactory with childStartBlock static value`
- `buildLogFactory with startBlockParameter from indexed topic`
- `buildLogFactory with startBlockParameter from data offset`
- `buildLogFactory with startBlockParameter extracts from chainId`
- `buildLogFactory throws if startBlockParameter not found`
- `getChildStartBlock() returns undefined when no config`
- `getChildStartBlock() returns static childStartBlock`
- `getChildStartBlock() extracts from topic`
- `getChildStartBlock() extracts from data offset`
- `getChildStartBlock() static childStartBlock takes precedence over location`

## Breaking Changes

None. The new options are fully optional and existing factory configurations continue to work unchanged.

## Testing

- ✅ All 311 core package tests pass
- ✅ Build succeeds