### PR TITLE
[WIP] improve internal error handling

### DIFF
--- a/packages/core/src/bin/commands/createViews.ts
+++ b/packages/core/src/bin/commands/createViews.ts
@@ -111,19 +111,6 @@ export async function createViews({
     return;
   }
 
-  const databaseDiagnostic = await build.databaseDiagnostic({
-    preBuild: buildResult.result,
-  });
-  if (databaseDiagnostic.status === "error") {
-    common.logger.error({
-      msg: "Build failed",
-      stage: "diagnostic",
-      error: databaseDiagnostic.error,
-    });
-    await exit({ code: 75 });
-    return;
-  }
-
   const database = createDatabase({
     common,
     // Note: `namespace` is not used in this command
@@ -134,6 +121,20 @@ export async function createViews({
     preBuild: buildResult.result,
     schemaBuild: emptySchemaBuild,
   });
+
+  const databaseDiagnostic = await build.databaseDiagnostic({
+    preBuild: buildResult.result,
+    database,
+  });
+  if (databaseDiagnostic.status === "error") {
+    common.logger.error({
+      msg: "Build failed",
+      stage: "diagnostic",
+      error: databaseDiagnostic.error,
+    });
+    await exit({ code: 75 });
+    return;
+  }
 
   const endClock = startClock();
 

--- a/packages/core/src/bin/commands/dev.ts
+++ b/packages/core/src/bin/commands/dev.ts
@@ -110,8 +110,6 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
         //   common.logger.error({ error: result.error });
         // }
 
-        console.log(result.kind);
-
         // This handles indexing function build failures on hot reload.
         metrics.hasError = true;
         return;

--- a/packages/core/src/bin/commands/dev.ts
+++ b/packages/core/src/bin/commands/dev.ts
@@ -162,23 +162,6 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
           return;
         }
 
-        const databaseDiagnostic = await build.databaseDiagnostic({
-          preBuild: preCompileResult.result,
-        });
-        if (databaseDiagnostic.status === "error") {
-          common.logger.error({
-            msg: "Build failed",
-            stage: "diagnostic",
-            error: databaseDiagnostic.error,
-          });
-          buildQueue.add({
-            status: "error",
-            kind: "indexing",
-            error: databaseDiagnostic.error,
-          });
-          return;
-        }
-
         const compileSchemaResult = build.compileSchema({
           ...schemaResult.result,
           preBuild: preCompileResult.result,
@@ -276,6 +259,25 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
           preBuild: preCompileResult.result,
           schemaBuild: compileSchemaResult.result,
         });
+
+        const databaseDiagnostic = await build.databaseDiagnostic({
+          preBuild: preCompileResult.result,
+          database,
+        });
+        if (databaseDiagnostic.status === "error") {
+          common.logger.error({
+            msg: "Build failed",
+            stage: "diagnostic",
+            error: databaseDiagnostic.error,
+          });
+          buildQueue.add({
+            status: "error",
+            kind: "indexing",
+            error: databaseDiagnostic.error,
+          });
+          return;
+        }
+
         crashRecoveryCheckpoint = await database.migrate({
           buildId: indexingBuildResult.result.buildId,
           chains: indexingBuildResult.result.chains,

--- a/packages/core/src/bin/commands/list.ts
+++ b/packages/core/src/bin/commands/list.ts
@@ -84,8 +84,17 @@ export async function list({ cliOptions }: { cliOptions: CliOptions }) {
     return;
   }
 
+  const database = createDatabase({
+    common,
+    // Note: `namespace` is not used in this command
+    namespace: { schema: "public", viewsSchema: undefined },
+    preBuild: buildResult.result,
+    schemaBuild: emptySchemaBuild,
+  });
+
   const databaseDiagnostic = await build.databaseDiagnostic({
     preBuild: buildResult.result,
+    database,
   });
   if (databaseDiagnostic.status === "error") {
     common.logger.error({
@@ -96,14 +105,6 @@ export async function list({ cliOptions }: { cliOptions: CliOptions }) {
     await exit({ code: 75 });
     return;
   }
-
-  const database = createDatabase({
-    common,
-    // Note: `namespace` is not used in this command
-    namespace: { schema: "public", viewsSchema: undefined },
-    preBuild: buildResult.result,
-    schemaBuild: emptySchemaBuild,
-  });
 
   const ponderSchemas = await database.adminQB.wrap((db) =>
     db

--- a/packages/core/src/bin/commands/prune.ts
+++ b/packages/core/src/bin/commands/prune.ts
@@ -91,8 +91,17 @@ export async function prune({ cliOptions }: { cliOptions: CliOptions }) {
     return;
   }
 
+  const database = createDatabase({
+    common,
+    // Note: `namespace` is not used in this command
+    namespace: { schema: "public", viewsSchema: undefined },
+    preBuild: buildResult.result,
+    schemaBuild: emptySchemaBuild,
+  });
+
   const databaseDiagnostic = await build.databaseDiagnostic({
     preBuild: buildResult.result,
+    database,
   });
   if (databaseDiagnostic.status === "error") {
     common.logger.error({
@@ -103,14 +112,6 @@ export async function prune({ cliOptions }: { cliOptions: CliOptions }) {
     await exit({ code: 75 });
     return;
   }
-
-  const database = createDatabase({
-    common,
-    // Note: `namespace` is not used in this command
-    namespace: { schema: "public", viewsSchema: undefined },
-    preBuild: buildResult.result,
-    schemaBuild: emptySchemaBuild,
-  });
 
   const ponderSchemas = await database.adminQB.wrap((db) =>
     db

--- a/packages/core/src/bin/commands/serve.ts
+++ b/packages/core/src/bin/commands/serve.ts
@@ -113,19 +113,6 @@ export async function serve({ cliOptions }: { cliOptions: CliOptions }) {
     return;
   }
 
-  const databaseDiagnostic = await build.databaseDiagnostic({
-    preBuild: preCompileResult.result,
-  });
-  if (databaseDiagnostic.status === "error") {
-    common.logger.error({
-      msg: "Build failed",
-      stage: "diagnostic",
-      error: databaseDiagnostic.error,
-    });
-    await exit({ code: 75 });
-    return;
-  }
-
   const compileSchemaResult = build.compileSchema({
     ...schemaResult.result,
     preBuild: preCompileResult.result,
@@ -163,6 +150,20 @@ export async function serve({ cliOptions }: { cliOptions: CliOptions }) {
     preBuild: preCompileResult.result,
     schemaBuild: compileSchemaResult.result,
   });
+
+  const databaseDiagnostic = await build.databaseDiagnostic({
+    preBuild: preCompileResult.result,
+    database,
+  });
+  if (databaseDiagnostic.status === "error") {
+    common.logger.error({
+      msg: "Build failed",
+      stage: "diagnostic",
+      error: databaseDiagnostic.error,
+    });
+    await exit({ code: 75 });
+    return;
+  }
 
   const schemaExists = await database.adminQB
     .wrap((db) =>

--- a/packages/core/src/bin/commands/start.ts
+++ b/packages/core/src/bin/commands/start.ts
@@ -227,11 +227,21 @@ export async function start({
     return;
   }
 
-  const crashRecoveryCheckpoint = await database.migrate({
-    buildId: indexingBuildResult.result.buildId,
-    chains: indexingBuildResult.result.chains,
-    finalizedBlocks: indexingBuildResult.result.finalizedBlocks,
-  });
+  const crashRecoveryCheckpoint = await database
+    .migrate({
+      buildId: indexingBuildResult.result.buildId,
+      chains: indexingBuildResult.result.chains,
+      finalizedBlocks: indexingBuildResult.result.finalizedBlocks,
+    })
+    .catch((error) => {
+      common.logger.error({
+        msg: "Database migration failed",
+        stage: "migration",
+        error: error as Error,
+      });
+
+      throw error;
+    });
 
   await database.migrateSync();
 

--- a/packages/core/src/bin/commands/start.ts
+++ b/packages/core/src/bin/commands/start.ts
@@ -225,6 +225,9 @@ export async function start({
     preBuild: preCompileResult.result,
     schemaBuild: compileSchemaResult.result,
   });
+
+  // TODO(kyle) database diagnostic
+
   const crashRecoveryCheckpoint = await database.migrate({
     buildId: indexingBuildResult.result.buildId,
     chains: indexingBuildResult.result.chains,

--- a/packages/core/src/bin/commands/start.ts
+++ b/packages/core/src/bin/commands/start.ts
@@ -137,19 +137,6 @@ export async function start({
     return;
   }
 
-  const databaseDiagnostic = await build.databaseDiagnostic({
-    preBuild: preCompileResult.result,
-  });
-  if (databaseDiagnostic.status === "error") {
-    common.logger.error({
-      msg: "Build failed",
-      stage: "diagnostic",
-      error: databaseDiagnostic.error,
-    });
-    await exit({ code: 75 });
-    return;
-  }
-
   const compileSchemaResult = build.compileSchema({
     ...schemaResult.result,
     preBuild: preCompileResult.result,
@@ -226,7 +213,19 @@ export async function start({
     schemaBuild: compileSchemaResult.result,
   });
 
-  // TODO(kyle) database diagnostic
+  const databaseDiagnostic = await build.databaseDiagnostic({
+    preBuild: preCompileResult.result,
+    database,
+  });
+  if (databaseDiagnostic.status === "error") {
+    common.logger.error({
+      msg: "Build failed",
+      stage: "diagnostic",
+      error: databaseDiagnostic.error,
+    });
+    await exit({ code: 75 });
+    return;
+  }
 
   const crashRecoveryCheckpoint = await database.migrate({
     buildId: indexingBuildResult.result.buildId,

--- a/packages/core/src/bin/isolatedController.ts
+++ b/packages/core/src/bin/isolatedController.ts
@@ -245,34 +245,18 @@ export async function isolatedController({
               break;
             }
             case "error": {
-              const error: Error = message.error;
-              // if (nonRetryableUserErrorNames.includes(message.error.name)) {
-              //   error = new NonRetryableUserError(message.error.message);
-              // } else {
-              //   error = new Error(message.error.message);
-              // }
-              // error = message.error;
-              // error.name = message.error.name;
-              // error.stack = message.error.stack;
-              throw error;
+              throw message.error;
             }
           }
         },
       );
 
       worker.on("error", (error: Error) => {
-        // if (nonRetryableUserErrorNames.includes(error.name)) {
-        //   error = new NonRetryableUserError(error.message);
-        // } else {
-        //   error = new Error(error.message);
-        // }
         throw error;
       });
 
       worker.on("exit", (code: number) => {
-        const error = new Error(`Worker thread exited with code ${code}.`);
-        error.stack = undefined;
-        throw error;
+        throw new Error(`Worker thread exited with code ${code}.`);
       });
 
       perThreadWorkers.push(worker);

--- a/packages/core/src/bin/isolatedController.ts
+++ b/packages/core/src/bin/isolatedController.ts
@@ -5,10 +5,7 @@ import { Worker } from "node:worker_threads";
 import { createIndexes, createViews } from "@/database/actions.js";
 import { type Database, getPonderMetaTable } from "@/database/index.js";
 import type { Common } from "@/internal/common.js";
-import {
-  NonRetryableUserError,
-  nonRetryableUserErrorNames,
-} from "@/internal/errors.js";
+import {} from "@/internal/errors.js";
 import { AggregateMetricsService, getAppProgress } from "@/internal/metrics.js";
 import type {
   CrashRecoveryCheckpoint,
@@ -248,14 +245,15 @@ export async function isolatedController({
               break;
             }
             case "error": {
-              let error: Error;
-              if (nonRetryableUserErrorNames.includes(message.error.name)) {
-                error = new NonRetryableUserError(message.error.message);
-              } else {
-                error = new Error(message.error.message);
-              }
-              error.name = message.error.name;
-              error.stack = message.error.stack;
+              const error: Error = message.error;
+              // if (nonRetryableUserErrorNames.includes(message.error.name)) {
+              //   error = new NonRetryableUserError(message.error.message);
+              // } else {
+              //   error = new Error(message.error.message);
+              // }
+              // error = message.error;
+              // error.name = message.error.name;
+              // error.stack = message.error.stack;
               throw error;
             }
           }
@@ -263,11 +261,11 @@ export async function isolatedController({
       );
 
       worker.on("error", (error: Error) => {
-        if (nonRetryableUserErrorNames.includes(error.name)) {
-          error = new NonRetryableUserError(error.message);
-        } else {
-          error = new Error(error.message);
-        }
+        // if (nonRetryableUserErrorNames.includes(error.name)) {
+        //   error = new NonRetryableUserError(error.message);
+        // } else {
+        //   error = new Error(error.message);
+        // }
         throw error;
       });
 

--- a/packages/core/src/bin/utils/exit.ts
+++ b/packages/core/src/bin/utils/exit.ts
@@ -3,8 +3,8 @@ import readline from "node:readline";
 import type { Common } from "@/internal/common.js";
 import {
   BaseError,
-  NonRetryableUserError,
   ShutdownError,
+  isUserDerivedError,
 } from "@/internal/errors.js";
 import type { Options } from "@/internal/options.js";
 
@@ -92,15 +92,16 @@ export const createExit = ({
         common.logger.error({
           msg: `unhandledRejection: ${error.name}`,
         });
+        if (isUserDerivedError(error)) {
+          exit({ code: 1 });
+        } else {
+          exit({ code: 75 });
+        }
       } else {
         common.logger.error({
           msg: "unhandledRejection",
           error,
         });
-      }
-      if (error instanceof NonRetryableUserError) {
-        exit({ code: 1 });
-      } else {
         exit({ code: 75 });
       }
     });
@@ -110,15 +111,16 @@ export const createExit = ({
         common.logger.error({
           msg: `unhandledRejection: ${error.name}`,
         });
+        if (isUserDerivedError(error)) {
+          exit({ code: 1 });
+        } else {
+          exit({ code: 75 });
+        }
       } else {
         common.logger.error({
           msg: "unhandledRejection",
           error,
         });
-      }
-      if (error instanceof NonRetryableUserError) {
-        exit({ code: 1 });
-      } else {
         exit({ code: 75 });
       }
     });

--- a/packages/core/src/bin/utils/exit.ts
+++ b/packages/core/src/bin/utils/exit.ts
@@ -90,7 +90,7 @@ export const createExit = ({
       if (error instanceof ShutdownError) return;
       if (error instanceof BaseError) {
         common.logger.error({
-          msg: `unhandledRejection: ${error.name}`,
+          msg: `unhandledRejection: ${error.name} ${error.message}`,
         });
         if (isUserDerivedError(error)) {
           exit({ code: 1 });
@@ -109,7 +109,7 @@ export const createExit = ({
       if (error instanceof ShutdownError) return;
       if (error instanceof BaseError) {
         common.logger.error({
-          msg: `unhandledRejection: ${error.name}`,
+          msg: `unhandledRejection: ${error.name} ${error.message}`,
         });
         if (isUserDerivedError(error)) {
           exit({ code: 1 });

--- a/packages/core/src/bin/utils/exit.ts
+++ b/packages/core/src/bin/utils/exit.ts
@@ -1,7 +1,11 @@
 import os from "node:os";
 import readline from "node:readline";
 import type { Common } from "@/internal/common.js";
-import { NonRetryableUserError, ShutdownError } from "@/internal/errors.js";
+import {
+  BaseError,
+  NonRetryableUserError,
+  ShutdownError,
+} from "@/internal/errors.js";
 import type { Options } from "@/internal/options.js";
 
 const SHUTDOWN_GRACE_PERIOD_MS = 5_000;
@@ -84,10 +88,16 @@ export const createExit = ({
   if (options.command !== "dev") {
     process.on("uncaughtException", (error: Error) => {
       if (error instanceof ShutdownError) return;
-      common.logger.error({
-        msg: "uncaughtException",
-        error,
-      });
+      if (error instanceof BaseError) {
+        common.logger.error({
+          msg: `unhandledRejection: ${error.name}`,
+        });
+      } else {
+        common.logger.error({
+          msg: "unhandledRejection",
+          error,
+        });
+      }
       if (error instanceof NonRetryableUserError) {
         exit({ code: 1 });
       } else {
@@ -96,10 +106,16 @@ export const createExit = ({
     });
     process.on("unhandledRejection", (error: Error) => {
       if (error instanceof ShutdownError) return;
-      common.logger.error({
-        msg: "unhandledRejection",
-        error,
-      });
+      if (error instanceof BaseError) {
+        common.logger.error({
+          msg: `unhandledRejection: ${error.name}`,
+        });
+      } else {
+        common.logger.error({
+          msg: "unhandledRejection",
+          error,
+        });
+      }
       if (error instanceof NonRetryableUserError) {
         exit({ code: 1 });
       } else {

--- a/packages/core/src/build/config.test.ts
+++ b/packages/core/src/build/config.test.ts
@@ -12,12 +12,7 @@ import {
   zeroAddress,
 } from "viem";
 import { beforeEach, expect, test } from "vitest";
-import {
-  buildConfig,
-  buildIndexingFunctions,
-  safeBuildConfig,
-  safeBuildIndexingFunctions,
-} from "./config.js";
+import { buildConfig, buildIndexingFunctions } from "./config.js";
 
 beforeEach(setupCommon);
 beforeEach(setupAnvil);
@@ -209,16 +204,15 @@ test("buildIndexingFunctions() throw useful error for common 0.11 migration mist
     config,
   });
 
-  const result = await safeBuildIndexingFunctions({
-    common: context.common,
-    // @ts-expect-error
-    config,
-    indexingFunctions,
-    configBuild,
-  });
-
-  expect(result.status).toBe("error");
-  expect(result.error?.message).toBe(
+  await expect(
+    buildIndexingFunctions({
+      common: context.common,
+      // @ts-expect-error
+      config,
+      indexingFunctions,
+      configBuild,
+    }),
+  ).rejects.toThrowError(
     "Validation failed: Chain for 'a' is null or undefined. Expected one of ['mainnet', 'optimism']. Did you forget to change 'network' to 'chain' when migrating to 0.11?",
   );
 });
@@ -402,15 +396,14 @@ test("buildIndexingFunctions() validates chain name", async () => {
     common: context.common,
     config,
   });
-  const result = await safeBuildIndexingFunctions({
-    common: context.common,
-    config,
-    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
-    configBuild,
-  });
-
-  expect(result.status).toBe("error");
-  expect(result.error?.message).toBe(
+  await expect(
+    buildIndexingFunctions({
+      common: context.common,
+      config,
+      indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+      configBuild,
+    }),
+  ).rejects.toThrowError(
     "Validation failed: Invalid chain for 'a'. Got 'mainnetz', expected one of ['mainnet'].",
   );
 });
@@ -430,13 +423,12 @@ test.skip("buildConfig() warns for public RPC URL", () => {
     },
   });
 
-  const result = safeBuildConfig({
+  const { logs } = buildConfig({
     common: context.common,
     config,
   });
 
-  expect(result.status).toBe("success");
-  expect(result.logs!.filter((l) => l.level === "warn")).toEqual([
+  expect(logs!.filter((l) => l.level === "warn")).toEqual([
     {
       level: "warn",
       msg: "Chain 'mainnet' is using a public RPC URL (https://cloudflare-eth.com). Most apps require an RPC URL with a higher rate limit.",
@@ -458,12 +450,7 @@ test("buildConfig() handles chains not found in viem", () => {
     },
   });
 
-  const result = safeBuildConfig({
-    common: context.common,
-    config,
-  });
-
-  expect(result.status).toBe("success");
+  buildConfig({ common: context.common, config });
 });
 
 test("buildIndexingFunctions() validates event filter event name must be present in ABI", async () => {
@@ -490,15 +477,14 @@ test("buildIndexingFunctions() validates event filter event name must be present
     common: context.common,
     config,
   });
-  const result = await safeBuildIndexingFunctions({
-    common: context.common,
-    config,
-    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
-    configBuild,
-  });
-
-  expect(result.status).toBe("error");
-  expect(result.error?.message).toBe(
+  await expect(
+    buildIndexingFunctions({
+      common: context.common,
+      config,
+      indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+      configBuild,
+    }),
+  ).rejects.toThrowError(
     "Validation failed: Invalid filter for contract 'a'. Got event name 'Event2', expected one of ['Event0'].",
   );
 });
@@ -522,15 +508,14 @@ test("buildIndexingFunctions() validates address empty string", async () => {
     config,
   });
 
-  const result = await safeBuildIndexingFunctions({
-    common: context.common,
-    config,
-    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
-    configBuild,
-  });
-
-  expect(result.status).toBe("error");
-  expect(result.error?.message).toBe(
+  await expect(
+    buildIndexingFunctions({
+      common: context.common,
+      config,
+      indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+      configBuild,
+    }),
+  ).rejects.toThrowError(
     "Validation failed: Invalid prefix for address ''. Got '', expected '0x'.",
   );
 });
@@ -551,15 +536,14 @@ test("buildIndexingFunctions() validates address prefix", async () => {
   });
 
   const configBuild = buildConfig({ common: context.common, config });
-  const result = await safeBuildIndexingFunctions({
-    common: context.common,
-    config,
-    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
-    configBuild,
-  });
-
-  expect(result.status).toBe("error");
-  expect(result.error?.message).toBe(
+  await expect(
+    buildIndexingFunctions({
+      common: context.common,
+      config,
+      indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+      configBuild,
+    }),
+  ).rejects.toThrowError(
     "Validation failed: Invalid prefix for address '0b0000000000000000000000000000000000000001'. Got '0b', expected '0x'.",
   );
 });
@@ -579,15 +563,14 @@ test("buildIndexingFunctions() validates address length", async () => {
   });
 
   const configBuild = buildConfig({ common: context.common, config });
-  const result = await safeBuildIndexingFunctions({
-    common: context.common,
-    config,
-    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
-    configBuild,
-  });
-
-  expect(result.status).toBe("error");
-  expect(result.error?.message).toBe(
+  await expect(
+    buildIndexingFunctions({
+      common: context.common,
+      config,
+      indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+      configBuild,
+    }),
+  ).rejects.toThrowError(
     "Validation failed: Invalid length for address '0x000000000001'. Got 14, expected 42 characters.",
   );
 });
@@ -923,15 +906,14 @@ test("buildIndexingFunctions() validates factory interval", async () => {
   });
 
   const configBuild = buildConfig({ common: context.common, config });
-  const result = await safeBuildIndexingFunctions({
-    common: context.common,
-    config,
-    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
-    configBuild,
-  });
-
-  expect(result.status).toBe("error");
-  expect(result.error?.message).toBe(
+  await expect(
+    buildIndexingFunctions({
+      common: context.common,
+      config,
+      indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+      configBuild,
+    }),
+  ).rejects.toThrowError(
     "Validation failed: Start block for 'a' is before start block of factory address (16370050 > 16370000).",
   );
 });
@@ -955,20 +937,17 @@ test("buildIndexingFunctions() validates start and end block", async () => {
 
   // @ts-expect-error
   const configBuild = buildConfig({ common: context.common, config });
-  const result = await safeBuildIndexingFunctions({
-    common: context.common,
-    // @ts-expect-error
-    config,
-    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
-    configBuild,
-  });
-
-  expect(result).toMatchInlineSnapshot(`
-    {
-      "error": [BuildError: Validation failed: Invalid start block for 'a'. Got 16370000 typeof string, expected an integer.],
-      "status": "error",
-    }
-  `);
+  await expect(
+    buildIndexingFunctions({
+      common: context.common,
+      // @ts-expect-error
+      config,
+      indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+      configBuild,
+    }),
+  ).rejects.toThrowError(
+    "Validation failed: Invalid start block for 'a'. Got 16370000 typeof string, expected an integer.",
+  );
 });
 
 test("buildIndexingFunctions() returns chain, rpc, and finalized block", async () => {

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -178,13 +178,13 @@ export const createBuild = async ({
       return { status: "success", exports } as const;
     } catch (error_) {
       const relativePath = path.relative(common.options.rootDir, file);
-      // TODO(kyle) error should be a `BuildError`
-      const error = parseViteNodeError(relativePath, error_ as Error);
+      const error = new BuildError(undefined, {
+        cause: parseViteNodeError(relativePath, error_ as Error),
+      });
       return { status: "error", error } as const;
     }
   };
 
-  // TODO(kyle) all files should use this function
   const executeFileWithTimeout = async ({
     file,
   }: { file: string }): Promise<

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -280,7 +280,7 @@ export const createBuild = async ({
         try {
           const contents = fs.readFileSync(file, "utf-8");
           hash.update(contents);
-        } catch (e) {
+        } catch {
           common.logger.warn({ msg: "Unable to read file", file });
           hash.update(file);
         }

--- a/packages/core/src/build/pre.ts
+++ b/packages/core/src/build/pre.ts
@@ -42,7 +42,7 @@ export function buildPre({
 
       if (connectionString === undefined) {
         if (config.database.poolConfig === undefined) {
-          throw new Error(
+          throw new BuildError(
             "Invalid database configuration: Either 'connectionString' or 'poolConfig' must be defined.",
           );
         }
@@ -87,28 +87,4 @@ export function buildPre({
     databaseConfig,
     ordering: config.ordering ?? "multichain",
   };
-}
-
-export function safeBuildPre({
-  config,
-  options,
-  logger,
-}: {
-  config: Config;
-  options: Pick<Options, "rootDir" | "ponderDir">;
-  logger: Logger;
-}) {
-  try {
-    const result = buildPre({ config, options, logger });
-
-    return {
-      status: "success",
-      databaseConfig: result.databaseConfig,
-      ordering: result.ordering,
-    } as const;
-  } catch (_error) {
-    const buildError = new BuildError((_error as Error).message);
-    buildError.stack = undefined;
-    return { status: "error", error: buildError } as const;
-  }
 }

--- a/packages/core/src/build/schema.ts
+++ b/packages/core/src/build/schema.ts
@@ -51,13 +51,13 @@ export const buildSchema = ({
         name === PONDER_META_TABLE_NAME ||
         name === PONDER_CHECKPOINT_TABLE_NAME
       ) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: '${name}' is a reserved table name.`,
         );
       }
 
       if (name.length > MAX_DATABASE_OBJECT_NAME_LENGTH) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: '${name}' table name cannot be longer than ${MAX_DATABASE_OBJECT_NAME_LENGTH} characters.`,
         );
       }
@@ -67,7 +67,7 @@ export const buildSchema = ({
       for (const [columnName, column] of Object.entries(getTableColumns(s))) {
         if (column.primary) {
           if (hasPrimaryKey) {
-            throw new Error(
+            throw new BuildError(
               `Schema validation failed: '${name}' has multiple primary keys.`,
             );
           } else {
@@ -81,44 +81,44 @@ export const buildSchema = ({
           column instanceof PgBigSerial53 ||
           column instanceof PgBigSerial64
         ) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}.${columnName}' has a serial column and serial columns are unsupported.`,
           );
         }
 
         if (column.isUnique) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}.${columnName}' has a unique constraint and unique constraints are unsupported.`,
           );
         }
 
         if (column.generated !== undefined) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}.${columnName}' is a generated column and generated columns are unsupported.`,
           );
         }
 
         if (column.generatedIdentity !== undefined) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}.${columnName}' is a generated column and generated columns are unsupported.`,
           );
         }
 
         if (column.hasDefault) {
           if (column.default && column.default instanceof SQL) {
-            throw new Error(
+            throw new BuildError(
               `Schema validation failed: '${name}.${columnName}' is a default column and default columns with raw sql are unsupported.`,
             );
           }
 
           if (column.defaultFn && column.defaultFn() instanceof SQL) {
-            throw new Error(
+            throw new BuildError(
               `Schema validation failed: '${name}.${columnName}' is a default column and default columns with raw sql are unsupported.`,
             );
           }
 
           if (column.onUpdateFn && column.onUpdateFn() instanceof SQL) {
-            throw new Error(
+            throw new BuildError(
               `Schema validation failed: '${name}.${columnName}' is a default column and default columns with raw sql are unsupported.`,
             );
           }
@@ -136,13 +136,13 @@ export const buildSchema = ({
           column.name === "operation" ||
           column.name === "checkpoint"
         ) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}.${columnName}' is a reserved column name.`,
           );
         }
 
         if (columnNames.has(column.name)) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}.${column.name}' column name is used multiple times.`,
           );
         } else {
@@ -152,7 +152,7 @@ export const buildSchema = ({
 
       if (preBuild.ordering === "experimental_isolated") {
         if (hasChainIdColumn === false) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}' does not have required 'chainId' column.`,
           );
         }
@@ -161,7 +161,7 @@ export const buildSchema = ({
           getTableColumns(s).chainId!.dataType !== "number" &&
           getTableColumns(s).chainId!.dataType !== "bigint"
         ) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}'.chainId column must be an integer or numeric.`,
           );
         }
@@ -170,14 +170,14 @@ export const buildSchema = ({
           getPrimaryKeyColumns(s).some(({ sql }) => sql === "chain_id") ===
           false
         ) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: '${name}.chain_id' column is required to be in the primary key when ordering is 'isolated'.`,
           );
         }
       }
 
       if (tableNames.has(getTableName(s))) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: table name '${getTableName(s)}' is used multiple times.`,
         );
       } else {
@@ -185,13 +185,13 @@ export const buildSchema = ({
       }
 
       if (getTableConfig(s).primaryKeys.length > 1) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: '${name}' has multiple primary keys.`,
         );
       }
 
       if (getTableConfig(s).primaryKeys.length === 1 && hasPrimaryKey) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: '${name}' has multiple primary keys.`,
         );
       }
@@ -200,25 +200,25 @@ export const buildSchema = ({
         getTableConfig(s).primaryKeys.length === 0 &&
         hasPrimaryKey === false
       ) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: '${name}' has no primary key. Declare one with ".primaryKey()".`,
         );
       }
 
       if (getTableConfig(s).foreignKeys.length > 0) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: '${name}' has a foreign key constraint and foreign key constraints are unsupported.`,
         );
       }
 
       if (getTableConfig(s).checks.length > 0) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: '${name}' has a check constraint and check constraints are unsupported.`,
         );
       }
 
       if (getTableConfig(s).uniqueConstraints.length > 0) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: '${name}' has a unique constraint and unique constraints are unsupported.`,
         );
       }
@@ -227,7 +227,7 @@ export const buildSchema = ({
         // Note: Ponder lets postgres handle the index name length limit and truncation.
 
         if (index.config.name && indexNames.has(index.config.name)) {
-          throw new Error(
+          throw new BuildError(
             `Schema validation failed: index name '${index.config.name}' is used multiple times.`,
           );
         } else if (index.config.name) {
@@ -237,7 +237,7 @@ export const buildSchema = ({
     }
 
     if (is(s, PgSequence)) {
-      throw new Error(
+      throw new BuildError(
         `Schema validation failed: '${name}' is a sequence and sequences are unsupported.`,
       );
     }
@@ -246,7 +246,7 @@ export const buildSchema = ({
       // Note: Ponder lets postgres handle the view name length limit and truncation.
 
       if (viewNames.has(getViewName(s))) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: view name '${getViewName(s)}' is used multiple times.`,
         );
       } else {
@@ -256,19 +256,19 @@ export const buildSchema = ({
       const viewConfig = getViewConfig(s);
 
       if (viewConfig.selectedFields.length === 0) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: view '${getViewName(s)}' has no selected fields.`,
         );
       }
 
       if (viewConfig.isExisting) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: view '${getViewName(s)}' is an existing view and existing views are unsupported.`,
         );
       }
 
       if (viewConfig.query === undefined) {
-        throw new Error(
+        throw new BuildError(
           `Schema validation failed: view '${getViewName(s)}' has no underlying query.`,
         );
       }
@@ -283,7 +283,7 @@ export const buildSchema = ({
             is(column, PgColumn) === false &&
             is(column, SQL.Aliased) === false
           ) {
-            throw new Error(
+            throw new BuildError(
               `Schema validation failed: view '${getViewName(s)}.${columnName}' is a non-column selected field.`,
             );
           }
@@ -295,31 +295,31 @@ export const buildSchema = ({
               column instanceof PgBigSerial53 ||
               column instanceof PgBigSerial64
             ) {
-              throw new Error(
+              throw new BuildError(
                 `Schema validation failed: '${name}.${columnName}' has a serial column and serial columns are unsupported.`,
               );
             }
 
             if (column.isUnique) {
-              throw new Error(
+              throw new BuildError(
                 `Schema validation failed: '${name}.${columnName}' has a unique constraint and unique constraints are unsupported.`,
               );
             }
 
             if (column.generated !== undefined) {
-              throw new Error(
+              throw new BuildError(
                 `Schema validation failed: '${name}.${columnName}' is a generated column and generated columns are unsupported.`,
               );
             }
 
             if (column.generatedIdentity !== undefined) {
-              throw new Error(
+              throw new BuildError(
                 `Schema validation failed: '${name}.${columnName}' is a generated column and generated columns are unsupported.`,
               );
             }
 
             if (columnNames.has((column as PgColumn).name)) {
-              throw new Error(
+              throw new BuildError(
                 `Schema validation failed: '${name}.${(column as PgColumn).name}' column name is used multiple times.`,
               );
             } else {
@@ -331,28 +331,10 @@ export const buildSchema = ({
   }
 
   if (tableNames.size > TABLE_LIMIT) {
-    throw new Error(
+    throw new BuildError(
       `Schema validation failed: the maximum number of tables is ${TABLE_LIMIT}.`,
     );
   }
 
   return { statements };
-};
-
-export const safeBuildSchema = ({
-  schema,
-  preBuild,
-}: { schema: Schema; preBuild: Pick<PreBuild, "ordering"> }) => {
-  try {
-    const result = buildSchema({ schema, preBuild });
-
-    return {
-      status: "success",
-      ...result,
-    } as const;
-  } catch (_error) {
-    const buildError = new BuildError((_error as Error).message);
-    buildError.stack = undefined;
-    return { status: "error", error: buildError } as const;
-  }
 };

--- a/packages/core/src/build/stacktrace.ts
+++ b/packages/core/src/build/stacktrace.ts
@@ -131,7 +131,7 @@ export function parseViteNodeError(file: string, error: Error): ViteNodeError {
   // This can throw with "Cannot set property message of [object Object] which has only a getter"
   try {
     resolvedError.message = `Error while ${verb} ${file}: ${resolvedError.message}`;
-  } catch (e) {}
+  } catch {}
 
   return resolvedError;
 }

--- a/packages/core/src/build/stacktrace.ts
+++ b/packages/core/src/build/stacktrace.ts
@@ -2,15 +2,15 @@ import { readFileSync } from "node:fs";
 import { codeFrameColumns } from "@babel/code-frame";
 import { parse as parseStackTrace } from "stacktrace-parser";
 
-class ESBuildTransformError extends Error {
+export class ESBuildTransformError extends Error {
   override name = "ESBuildTransformError";
 }
 
-class ESBuildBuildError extends Error {
+export class ESBuildBuildError extends Error {
   override name = "ESBuildBuildError";
 }
 
-class ESBuildContextError extends Error {
+export class ESBuildContextError extends Error {
   override name = "ESBuildContextError";
 }
 

--- a/packages/core/src/database/actions.test.ts
+++ b/packages/core/src/database/actions.test.ts
@@ -7,7 +7,6 @@ import {
 import { buildSchema } from "@/build/schema.js";
 import { getReorgTable } from "@/drizzle/kit/index.js";
 import { onchainTable, primaryKey } from "@/drizzle/onchain.js";
-import type { RetryableError } from "@/internal/errors.js";
 import type { IndexingErrorHandler } from "@/internal/types.js";
 import {
   type Checkpoint,
@@ -44,16 +43,16 @@ function createCheckpoint(checkpoint: Partial<Checkpoint>): string {
 }
 
 const indexingErrorHandler: IndexingErrorHandler = {
-  getRetryableError: () => {
+  getError: () => {
     return indexingErrorHandler.error;
   },
-  setRetryableError: (error: RetryableError) => {
+  setError: (error: Error) => {
     indexingErrorHandler.error = error;
   },
-  clearRetryableError: () => {
+  clearError: () => {
     indexingErrorHandler.error = undefined;
   },
-  error: undefined as RetryableError | undefined,
+  error: undefined as Error | undefined,
 };
 
 test("finalize()", async () => {

--- a/packages/core/src/database/index.test.ts
+++ b/packages/core/src/database/index.test.ts
@@ -7,7 +7,6 @@ import {
   onchainView,
   primaryKey,
 } from "@/drizzle/onchain.js";
-import type { RetryableError } from "@/internal/errors.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import type { IndexingErrorHandler } from "@/internal/types.js";
 import {
@@ -55,16 +54,16 @@ function createCheckpoint(checkpoint: Partial<Checkpoint>): string {
 }
 
 const indexingErrorHandler: IndexingErrorHandler = {
-  getRetryableError: () => {
+  getError: () => {
     return indexingErrorHandler.error;
   },
-  setRetryableError: (error: RetryableError) => {
+  setError: (error: Error) => {
     indexingErrorHandler.error = error;
   },
-  clearRetryableError: () => {
+  clearError: () => {
     indexingErrorHandler.error = undefined;
   },
-  error: undefined as RetryableError | undefined,
+  error: undefined as Error | undefined,
 };
 
 test("migrate() succeeds with empty schema", async () => {

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -454,7 +454,9 @@ export const createDatabase = ({
 
           return;
         } catch (_error) {
-          const error = new QueryBuilderError({ cause: _error as Error });
+          const error = new QueryBuilderError(undefined, {
+            cause: _error as Error,
+          });
 
           if (common.shutdown.isKilled) {
             throw new ShutdownError();

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -48,7 +48,7 @@ import {
   dropLiveQueryTriggers,
   dropTriggers,
 } from "./actions.js";
-import { type QB, createQB, parseDbError } from "./queryBuilder.js";
+import { type QB, createQB, parseQBError } from "./queryBuilder.js";
 
 export type Database = {
   driver: PostgresDriver | PGliteDriver;
@@ -454,7 +454,7 @@ export const createDatabase = ({
 
           return;
         } catch (_error) {
-          const error = parseDbError(_error);
+          const error = parseQBError(_error as Error);
 
           if (common.shutdown.isKilled) {
             throw new ShutdownError();

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -8,7 +8,7 @@ import {
 import type { Common } from "@/internal/common.js";
 import {
   MigrationError,
-  NonRetryableUserError,
+  QueryBuilderError,
   ShutdownError,
 } from "@/internal/errors.js";
 import type {
@@ -48,7 +48,7 @@ import {
   dropLiveQueryTriggers,
   dropTriggers,
 } from "./actions.js";
-import { type QB, createQB, parseQBError } from "./queryBuilder.js";
+import { type QB, createQB } from "./queryBuilder.js";
 
 export type Database = {
   driver: PostgresDriver | PGliteDriver;
@@ -454,7 +454,7 @@ export const createDatabase = ({
 
           return;
         } catch (_error) {
-          const error = parseQBError(_error as Error);
+          const error = new QueryBuilderError({ cause: _error as Error });
 
           if (common.shutdown.isKilled) {
             throw new ShutdownError();
@@ -475,14 +475,7 @@ export const createDatabase = ({
             error,
           });
 
-          if (error instanceof NonRetryableUserError) {
-            common.logger.warn({
-              msg: "Failed database query",
-              query: "migrate_sync",
-              error,
-            });
-            throw error;
-          }
+          // TODO(kyle) shouldRetry()
 
           if (i === 9) {
             common.logger.warn({
@@ -540,13 +533,10 @@ export const createDatabase = ({
               );
             }
           } catch (_error) {
-            let error = _error as Error;
-            if (!error.message.includes("already exists")) throw error;
-            error = new MigrationError(
-              `Unable to create table '${namespace.schema}'.'${schemaBuild.statements.tables.json[i]!.tableName}' because a table with that name already exists.`,
+            throw new MigrationError(
+              `Unable to create table '${namespace.schema}'.'${schemaBuild.statements.tables.json[i]!.tableName}'.`,
+              { cause: _error as Error },
             );
-            error.stack = undefined;
-            throw error;
           }
         }
 
@@ -569,13 +559,10 @@ export const createDatabase = ({
               context,
             )
             .catch((_error) => {
-              const error = _error as Error;
-              if (!error.message.includes("already exists")) throw error;
-              const e = new MigrationError(
-                `Unable to create view "${namespace.schema}"."${schemaBuild.statements.views.json[i]!.name}" because a view with that name already exists.`,
+              throw new MigrationError(
+                `Unable to create view "${namespace.schema}"."${schemaBuild.statements.views.json[i]!.name}".`,
+                { cause: _error as Error },
               );
-              e.stack = undefined;
-              throw e;
             });
         }
       };
@@ -588,13 +575,10 @@ export const createDatabase = ({
               context,
             )
             .catch((_error) => {
-              const error = _error as Error;
-              if (!error.message.includes("already exists")) throw error;
-              const e = new MigrationError(
-                `Unable to create enum "${namespace.schema}"."${schemaBuild.statements.enums.json[i]!.name}" because an enum with that name already exists.`,
+              throw new MigrationError(
+                `Unable to create enum "${namespace.schema}"."${schemaBuild.statements.enums.json[i]!.name}".`,
+                { cause: _error as Error },
               );
-              e.stack = undefined;
-              throw e;
             });
         }
       };
@@ -854,11 +838,9 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
 
           // Note: ponder <=0.8 will evaluate this as true because the version is undefined
           if (previousApp.version !== VERSION) {
-            const error = new MigrationError(
+            throw new MigrationError(
               `Schema "${namespace.schema}" was previously used by a Ponder app with a different minor version. Drop the schema first, or use a different schema. Read more: https://ponder.sh/docs/database#database-schema`,
             );
-            error.stack = undefined;
-            throw error;
           }
 
           if (
@@ -866,11 +848,9 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
             (common.options.command === "dev" ||
               previousApp.build_id !== buildId)
           ) {
-            const error = new MigrationError(
+            throw new MigrationError(
               `Schema "${namespace.schema}" was previously used by a different Ponder app. Drop the schema first, or use a different schema. Read more: https://ponder.sh/docs/database#database-schema`,
             );
-            error.stack = undefined;
-            throw error;
           }
 
           const expiry =
@@ -986,11 +966,9 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
 
         result = await tryAcquireLockAndMigrate();
         if (result.status === "locked") {
-          const error = new MigrationError(
+          throw new MigrationError(
             `Failed to acquire lock on schema "${namespace.schema}". A different Ponder app is actively using this schema.`,
           );
-          error.stack = undefined;
-          throw error;
         }
       }
 

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -48,7 +48,7 @@ import {
   dropLiveQueryTriggers,
   dropTriggers,
 } from "./actions.js";
-import { type QB, createQB } from "./queryBuilder.js";
+import { type QB, createQB, shouldRetry } from "./queryBuilder.js";
 
 export type Database = {
   driver: PostgresDriver | PGliteDriver;
@@ -468,14 +468,13 @@ export const createDatabase = ({
             method: "migrate_sync",
           });
 
-          common.logger.warn({
-            msg: "Failed database query",
-            query: "migrate_sync",
-            retry_count: i,
-            error,
-          });
-
-          // TODO(kyle) shouldRetry()
+          if (shouldRetry(error.cause) === false) {
+            common.logger.warn({
+              msg: "Failed database query",
+              query: "migrate_sync",
+              error,
+            });
+          }
 
           if (i === 9) {
             common.logger.warn({

--- a/packages/core/src/database/queryBuilder.test.ts
+++ b/packages/core/src/database/queryBuilder.test.ts
@@ -101,6 +101,13 @@ test("QB transaction retries error", async () => {
   // BEGIN, BEGIN, SELECT, ROLLBACK, BEGIN, SELECT, COMMIT
   expect(querySpy).toHaveBeenCalledTimes(7);
 
+  // unrecognized errors are propagated
+  await expect(
+    qb.transaction({ label: "test1" }, async () => {
+      throw new Error("i'm an error");
+    }),
+  ).rejects.toThrow("i'm an error");
+
   connection.release();
 });
 

--- a/packages/core/src/database/queryBuilder.test.ts
+++ b/packages/core/src/database/queryBuilder.test.ts
@@ -1,5 +1,4 @@
 import { context, setupCommon, setupIsolatedDatabase } from "@/_test/setup.js";
-import { NotNullConstraintError } from "@/internal/errors.js";
 import { createPool } from "@/utils/pg.js";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
@@ -111,7 +110,7 @@ test("QB transaction retries error", async () => {
   connection.release();
 });
 
-test("QB parses error", async () => {
+test.skip("QB parses error", async () => {
   if (context.databaseConfig.kind !== "postgres") return;
 
   const pool = createPool(

--- a/packages/core/src/database/queryBuilder.ts
+++ b/packages/core/src/database/queryBuilder.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import type { Common } from "@/internal/common.js";
 import {
+  BaseError,
   BigIntSerializationError,
   QueryBuilderError,
   ShutdownError,
@@ -545,7 +546,7 @@ export const createQB = <
   return qb;
 };
 
-function shouldRetry(error: Error) {
+export function shouldRetry(error: Error) {
   if (error?.message?.includes("violates not-null constraint")) {
     return false;
   }
@@ -572,6 +573,9 @@ function shouldRetry(error: Error) {
   }
   if (error?.message?.includes("syntax error")) {
     return false;
+  }
+  if (error instanceof BaseError && error.cause) {
+    if (shouldRetry(error.cause) === false) return false;
   }
 
   //  if (

--- a/packages/core/src/database/queryBuilder.ts
+++ b/packages/core/src/database/queryBuilder.ts
@@ -162,15 +162,9 @@ export const createQB = <
 
         return result;
       } catch (_error) {
-        const error = new QueryBuilderError({ cause: _error as Error });
-
-        // TODO(kyle) determine transaction control error?
-        // if (
-        //   isTransaction &&
-        //   error instanceof TransactionStatementError === false &&
-        //   error instanceof TransactionCallbackError === false
-        // ) {
-        // }
+        const error = new QueryBuilderError(undefined, {
+          cause: _error as Error,
+        });
 
         if (common.shutdown.isKilled) {
           throw new ShutdownError();
@@ -208,7 +202,7 @@ export const createQB = <
           });
           // Transaction statements are not immediately retried, so the transaction
           // will be properly rolled back.
-          throw new TransactionStatementError({ cause: error });
+          throw new TransactionStatementError(undefined, { cause: error });
         } else if (error.cause instanceof TransactionCallbackError) {
           // Unrelated errors are bubbled out of the query builder.
           throw error.cause.cause;
@@ -336,7 +330,9 @@ export const createQB = <
                 if (error instanceof TransactionStatementError) {
                   throw error;
                 } else {
-                  throw new TransactionCallbackError({ cause: error as Error });
+                  throw new TransactionCallbackError(undefined, {
+                    cause: error as Error,
+                  });
                 }
               }
             }, config),
@@ -426,7 +422,9 @@ export const createQB = <
                 if (error instanceof TransactionStatementError) {
                   throw error;
                 } else {
-                  throw new TransactionCallbackError({ cause: error as Error });
+                  throw new TransactionCallbackError(undefined, {
+                    cause: error as Error,
+                  });
                 }
               }
             }, config),
@@ -468,7 +466,9 @@ export const createQB = <
               if (error instanceof TransactionStatementError) {
                 throw error;
               } else {
-                throw new TransactionCallbackError({ cause: error as Error });
+                throw new TransactionCallbackError(undefined, {
+                  cause: error as Error,
+                });
               }
             }
           },
@@ -501,7 +501,9 @@ export const createQB = <
               if (error instanceof TransactionStatementError) {
                 throw error;
               } else {
-                throw new TransactionCallbackError({ cause: error as Error });
+                throw new TransactionCallbackError(undefined, {
+                  cause: error as Error,
+                });
               }
             }
           },

--- a/packages/core/src/drizzle/json.ts
+++ b/packages/core/src/drizzle/json.ts
@@ -61,7 +61,7 @@ export class PgJson<
         // bun error message
         error?.message?.includes("cannot serialize BigInt")
       ) {
-        error = new BigIntSerializationError({ cause: error });
+        error = new BigIntSerializationError(undefined, { cause: error });
         (error as BigIntSerializationError).meta.push(
           "Hint:\n  The JSON column type does not support BigInt values. Use the replaceBigInts() helper function before inserting into the database. Docs: https://ponder.sh/docs/api-reference/ponder-utils#replacebigints",
         );
@@ -141,7 +141,7 @@ export class PgJsonb<
         // bun error message
         error?.message?.includes("cannot serialize BigInt")
       ) {
-        error = new BigIntSerializationError({ cause: error });
+        error = new BigIntSerializationError(undefined, { cause: error });
         (error as BigIntSerializationError).meta.push(
           "Hint:\n  The JSONB column type does not support BigInt values. Use the replaceBigInts() helper function before inserting into the database. Docs: https://ponder.sh/docs/api-reference/ponder-utils#replacebigints",
         );

--- a/packages/core/src/drizzle/json.ts
+++ b/packages/core/src/drizzle/json.ts
@@ -1,4 +1,4 @@
-import { type BaseError, BigIntSerializationError } from "@/internal/errors.js";
+import { BigIntSerializationError } from "@/internal/errors.js";
 import { type ColumnBaseConfig, entityKind } from "drizzle-orm";
 import type {
   ColumnBuilderBaseConfig,
@@ -61,8 +61,8 @@ export class PgJson<
         // bun error message
         error?.message?.includes("cannot serialize BigInt")
       ) {
-        error = new BigIntSerializationError(error.message);
-        (error as BaseError).meta.push(
+        error = new BigIntSerializationError({ cause: error });
+        (error as BigIntSerializationError).meta.push(
           "Hint:\n  The JSON column type does not support BigInt values. Use the replaceBigInts() helper function before inserting into the database. Docs: https://ponder.sh/docs/api-reference/ponder-utils#replacebigints",
         );
       }
@@ -135,10 +135,15 @@ export class PgJsonb<
       return JSON.stringify(value);
     } catch (_error) {
       let error = _error as Error;
-      if (error?.message?.includes("Do not know how to serialize a BigInt")) {
-        error = new BigIntSerializationError(error.message);
-        (error as BaseError).meta.push(
-          "Hint:\n  The JSON column type does not support BigInt values. Use the replaceBigInts() helper function before inserting into the database. Docs: https://ponder.sh/docs/api-reference/ponder-utils#replacebigints",
+      if (
+        // node error message
+        error?.message?.includes("Do not know how to serialize a BigInt") ||
+        // bun error message
+        error?.message?.includes("cannot serialize BigInt")
+      ) {
+        error = new BigIntSerializationError({ cause: error });
+        (error as BigIntSerializationError).meta.push(
+          "Hint:\n  The JSONB column type does not support BigInt values. Use the replaceBigInts() helper function before inserting into the database. Docs: https://ponder.sh/docs/api-reference/ponder-utils#replacebigints",
         );
       }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,8 @@ export {
   primaryKey,
   hex,
   bigint,
+  json,
+  jsonb,
 } from "@/drizzle/onchain.js";
 
 export type {
@@ -112,8 +114,6 @@ export {
   inet,
   integer,
   interval,
-  json,
-  jsonb,
   line,
   macaddr,
   macaddr8,

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -285,10 +285,8 @@ export const getCopyHelper = (qb: QB, chainId?: number) => {
         .query(`COPY ${target} FROM '/dev/blob'`, [], {
           blob: new Blob([text]),
         })
-        // Note: `TransactionError` is applied because the query
-        // uses the low-level `$client.query` method.
         .catch((error) => {
-          throw new CopyFlushError(error.message);
+          throw new CopyFlushError(undefined, { cause: error as Error });
         });
     };
   } else {
@@ -307,7 +305,7 @@ export const getCopyHelper = (qb: QB, chainId?: number) => {
         copyStream.write(text);
         copyStream.end();
       }).catch((error) => {
-        throw new CopyFlushError(error.message);
+        throw new CopyFlushError(undefined, { cause: error as Error });
       });
     };
   }
@@ -829,8 +827,9 @@ export const createIndexingCache = ({
             );
 
             if (result.status === "error") {
-              error = new DelayedInsertError(result.error.message);
-              error.stack = undefined;
+              error = new DelayedInsertError(undefined, {
+                cause: result.error as Error,
+              });
 
               addErrorMeta(
                 error,

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -286,7 +286,7 @@ export const getCopyHelper = (qb: QB, chainId?: number) => {
           blob: new Blob([text]),
         })
         .catch((error) => {
-          throw new CopyFlushError(undefined, { cause: error as Error });
+          throw new CopyFlushError({ cause: error as Error });
         });
     };
   } else {
@@ -305,7 +305,7 @@ export const getCopyHelper = (qb: QB, chainId?: number) => {
         copyStream.write(text);
         copyStream.end();
       }).catch((error) => {
-        throw new CopyFlushError(undefined, { cause: error as Error });
+        throw new CopyFlushError({ cause: error as Error });
       });
     };
   }
@@ -755,8 +755,7 @@ export const createIndexingCache = ({
             );
 
             if (result.status === "error") {
-              error = new DelayedInsertError(result.error.message);
-              error.stack = undefined;
+              error = new DelayedInsertError({ cause: result.error as Error });
 
               addErrorMeta(
                 error,
@@ -827,9 +826,7 @@ export const createIndexingCache = ({
             );
 
             if (result.status === "error") {
-              error = new DelayedInsertError(undefined, {
-                cause: result.error as Error,
-              });
+              error = new DelayedInsertError({ cause: result.error as Error });
 
               addErrorMeta(
                 error,

--- a/packages/core/src/indexing-store/index.test.ts
+++ b/packages/core/src/indexing-store/index.test.ts
@@ -572,7 +572,8 @@ test("sql", async () => {
         .values({
           address: "0x0000000000000000000000000000000000000001",
           balance: undefined,
-        }),
+        })
+        .then((res) => res),
     ).rejects.toThrow(RawSqlError);
 
     // TODO(kyle) check constraint
@@ -584,7 +585,8 @@ test("sql", async () => {
     await expect(
       indexingStore.db.sql
         .insert(schema.account)
-        .values({ address: zeroAddress, balance: 10n }),
+        .values({ address: zeroAddress, balance: 10n })
+        .then((res) => res),
     ).rejects.toThrow(RawSqlError);
   });
 });

--- a/packages/core/src/indexing-store/index.test.ts
+++ b/packages/core/src/indexing-store/index.test.ts
@@ -10,9 +10,8 @@ import { getRejectionValue } from "@/_test/utils.js";
 import { onchainEnum, onchainTable } from "@/drizzle/onchain.js";
 import {
   BigIntSerializationError,
-  NonRetryableUserError,
+  IndexingDBError,
   RawSqlError,
-  type RetryableError,
 } from "@/internal/errors.js";
 import type { IndexingErrorHandler } from "@/internal/types.js";
 import { eq } from "drizzle-orm";
@@ -27,16 +26,16 @@ beforeEach(setupIsolatedDatabase);
 beforeEach(setupCleanup);
 
 const indexingErrorHandler: IndexingErrorHandler = {
-  getRetryableError: () => {
+  getError: () => {
     return indexingErrorHandler.error;
   },
-  setRetryableError: (error: RetryableError) => {
+  setError: (error: Error) => {
     indexingErrorHandler.error = error;
   },
-  clearRetryableError: () => {
+  clearError: () => {
     indexingErrorHandler.error = undefined;
   },
-  error: undefined as RetryableError | undefined,
+  error: undefined as Error | undefined,
 };
 
 test("find", async () => {
@@ -415,7 +414,7 @@ test("update throw error when primary key is updated", async () => {
       .set({ address: ALICE })
       .catch((error) => error);
 
-    expect(error).toBeInstanceOf(NonRetryableUserError);
+    expect(error).toBeInstanceOf(IndexingDBError);
 
     // function
 
@@ -424,7 +423,7 @@ test("update throw error when primary key is updated", async () => {
       .set(() => ({ address: ALICE }))
       .catch((error) => error);
 
-    expect(error).toBeInstanceOf(NonRetryableUserError);
+    expect(error).toBeInstanceOf(IndexingDBError);
 
     // update same primary key no function
     let row: any = await indexingStore.db
@@ -566,16 +565,15 @@ test("sql", async () => {
 
     await tx.wrap((db) => db.execute("SAVEPOINT test"));
 
-    expect(
-      await getRejectionValue(
-        async () =>
-          // @ts-ignore
-          await indexingStore.db.sql.insert(schema.account).values({
-            address: "0x0000000000000000000000000000000000000001",
-            balance: undefined,
-          }),
-      ),
-    ).toBeInstanceOf(RawSqlError);
+    await expect(
+      // @ts-ignore
+      indexingStore.db.sql
+        .insert(schema.account)
+        .values({
+          address: "0x0000000000000000000000000000000000000001",
+          balance: undefined,
+        }),
+    ).rejects.toThrow(RawSqlError);
 
     // TODO(kyle) check constraint
 
@@ -583,14 +581,11 @@ test("sql", async () => {
 
     await tx.wrap((db) => db.execute("ROLLBACK TO test"));
 
-    expect(
-      await getRejectionValue(
-        async () =>
-          await indexingStore.db.sql
-            .insert(schema.account)
-            .values({ address: zeroAddress, balance: 10n }),
-      ),
-    ).toBeInstanceOf(RawSqlError);
+    await expect(
+      indexingStore.db.sql
+        .insert(schema.account)
+        .values({ address: zeroAddress, balance: 10n }),
+    ).rejects.toThrow(RawSqlError);
   });
 });
 

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -2,7 +2,6 @@ import type { QB } from "@/database/queryBuilder.js";
 import { onchain } from "@/drizzle/onchain.js";
 import type { Common } from "@/internal/common.js";
 import {
-  DbConnectionError,
   InvalidStoreAccessError,
   InvalidStoreMethodError,
   NonRetryableUserError,
@@ -604,11 +603,7 @@ export const createIndexingStore = ({
               return result;
             });
           } catch (error) {
-            if (error instanceof DbConnectionError) {
-              throw error;
-            }
-
-            throw new RawSqlError((error as Error).message);
+            throw new RawSqlError(undefined, { cause: error as Error });
           } finally {
             common.metrics.ponder_indexing_store_raw_sql_duration.observe(
               endClock(),

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -595,7 +595,7 @@ export const createIndexingStore = ({
               return result;
             });
           } catch (error) {
-            throw new RawSqlError({ cause: error as Error });
+            throw new RawSqlError(undefined, { cause: error as Error });
           } finally {
             common.metrics.ponder_indexing_store_raw_sql_duration.observe(
               endClock(),

--- a/packages/core/src/indexing/client.ts
+++ b/packages/core/src/indexing/client.ts
@@ -1032,7 +1032,7 @@ export const cachedTransport =
               functionName: "aggregate3",
               result: resultsToEncode,
             });
-          } catch (e) {
+          } catch {
             return encodeFunctionResult({
               abi: multicall3Abi,
               functionName: "aggregate3",

--- a/packages/core/src/indexing/index.test.ts
+++ b/packages/core/src/indexing/index.test.ts
@@ -18,10 +18,7 @@ import { onchainTable } from "@/drizzle/onchain.js";
 import { createIndexingCache } from "@/indexing-store/cache.js";
 import { createIndexingStore } from "@/indexing-store/index.js";
 import { createCachedViemClient } from "@/indexing/client.js";
-import {
-  InvalidEventAccessError,
-  type RetryableError,
-} from "@/internal/errors.js";
+import { InvalidEventAccessError } from "@/internal/errors.js";
 import type { IndexingErrorHandler } from "@/internal/types.js";
 import { createRpc } from "@/rpc/index.js";
 import { parseEther, toHex, zeroAddress } from "viem";
@@ -47,16 +44,16 @@ const account = onchainTable("account", (p) => ({
 const schema = { account };
 
 const indexingErrorHandler: IndexingErrorHandler = {
-  getRetryableError: () => {
+  getError: () => {
     return indexingErrorHandler.error;
   },
-  setRetryableError: (error: RetryableError) => {
+  setError: (error: Error) => {
     indexingErrorHandler.error = error;
   },
-  clearRetryableError: () => {
+  clearError: () => {
     indexingErrorHandler.error = undefined;
   },
-  error: undefined as RetryableError | undefined,
+  error: undefined as Error | undefined,
 };
 
 test("createIndexing()", async () => {

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -4,7 +4,6 @@ import type { IndexingStore } from "@/indexing-store/index.js";
 import type { CachedViemClient } from "@/indexing/client.js";
 import type { Common } from "@/internal/common.js";
 import {
-  BaseError,
   IndexingFunctionError,
   InvalidEventAccessError,
   ShutdownError,
@@ -256,11 +255,7 @@ export const createIndexing = ({
 
       common.metrics.hasError = true;
 
-      if (error instanceof BaseError === false) {
-        error = new IndexingFunctionError(error.message);
-      }
-
-      throw error;
+      throw new IndexingFunctionError(undefined, { cause: error as Error });
     }
   };
 
@@ -332,11 +327,7 @@ export const createIndexing = ({
 
       common.metrics.hasError = true;
 
-      if (error instanceof BaseError === false) {
-        error = new IndexingFunctionError(error.message);
-      }
-
-      throw error;
+      throw new IndexingFunctionError(undefined, { cause: error as Error });
     }
   };
 

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -234,12 +234,14 @@ export const createIndexing = ({
 
       let error: IndexingFunctionError<Error>;
       if (indexingErrorHandler.getError()) {
-        error = new IndexingFunctionError({
+        error = new IndexingFunctionError(undefined, {
           cause: indexingErrorHandler.getError()!,
         });
         indexingErrorHandler.clearError();
       } else {
-        error = new IndexingFunctionError({ cause: _error as Error });
+        error = new IndexingFunctionError(undefined, {
+          cause: _error as Error,
+        });
       }
 
       // Copy the stack from the inner error.
@@ -259,7 +261,7 @@ export const createIndexing = ({
 
       common.metrics.hasError = true;
 
-      throw new IndexingFunctionError({ cause: error as Error });
+      throw new IndexingFunctionError(undefined, { cause: error as Error });
     }
   };
 
@@ -305,12 +307,14 @@ export const createIndexing = ({
 
       let error: IndexingFunctionError<Error>;
       if (indexingErrorHandler.getError()) {
-        error = new IndexingFunctionError({
+        error = new IndexingFunctionError(undefined, {
           cause: indexingErrorHandler.getError()!,
         });
         indexingErrorHandler.clearError();
       } else {
-        error = new IndexingFunctionError({ cause: _error as Error });
+        error = new IndexingFunctionError(undefined, {
+          cause: _error as Error,
+        });
       }
 
       if (error.cause instanceof InvalidEventAccessError) {

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -211,13 +211,13 @@ export const createIndexing = ({
 
       await event.setupCallback.fn(indexingFunctionArg);
 
-      // Note: Check `getRetryableError` to handle user-code catching errors
+      // Note: Check `getError` to handle user-code catching errors
       // from the indexing store.
 
-      if (indexingErrorHandler.getRetryableError()) {
-        const retryableError = indexingErrorHandler.getRetryableError()!;
-        indexingErrorHandler.clearRetryableError();
-        throw retryableError;
+      if (indexingErrorHandler.getError()) {
+        const error = indexingErrorHandler.getError()!;
+        indexingErrorHandler.clearError();
+        throw error;
       }
 
       common.metrics.ponder_indexing_function_duration.observe(
@@ -225,21 +225,25 @@ export const createIndexing = ({
         endClock(),
       );
     } catch (_error) {
-      let error = _error instanceof Error ? _error : new Error(String(_error));
-
-      // Note: Use `getRetryableError` rather than `error` to avoid
-      // issues with the user-code augmenting errors from the indexing store.
-
-      if (indexingErrorHandler.getRetryableError()) {
-        const retryableError = indexingErrorHandler.getRetryableError()!;
-        indexingErrorHandler.clearRetryableError();
-        error = retryableError;
-      }
-
       if (common.shutdown.isKilled) {
         throw new ShutdownError();
       }
 
+      // Note: Use `getError` rather than `error` to avoid
+      // issues with the user-code augmenting errors from the indexing store.
+
+      let error: IndexingFunctionError<Error>;
+      if (indexingErrorHandler.getError()) {
+        error = new IndexingFunctionError({
+          cause: indexingErrorHandler.getError()!,
+        });
+        indexingErrorHandler.clearError();
+      } else {
+        error = new IndexingFunctionError({ cause: _error as Error });
+      }
+
+      // Copy the stack from the inner error.
+      error.stack = error.cause.stack;
       addStackTrace(error, common.options);
       addErrorMeta(error, toErrorMeta(event));
 
@@ -255,7 +259,7 @@ export const createIndexing = ({
 
       common.metrics.hasError = true;
 
-      throw new IndexingFunctionError(undefined, { cause: error as Error });
+      throw new IndexingFunctionError({ cause: error as Error });
     }
   };
 
@@ -278,39 +282,43 @@ export const createIndexing = ({
 
       await event.eventCallback.fn(indexingFunctionArg);
 
+      // Note: Check `getError` to handle user-code catching errors
+      // from the indexing store.
+
+      if (indexingErrorHandler.getError()) {
+        const error = indexingErrorHandler.getError()!;
+        indexingErrorHandler.clearError();
+        throw error;
+      }
+
       common.metrics.ponder_indexing_function_duration.observe(
         metricLabels[event.eventCallback.name]!,
         endClock(),
       );
-
-      // Note: Check `getRetryableError` to handle user-code catching errors
-      // from the indexing store.
-
-      if (indexingErrorHandler.getRetryableError()) {
-        const retryableError = indexingErrorHandler.getRetryableError()!;
-        indexingErrorHandler.clearRetryableError();
-        throw retryableError;
-      }
     } catch (_error) {
-      let error = _error instanceof Error ? _error : new Error(String(_error));
-
-      // Note: Use `getRetryableError` rather than `error` to avoid
-      // issues with the user-code augmenting errors from the indexing store.
-
-      if (indexingErrorHandler.getRetryableError()) {
-        const retryableError = indexingErrorHandler.getRetryableError()!;
-        indexingErrorHandler.clearRetryableError();
-        error = retryableError;
-      }
-
       if (common.shutdown.isKilled) {
         throw new ShutdownError();
       }
 
-      if (error instanceof InvalidEventAccessError) {
-        throw error;
+      // Note: Use `getError` rather than `error` to avoid
+      // issues with the user-code augmenting errors from the indexing store.
+
+      let error: IndexingFunctionError<Error>;
+      if (indexingErrorHandler.getError()) {
+        error = new IndexingFunctionError({
+          cause: indexingErrorHandler.getError()!,
+        });
+        indexingErrorHandler.clearError();
+      } else {
+        error = new IndexingFunctionError({ cause: _error as Error });
       }
 
+      if (error.cause instanceof InvalidEventAccessError) {
+        throw error.cause;
+      }
+
+      // Copy the stack from the inner error.
+      error.stack = error.cause.stack;
       addStackTrace(error, common.options);
       addErrorMeta(error, toErrorMeta(event));
 
@@ -327,7 +335,7 @@ export const createIndexing = ({
 
       common.metrics.hasError = true;
 
-      throw new IndexingFunctionError(undefined, { cause: error as Error });
+      throw error;
     }
   };
 
@@ -776,7 +784,7 @@ export const createEventProxy = <
           resetFilterInclude(eventName);
           // @ts-expect-error
           const error = new InvalidEventAccessError(`${type}.${prop}`);
-          indexingErrorHandler.setRetryableError(error);
+          indexingErrorHandler.setError(error);
           throw error;
         }
 
@@ -808,7 +816,7 @@ export const createEventProxy = <
           resetFilterInclude(eventName);
           // @ts-expect-error
           const error = new InvalidEventAccessError(`${type}.${prop}`);
-          indexingErrorHandler.setRetryableError(error);
+          indexingErrorHandler.setError(error);
           throw error;
         }
 
@@ -833,7 +841,7 @@ export const createEventProxy = <
           resetFilterInclude(eventName);
           // @ts-expect-error
           const error = new InvalidEventAccessError(`${type}.${prop}`);
-          indexingErrorHandler.setRetryableError(error);
+          indexingErrorHandler.setError(error);
           throw error;
         }
 

--- a/packages/core/src/internal/errors.ts
+++ b/packages/core/src/internal/errors.ts
@@ -36,6 +36,17 @@ export class BuildError<
   }
 }
 
+export class ExecuteFileError<
+  cause extends Error | undefined = undefined,
+> extends BaseError<cause> {
+  override name = "ExecuteFileError";
+
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
+    Object.setPrototypeOf(this, ExecuteFileError.prototype);
+  }
+}
+
 export class RpcRequestError<
   cause extends Error | undefined = undefined,
 > extends BaseError<cause> {
@@ -247,6 +258,7 @@ export class MigrationError<
  */
 export function isUserDerivedError(error: BaseError): boolean {
   if (error instanceof BuildError) return true;
+  if (error instanceof ExecuteFileError) return true;
   if (error instanceof IndexingDBError) return true;
   if (error instanceof DelayedInsertError) return true;
   if (

--- a/packages/core/src/internal/errors.ts
+++ b/packages/core/src/internal/errors.ts
@@ -1,8 +1,3 @@
-import {
-  ESBuildBuildError,
-  ESBuildContextError,
-  ESBuildTransformError,
-} from "@/build/stacktrace.js";
 import type { getLogsRetryHelper } from "@ponder/utils";
 
 /** Base class for all known errors. */
@@ -264,23 +259,5 @@ export function isUserDerivedError(error: BaseError): boolean {
   if (error instanceof BaseError && error.cause) {
     if (isUserDerivedError(error.cause)) return true;
   }
-  return false;
-}
-
-export function stripErrorStack(error: Error): void {
-  if (shouldPrintErrorStack(error) === false) {
-    error.stack = undefined;
-  }
-  if (error instanceof BaseError && error.cause) {
-    stripErrorStack(error.cause);
-  }
-}
-
-export function shouldPrintErrorStack(error: Error): boolean {
-  if (error instanceof ServerError) return true;
-  if (error instanceof IndexingFunctionError) return true;
-  if (error instanceof ESBuildTransformError) return true;
-  if (error instanceof ESBuildBuildError) return true;
-  if (error instanceof ESBuildContextError) return true;
   return false;
 }

--- a/packages/core/src/internal/errors.ts
+++ b/packages/core/src/internal/errors.ts
@@ -115,14 +115,14 @@ export class DbConnectionError extends RetryableError {
   }
 }
 
-export class TransactionStatementError extends RetryableError {
-  override name = "TransactionStatementError";
+// export class TransactionStatementError extends RetryableError {
+//   override name = "TransactionStatementError";
 
-  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
-    super(message, { cause });
-    Object.setPrototypeOf(this, TransactionStatementError.prototype);
-  }
-}
+//   constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+//     super(message, { cause });
+//     Object.setPrototypeOf(this, TransactionStatementError.prototype);
+//   }
+// }
 
 export class CopyFlushError extends RetryableError {
   override name = "CopyFlushError";
@@ -201,12 +201,67 @@ export class IndexingFunctionError extends NonRetryableUserError {
   }
 }
 
-export class RpcProviderError extends BaseError {
-  override name = "RpcProviderError";
+/**
+ * @dev All JSON-RPC request errors are retryable.
+ */
+export class RpcRequestError<
+  cause extends Error | undefined = undefined,
+> extends RetryableError {
+  override name = "RpcRequestError";
+  override cause: cause;
+
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
+    // @ts-ignore
+    this.cause = cause;
+    Object.setPrototypeOf(this, RpcRequestError.prototype);
+  }
+}
+
+export class QueryBuilderRetryableError extends RetryableError {
+  override name = "QueryBuilderRetryableError";
 
   constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
     super(message, { cause });
-    Object.setPrototypeOf(this, RpcProviderError.prototype);
+    Object.setPrototypeOf(this, QueryBuilderRetryableError.prototype);
+  }
+}
+
+export class QueryBuilderNonRetryableError extends NonRetryableUserError {
+  override name = "QueryBuilderNonRetryableError";
+
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
+    Object.setPrototypeOf(this, QueryBuilderNonRetryableError.prototype);
+  }
+}
+
+export class TransactionControlError extends QueryBuilderRetryableError {
+  override name = "TransactionControlError";
+
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
+    Object.setPrototypeOf(this, TransactionControlError.prototype);
+  }
+}
+
+export class TransactionStatementError extends QueryBuilderRetryableError {
+  override name = "TransactionStatementError";
+
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
+    Object.setPrototypeOf(this, TransactionStatementError.prototype);
+  }
+}
+
+export class TransactionCallbackError extends QueryBuilderRetryableError {
+  override name = "TransactionCallbackError";
+  override cause: Error;
+
+  constructor({ cause }: { cause: Error }) {
+    super(undefined, { cause });
+    this.cause = cause;
+    Object.setPrototypeOf(this, TransactionCallbackError.prototype);
   }
 }
 

--- a/packages/core/src/internal/errors.ts
+++ b/packages/core/src/internal/errors.ts
@@ -92,8 +92,8 @@ export class QueryBuilderError<
 > extends BaseError<cause> {
   override name = "QueryBuilderError";
 
-  constructor({ cause }: { cause?: cause } = {}) {
-    super(undefined, { cause });
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, QueryBuilderError.prototype);
   }
 }
@@ -107,8 +107,8 @@ export class TransactionStatementError<
 > extends BaseError<cause> {
   override name = "TransactionStatementError";
 
-  constructor({ cause }: { cause?: cause } = {}) {
-    super(undefined, { cause });
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, TransactionStatementError.prototype);
   }
 }
@@ -121,20 +121,9 @@ export class TransactionCallbackError<
 > extends BaseError<cause> {
   override name = "TransactionCallbackError";
 
-  constructor({ cause }: { cause: cause }) {
-    super(undefined, { cause });
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, TransactionCallbackError.prototype);
-  }
-}
-
-export class CopyFlushError<
-  cause extends Error | undefined = undefined,
-> extends BaseError<cause> {
-  override name = "CopyFlushError";
-
-  constructor({ cause }: { cause?: cause } = {}) {
-    super(undefined, { cause });
-    Object.setPrototypeOf(this, CopyFlushError.prototype);
   }
 }
 
@@ -143,8 +132,8 @@ export class DelayedInsertError<
 > extends BaseError<cause> {
   override name = "DelayedInsertError";
 
-  constructor({ cause }: { cause?: cause } = {}) {
-    super(undefined, { cause });
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, DelayedInsertError.prototype);
   }
 }
@@ -165,8 +154,8 @@ export class RawSqlError<
 > extends BaseError<cause> {
   override name = "RawSqlError";
 
-  constructor({ cause }: { cause?: cause } = {}) {
-    super(undefined, { cause });
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, RawSqlError.prototype);
   }
 }
@@ -176,8 +165,8 @@ export class BigIntSerializationError<
 > extends BaseError<cause> {
   override name = "BigIntSerializationError";
 
-  constructor({ cause }: { cause?: cause } = {}) {
-    super(undefined, { cause });
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, BigIntSerializationError.prototype);
   }
 }
@@ -190,8 +179,8 @@ export class ServerError<
 > extends BaseError<cause> {
   override name = "ServerError";
 
-  constructor({ cause }: { cause?: cause } = {}) {
-    super(undefined, { cause });
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, ServerError.prototype);
   }
 }
@@ -204,8 +193,8 @@ export class IndexingFunctionError<
 > extends BaseError<cause> {
   override name = "IndexingFunctionError";
 
-  constructor({ cause }: { cause?: cause } = {}) {
-    super(undefined, { cause });
+  constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, IndexingFunctionError.prototype);
   }
 }
@@ -228,7 +217,6 @@ export class MigrationError<
   cause extends Error | undefined = undefined,
 > extends BaseError<cause> {
   override name = "MigrationError";
-  // TODO(kyle) exit code
 
   constructor(message?: string | undefined, { cause }: { cause?: cause } = {}) {
     super(message, { cause });
@@ -236,39 +224,23 @@ export class MigrationError<
   }
 }
 
-// export const nonRetryableUserErrorNames = [
-//   ShutdownError,
-//   BuildError,
-//   MigrationError,
-//   UniqueConstraintError,
-//   NotNullConstraintError,
-//   InvalidStoreAccessError,
-//   RecordNotFoundError,
-//   CheckConstraintError,
-//   InvalidStoreMethodError,
-//   UndefinedTableError,
-//   BigIntSerializationError,
-//   DelayedInsertError,
-//   RawSqlError,
-//   IndexingFunctionError,
-// ].map((err) => err.name);
-
 /**
  * Returns true if the error is derived from a logical error in user code.
+ * @dev `instanceof` is not used because it doesn't work with serialized errors
+ * from threads.
  */
 export function isUserDerivedError(error: BaseError): boolean {
-  if (error instanceof BuildError) return true;
-  if (error instanceof ExecuteFileError) return true;
-  if (error instanceof IndexingDBError) return true;
-  if (error instanceof DelayedInsertError) return true;
-  if (
-    error instanceof IndexingFunctionError &&
-    error.cause instanceof BaseError === false
-  ) {
-    return true;
-  }
+  if (error.name === BuildError.name) return true;
+  if (error.name === ExecuteFileError.name) return true;
+  if (error.name === MigrationError.name) return true;
+  if (error.name === IndexingDBError.name) return true;
+  if (error.name === BigIntSerializationError.name) return true;
+  if (error.name === RawSqlError.name) return true;
+  if (error.name === DelayedInsertError.name) return true;
+  if (error.name === IndexingFunctionError.name) return true;
 
-  if (error instanceof BaseError && error.cause) {
+  if ("cause" in error) {
+    // @ts-ignore
     if (isUserDerivedError(error.cause)) return true;
   }
   return false;

--- a/packages/core/src/internal/errors.ts
+++ b/packages/core/src/internal/errors.ts
@@ -33,8 +33,8 @@ export class RetryableError extends BaseError {
 export class ShutdownError extends NonRetryableUserError {
   override name = "ShutdownError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, ShutdownError.prototype);
   }
 }
@@ -42,8 +42,8 @@ export class ShutdownError extends NonRetryableUserError {
 export class BuildError extends NonRetryableUserError {
   override name = "BuildError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, BuildError.prototype);
   }
 }
@@ -51,8 +51,8 @@ export class BuildError extends NonRetryableUserError {
 export class MigrationError extends NonRetryableUserError {
   override name = "MigrationError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, MigrationError.prototype);
   }
 }
@@ -62,8 +62,8 @@ export class MigrationError extends NonRetryableUserError {
 export class UniqueConstraintError extends NonRetryableUserError {
   override name = "UniqueConstraintError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, UniqueConstraintError.prototype);
   }
 }
@@ -71,8 +71,8 @@ export class UniqueConstraintError extends NonRetryableUserError {
 export class NotNullConstraintError extends NonRetryableUserError {
   override name = "NotNullConstraintError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, NotNullConstraintError.prototype);
   }
 }
@@ -80,8 +80,8 @@ export class NotNullConstraintError extends NonRetryableUserError {
 export class InvalidStoreAccessError extends NonRetryableUserError {
   override name = "InvalidStoreAccessError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, InvalidStoreAccessError.prototype);
   }
 }
@@ -89,8 +89,8 @@ export class InvalidStoreAccessError extends NonRetryableUserError {
 export class RecordNotFoundError extends NonRetryableUserError {
   override name = "RecordNotFoundError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, RecordNotFoundError.prototype);
   }
 }
@@ -98,8 +98,8 @@ export class RecordNotFoundError extends NonRetryableUserError {
 export class CheckConstraintError extends NonRetryableUserError {
   override name = "CheckConstraintError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, CheckConstraintError.prototype);
   }
 }
@@ -109,8 +109,8 @@ export class CheckConstraintError extends NonRetryableUserError {
 export class DbConnectionError extends RetryableError {
   override name = "DbConnectionError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, DbConnectionError.prototype);
   }
 }
@@ -118,8 +118,8 @@ export class DbConnectionError extends RetryableError {
 export class TransactionStatementError extends RetryableError {
   override name = "TransactionStatementError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, TransactionStatementError.prototype);
   }
 }
@@ -127,8 +127,8 @@ export class TransactionStatementError extends RetryableError {
 export class CopyFlushError extends RetryableError {
   override name = "CopyFlushError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, CopyFlushError.prototype);
   }
 }
@@ -150,8 +150,8 @@ export class InvalidEventAccessError extends RetryableError {
 export class InvalidStoreMethodError extends NonRetryableUserError {
   override name = "InvalidStoreMethodError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, InvalidStoreMethodError.prototype);
   }
 }
@@ -159,8 +159,8 @@ export class InvalidStoreMethodError extends NonRetryableUserError {
 export class UndefinedTableError extends NonRetryableUserError {
   override name = "UndefinedTableError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, UndefinedTableError.prototype);
   }
 }
@@ -168,8 +168,8 @@ export class UndefinedTableError extends NonRetryableUserError {
 export class BigIntSerializationError extends NonRetryableUserError {
   override name = "BigIntSerializationError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, BigIntSerializationError.prototype);
   }
 }
@@ -177,8 +177,8 @@ export class BigIntSerializationError extends NonRetryableUserError {
 export class DelayedInsertError extends NonRetryableUserError {
   override name = "DelayedInsertError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, DelayedInsertError.prototype);
   }
 }
@@ -186,8 +186,8 @@ export class DelayedInsertError extends NonRetryableUserError {
 export class RawSqlError extends NonRetryableUserError {
   override name = "RawSqlError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, RawSqlError.prototype);
   }
 }
@@ -195,8 +195,8 @@ export class RawSqlError extends NonRetryableUserError {
 export class IndexingFunctionError extends NonRetryableUserError {
   override name = "IndexingFunctionError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, IndexingFunctionError.prototype);
   }
 }
@@ -204,8 +204,8 @@ export class IndexingFunctionError extends NonRetryableUserError {
 export class RpcProviderError extends BaseError {
   override name = "RpcProviderError";
 
-  constructor(message?: string | undefined) {
-    super(message);
+  constructor(message?: string | undefined, { cause }: { cause?: Error } = {}) {
+    super(message, { cause });
     Object.setPrototypeOf(this, RpcProviderError.prototype);
   }
 }

--- a/packages/core/src/internal/logger.ts
+++ b/packages/core/src/internal/logger.ts
@@ -2,6 +2,7 @@ import type { Prettify } from "@/types/utils.js";
 import { formatEta } from "@/utils/format.js";
 import pc from "picocolors";
 import { type DestinationStream, type LevelWithSilent, pino } from "pino";
+import { NonRetryableUserError } from "./errors.js";
 
 export type LogMode = "pretty" | "json";
 export type LogLevel = Prettify<LevelWithSilent>;
@@ -235,7 +236,7 @@ const format = (log: Log) => {
   }
 
   if (log.error) {
-    if (log.error.stack) {
+    if (log.error.stack && log.error instanceof NonRetryableUserError) {
       prettyLog.push(log.error.stack);
     } else {
       prettyLog.push(`${log.error.name}: ${log.error.message}`);

--- a/packages/core/src/internal/logger.ts
+++ b/packages/core/src/internal/logger.ts
@@ -85,6 +85,7 @@ export function createLogger({
         }
         if (options.error && options.error instanceof Error) {
           stripErrorStack(options.error);
+          populateErrorMessageAndStack;
         }
         logger.error(options);
       },
@@ -98,7 +99,9 @@ export function createLogger({
         }
         if (options.error && options.error instanceof Error) {
           stripErrorStack(options.error);
+          populateErrorMessageAndStack(options.error);
         }
+
         logger.warn(options);
       },
       info<T extends Omit<Log, "level" | "time">>(
@@ -111,6 +114,7 @@ export function createLogger({
         }
         if (options.error && options.error instanceof Error) {
           stripErrorStack(options.error);
+          populateErrorMessageAndStack;
         }
         logger.info(options);
       },
@@ -124,6 +128,7 @@ export function createLogger({
         }
         if (options.error && options.error instanceof Error) {
           stripErrorStack(options.error);
+          populateErrorMessageAndStack;
         }
 
         logger.debug(options);
@@ -138,6 +143,7 @@ export function createLogger({
         }
         if (options.error && options.error instanceof Error) {
           stripErrorStack(options.error);
+          populateErrorMessageAndStack;
         }
         logger.trace(options);
       },
@@ -280,6 +286,18 @@ function stripErrorStack(error: Error): void {
   }
   if (error instanceof BaseError && error.cause) {
     stripErrorStack(error.cause);
+  }
+}
+
+function populateErrorMessageAndStack(error: Error): void {
+  if (error.message === undefined || error.message === "") {
+    error.message = error.name;
+  }
+  if (error.stack === undefined) {
+    error.stack = error.message;
+  }
+  if (error instanceof BaseError && error.cause) {
+    populateErrorMessageAndStack(error.cause);
   }
 }
 

--- a/packages/core/src/internal/logger.ts
+++ b/packages/core/src/internal/logger.ts
@@ -7,7 +7,12 @@ import type { Prettify } from "@/types/utils.js";
 import { formatEta } from "@/utils/format.js";
 import pc from "picocolors";
 import { type DestinationStream, type LevelWithSilent, pino } from "pino";
-import { BaseError, IndexingFunctionError, ServerError } from "./errors.js";
+import {
+  BaseError,
+  ExecuteFileError,
+  IndexingFunctionError,
+  ServerError,
+} from "./errors.js";
 
 export type LogMode = "pretty" | "json";
 export type LogLevel = Prettify<LevelWithSilent>;
@@ -304,6 +309,7 @@ function populateErrorMessageAndStack(error: Error): void {
 function shouldPrintErrorStack(error: Error): boolean {
   if (error instanceof ServerError) return true;
   if (error instanceof IndexingFunctionError) return true;
+  if (error instanceof ExecuteFileError) return true;
   if (error instanceof ESBuildTransformError) return true;
   if (error instanceof ESBuildBuildError) return true;
   if (error instanceof ESBuildContextError) return true;

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -29,7 +29,6 @@ import type {
   Chain as ViemChain,
   Log as ViemLog,
 } from "viem";
-import type { RetryableError } from "./errors.js";
 
 // Database
 
@@ -388,11 +387,14 @@ export type Status = {
 
 // Indexing error handler
 
+/**
+ * Object to prevent user code from swallowing internal ponder errors.
+ */
 export type IndexingErrorHandler = {
-  getRetryableError: () => RetryableError | undefined;
-  setRetryableError: (error: RetryableError) => void;
-  clearRetryableError: () => void;
-  error: RetryableError | undefined;
+  getError: () => Error | undefined;
+  setError: (error: Error) => void;
+  clearError: () => void;
+  error: Error | undefined;
 };
 
 // Seconds

--- a/packages/core/src/rpc/actions.ts
+++ b/packages/core/src/rpc/actions.ts
@@ -1,4 +1,4 @@
-import { RpcProviderError } from "@/internal/errors.js";
+import { RpcRequestError } from "@/internal/errors.js";
 import type {
   LightBlock,
   SyncBlock,
@@ -320,7 +320,7 @@ export const validateTransactionsAndBlock = (
 ) => {
   for (const [index, transaction] of block.transactions.entries()) {
     if (block.hash !== transaction.blockHash) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The transaction at index ${index} of the 'block.transactions' array has a 'transaction.blockHash' of ${transaction.blockHash}, but the block itself has a 'block.hash' of ${block.hash}.`,
       );
       error.meta = [
@@ -331,7 +331,7 @@ export const validateTransactionsAndBlock = (
     }
 
     if (block.number !== transaction.blockNumber) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The transaction at index ${index} of the 'block.transactions' array has a 'transaction.blockNumber' of ${transaction.blockNumber} (${hexToNumber(transaction.blockNumber)}), but the block itself has a 'block.number' of ${block.number} (${hexToNumber(block.number)}).`,
       );
       error.meta = [
@@ -359,7 +359,7 @@ export const validateLogsAndBlock = (
   >,
 ) => {
   if (block.logsBloom !== zeroLogsBloom && logs.length === 0) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       `Inconsistent RPC response data. The logs array has length 0, but the associated block has a non-empty 'block.logsBloom'.`,
     );
     error.meta = [
@@ -379,7 +379,7 @@ export const validateLogsAndBlock = (
 
   for (const log of logs) {
     if (block.hash !== log.blockHash) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The log with 'logIndex' ${log.logIndex} (${hexToNumber(log.logIndex)}) has a 'log.blockHash' of ${log.blockHash}, but the associated block has a 'block.hash' of ${block.hash}.`,
       );
       error.meta = [
@@ -391,7 +391,7 @@ export const validateLogsAndBlock = (
     }
 
     if (block.number !== log.blockNumber) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The log with 'logIndex' ${log.logIndex} (${hexToNumber(log.logIndex)}) has a 'log.blockNumber' of ${log.blockNumber} (${hexToNumber(log.blockNumber)}), but the associated block has a 'block.number' of ${block.number} (${hexToNumber(block.number)}).`,
       );
       error.meta = [
@@ -405,7 +405,7 @@ export const validateLogsAndBlock = (
     if (log.transactionHash !== zeroHash) {
       const transaction = transactionByIndex.get(log.transactionIndex);
       if (transaction === undefined) {
-        const error = new RpcProviderError(
+        const error = new RpcRequestError(
           `Inconsistent RPC response data. The log with 'logIndex' ${log.logIndex} (${hexToNumber(log.logIndex)}) has a 'log.transactionIndex' of ${log.transactionIndex} (${hexToNumber(log.transactionIndex)}), but the associated 'block.transactions' array does not contain a transaction matching that 'transactionIndex'.`,
         );
         error.meta = [
@@ -415,7 +415,7 @@ export const validateLogsAndBlock = (
         ];
         throw error;
       } else if (transaction.hash !== log.transactionHash) {
-        const error = new RpcProviderError(
+        const error = new RpcRequestError(
           `Inconsistent RPC response data. The log with 'logIndex' ${log.logIndex} (${hexToNumber(log.logIndex)}) matches a transaction in the associated 'block.transactions' array by 'transactionIndex' ${log.transactionIndex} (${hexToNumber(log.transactionIndex)}), but the log has a 'log.transactionHash' of ${log.transactionHash} while the transaction has a 'transaction.hash' of ${transaction.hash}.`,
         );
         error.meta = [
@@ -447,7 +447,7 @@ export const validateTracesAndBlock = (
   const transactionHashes = new Set(block.transactions.map((t) => t.hash));
   for (const [index, trace] of traces.entries()) {
     if (transactionHashes.has(trace.transactionHash) === false) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The top-level trace at array index ${index} has a 'transactionHash' of ${trace.transactionHash}, but the associated 'block.transactions' array does not contain a transaction matching that hash.`,
       );
       error.meta = [
@@ -461,7 +461,7 @@ export const validateTracesAndBlock = (
 
   // Use the fact that any transaction produces a trace to validate.
   if (block.transactions.length !== 0 && traces.length === 0) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       `Inconsistent RPC response data. The traces array has length 0, but the associated 'block.transactions' array has length ${block.transactions.length}.`,
     );
     error.meta = [
@@ -497,7 +497,7 @@ export const validateReceiptsAndBlock = (
 
   for (const [index, receipt] of receipts.entries()) {
     if (block.hash !== receipt.blockHash) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The receipt at array index ${index} has a 'receipt.blockHash' of ${receipt.blockHash}, but the associated block has a 'block.hash' of ${block.hash}.`,
       );
       error.meta = [
@@ -509,7 +509,7 @@ export const validateReceiptsAndBlock = (
     }
 
     if (block.number !== receipt.blockNumber) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The receipt at array index ${index} has a 'receipt.blockNumber' of ${receipt.blockNumber} (${hexToNumber(receipt.blockNumber)}), but the associated block has a 'block.number' of ${block.number} (${hexToNumber(block.number)}).`,
       );
       error.meta = [
@@ -522,7 +522,7 @@ export const validateReceiptsAndBlock = (
 
     const transaction = transactionByIndex.get(receipt.transactionIndex);
     if (transaction === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The receipt at array index ${index} has a 'receipt.transactionIndex' of ${receipt.transactionIndex} (${hexToNumber(receipt.transactionIndex)}), but the associated 'block.transactions' array does not contain a transaction matching that 'transactionIndex'.`,
       );
       error.meta = [
@@ -532,7 +532,7 @@ export const validateReceiptsAndBlock = (
       ];
       throw error;
     } else if (transaction.hash !== receipt.transactionHash) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The receipt at array index ${index} matches a transaction in the associated 'block.transactions' array by 'transactionIndex' ${receipt.transactionIndex} (${hexToNumber(receipt.transactionIndex)}), but the receipt has a 'receipt.transactionHash' of ${receipt.transactionHash} while the transaction has a 'transaction.hash' of ${transaction.hash}.`,
       );
       error.meta = [
@@ -548,7 +548,7 @@ export const validateReceiptsAndBlock = (
     receiptsRequest.method === "eth_getBlockReceipts" &&
     block.transactions.length !== receipts.length
   ) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       `Inconsistent RPC response data. The receipts array has length ${receipts.length}, but the associated 'block.transactions' array has length ${block.transactions.length}.`,
     );
     error.meta = [
@@ -603,7 +603,7 @@ export const standardizeBlock = <
 ): block extends SyncBlock ? SyncBlock : SyncBlockHeader => {
   // required properties
   if (block.hash === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'block.hash' is a required property",
     );
     error.meta = [
@@ -613,7 +613,7 @@ export const standardizeBlock = <
     throw error;
   }
   if (block.number === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'block.number' is a required property",
     );
     error.meta = [
@@ -623,7 +623,7 @@ export const standardizeBlock = <
     throw error;
   }
   if (block.timestamp === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'block.timestamp' is a required property",
     );
     error.meta = [
@@ -633,7 +633,7 @@ export const standardizeBlock = <
     throw error;
   }
   if (block.logsBloom === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'block.logsBloom' is a required property",
     );
     error.meta = [
@@ -643,7 +643,7 @@ export const standardizeBlock = <
     throw error;
   }
   if (block.parentHash === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'block.parentHash' is a required property",
     );
     error.meta = [
@@ -695,7 +695,7 @@ export const standardizeBlock = <
   }
 
   if (hexToBigInt(block.number) > PG_BIGINT_MAX) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       `Invalid RPC response: 'block.number' (${hexToBigInt(block.number)}) is larger than the maximum allowed value (${PG_BIGINT_MAX}).`,
     );
     error.meta = [
@@ -705,7 +705,7 @@ export const standardizeBlock = <
     throw error;
   }
   if (hexToBigInt(block.timestamp) > PG_BIGINT_MAX) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       `Invalid RPC response: 'block.timestamp' (${hexToBigInt(block.timestamp)}) is larger than the maximum allowed value (${PG_BIGINT_MAX}).`,
     );
     error.meta = [
@@ -770,7 +770,7 @@ export const standardizeTransactions = (
 
   for (const transaction of transactions) {
     if (transactionIds.has(transaction.transactionIndex)) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The 'block.transactions' array contains two objects with a 'transactionIndex' of ${transaction.transactionIndex} (${hexToNumber(transaction.transactionIndex)}).`,
       );
       error.meta = [
@@ -784,7 +784,7 @@ export const standardizeTransactions = (
 
     // required properties
     if (transaction.hash === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'transaction.hash' is a required property",
       );
       error.meta = [
@@ -794,7 +794,7 @@ export const standardizeTransactions = (
       throw error;
     }
     if (transaction.transactionIndex === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'transaction.transactionIndex' is a required property",
       );
       error.meta = [
@@ -804,7 +804,7 @@ export const standardizeTransactions = (
       throw error;
     }
     if (transaction.blockNumber === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'transaction.blockNumber' is a required property",
       );
       error.meta = [
@@ -814,7 +814,7 @@ export const standardizeTransactions = (
       throw error;
     }
     if (transaction.blockHash === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'transaction.blockHash' is a required property",
       );
       error.meta = [
@@ -824,7 +824,7 @@ export const standardizeTransactions = (
       throw error;
     }
     if (transaction.from === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'transaction.from' is a required property",
       );
       error.meta = [
@@ -867,7 +867,7 @@ export const standardizeTransactions = (
     }
 
     if (hexToBigInt(transaction.blockNumber) > PG_BIGINT_MAX) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Invalid RPC response: 'transaction.blockNumber' (${hexToBigInt(transaction.blockNumber)}) is larger than the maximum allowed value (${PG_BIGINT_MAX}).`,
       );
       error.meta = [
@@ -877,7 +877,7 @@ export const standardizeTransactions = (
       throw error;
     }
     if (hexToBigInt(transaction.transactionIndex) > BigInt(PG_INTEGER_MAX)) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Invalid RPC response: 'transaction.transactionIndex' (${hexToBigInt(transaction.transactionIndex)}) is larger than the maximum allowed value (${PG_INTEGER_MAX}).`,
       );
       error.meta = [
@@ -887,7 +887,7 @@ export const standardizeTransactions = (
       throw error;
     }
     if (hexToBigInt(transaction.nonce) > BigInt(PG_INTEGER_MAX)) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Invalid RPC response: 'transaction.nonce' (${hexToBigInt(transaction.nonce)}) is larger than the maximum allowed value (${PG_INTEGER_MAX}).`,
       );
       error.meta = [
@@ -923,7 +923,7 @@ export const standardizeLogs = (
   const logIds = new Set<string>();
   for (const log of logs) {
     if (logIds.has(`${log.blockNumber}_${log.logIndex}`)) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The logs array contains two objects with 'blockNumber' ${log.blockNumber} (${hexToNumber(log.blockNumber)}) and 'logIndex' ${log.logIndex} (${hexToNumber(log.logIndex)}).`,
       );
       error.meta = [
@@ -939,7 +939,7 @@ export const standardizeLogs = (
 
     // required properties
     if (log.blockNumber === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'log.blockNumber' is a required property",
       );
       error.meta = [
@@ -949,7 +949,7 @@ export const standardizeLogs = (
       throw error;
     }
     if (log.logIndex === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'log.logIndex' is a required property",
       );
       error.meta = [
@@ -959,7 +959,7 @@ export const standardizeLogs = (
       throw error;
     }
     if (log.blockHash === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'log.blockHash' is a required property",
       );
       error.meta = [
@@ -969,7 +969,7 @@ export const standardizeLogs = (
       throw error;
     }
     if (log.address === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'log.address' is a required property",
       );
       error.meta = [
@@ -979,7 +979,7 @@ export const standardizeLogs = (
       throw error;
     }
     if (log.topics === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'log.topics' is a required property",
       );
       error.meta = [
@@ -989,7 +989,7 @@ export const standardizeLogs = (
       throw error;
     }
     if (log.data === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'log.data' is a required property",
       );
       error.meta = [
@@ -1011,7 +1011,7 @@ export const standardizeLogs = (
     }
 
     if (hexToBigInt(log.blockNumber) > PG_BIGINT_MAX) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Invalid RPC response: 'log.blockNumber' (${hexToBigInt(log.blockNumber)}) is larger than the maximum allowed value (${PG_BIGINT_MAX}).`,
       );
       error.meta = [
@@ -1021,7 +1021,7 @@ export const standardizeLogs = (
       throw error;
     }
     if (hexToBigInt(log.transactionIndex) > BigInt(PG_INTEGER_MAX)) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Invalid RPC response: 'log.transactionIndex' (${hexToBigInt(log.transactionIndex)}) is larger than the maximum allowed value (${PG_INTEGER_MAX}).`,
       );
       error.meta = [
@@ -1031,7 +1031,7 @@ export const standardizeLogs = (
       throw error;
     }
     if (hexToBigInt(log.logIndex) > BigInt(PG_INTEGER_MAX)) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Invalid RPC response: 'log.logIndex' (${hexToBigInt(log.logIndex)}) is larger than the maximum allowed value (${PG_INTEGER_MAX}).`,
       );
       error.meta = [
@@ -1067,7 +1067,7 @@ export const standardizeTrace = (
 ): SyncTrace => {
   // required properties
   if (trace.transactionHash === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'trace.transactionHash' is a required property",
     );
     error.meta = [
@@ -1077,7 +1077,7 @@ export const standardizeTrace = (
     throw error;
   }
   if (trace.trace.type === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'trace.type' is a required property",
     );
     error.meta = [
@@ -1087,7 +1087,7 @@ export const standardizeTrace = (
     throw error;
   }
   if (trace.trace.from === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'trace.from' is a required property",
     );
     error.meta = [
@@ -1097,7 +1097,7 @@ export const standardizeTrace = (
     throw error;
   }
   if (trace.trace.input === undefined) {
-    const error = new RpcProviderError(
+    const error = new RpcRequestError(
       "Invalid RPC response: 'trace.input' is a required property",
     );
     error.meta = [
@@ -1152,7 +1152,7 @@ export const standardizeTransactionReceipts = (
   const receiptIds = new Set<string>();
   for (const receipt of receipts) {
     if (receiptIds.has(receipt.transactionHash)) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Inconsistent RPC response data. The receipts array contains two objects with a 'transactionHash' of ${receipt.transactionHash}.`,
       );
       error.meta = [
@@ -1166,7 +1166,7 @@ export const standardizeTransactionReceipts = (
 
     // required properties
     if (receipt.blockHash === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'receipt.blockHash' is a required property",
       );
       error.meta = [
@@ -1176,7 +1176,7 @@ export const standardizeTransactionReceipts = (
       throw error;
     }
     if (receipt.blockNumber === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'receipt.blockNumber' is a required property",
       );
       error.meta = [
@@ -1186,7 +1186,7 @@ export const standardizeTransactionReceipts = (
       throw error;
     }
     if (receipt.transactionHash === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'receipt.transactionHash' is a required property",
       );
       error.meta = [
@@ -1196,7 +1196,7 @@ export const standardizeTransactionReceipts = (
       throw error;
     }
     if (receipt.transactionIndex === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'receipt.transactionIndex' is a required property",
       );
       error.meta = [
@@ -1206,7 +1206,7 @@ export const standardizeTransactionReceipts = (
       throw error;
     }
     if (receipt.from === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'receipt.from' is a required property",
       );
       error.meta = [
@@ -1216,7 +1216,7 @@ export const standardizeTransactionReceipts = (
       throw error;
     }
     if (receipt.status === undefined) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         "Invalid RPC response: 'receipt.status' is a required property",
       );
       error.meta = [
@@ -1256,7 +1256,7 @@ export const standardizeTransactionReceipts = (
     }
 
     if (hexToBigInt(receipt.blockNumber) > PG_BIGINT_MAX) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Invalid RPC response: 'receipt.blockNumber' (${hexToBigInt(receipt.blockNumber)}) is larger than the maximum allowed value (${PG_BIGINT_MAX}).`,
       );
       error.meta = [
@@ -1266,7 +1266,7 @@ export const standardizeTransactionReceipts = (
       throw error;
     }
     if (hexToBigInt(receipt.transactionIndex) > BigInt(PG_INTEGER_MAX)) {
-      const error = new RpcProviderError(
+      const error = new RpcRequestError(
         `Invalid RPC response: 'receipt.transactionIndex' (${hexToBigInt(receipt.transactionIndex)}) is larger than the maximum allowed value (${PG_INTEGER_MAX}).`,
       );
       error.meta = [

--- a/packages/core/src/rpc/actions.ts
+++ b/packages/core/src/rpc/actions.ts
@@ -931,7 +931,6 @@ export const standardizeLogs = (
         requestText(request),
       ];
 
-      console.log(logs);
       throw error;
     } else {
       logIds.add(`${log.blockNumber}_${log.logIndex}`);

--- a/packages/core/src/rpc/actions.ts
+++ b/packages/core/src/rpc/actions.ts
@@ -327,7 +327,6 @@ export const validateTransactionsAndBlock = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
 
@@ -339,7 +338,6 @@ export const validateTransactionsAndBlock = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
   }
@@ -369,7 +367,6 @@ export const validateLogsAndBlock = (
       requestText(blockRequest),
       requestText(logsRequest),
     ];
-    error.stack = undefined;
     throw error;
   }
 
@@ -390,7 +387,6 @@ export const validateLogsAndBlock = (
         requestText(blockRequest),
         requestText(logsRequest),
       ];
-      error.stack = undefined;
       throw error;
     }
 
@@ -403,7 +399,6 @@ export const validateLogsAndBlock = (
         requestText(blockRequest),
         requestText(logsRequest),
       ];
-      error.stack = undefined;
       throw error;
     }
 
@@ -418,7 +413,6 @@ export const validateLogsAndBlock = (
           requestText(blockRequest),
           requestText(logsRequest),
         ];
-        error.stack = undefined;
         throw error;
       } else if (transaction.hash !== log.transactionHash) {
         const error = new RpcProviderError(
@@ -429,7 +423,6 @@ export const validateLogsAndBlock = (
           requestText(blockRequest),
           requestText(logsRequest),
         ];
-        error.stack = undefined;
         throw error;
       }
     }
@@ -462,7 +455,6 @@ export const validateTracesAndBlock = (
         requestText(blockRequest),
         requestText(tracesRequest),
       ];
-      error.stack = undefined;
       throw error;
     }
   }
@@ -477,7 +469,6 @@ export const validateTracesAndBlock = (
       requestText(blockRequest),
       requestText(tracesRequest),
     ];
-    error.stack = undefined;
     throw error;
   }
 };
@@ -514,7 +505,6 @@ export const validateReceiptsAndBlock = (
         requestText(blockRequest),
         requestText(receiptsRequest),
       ];
-      error.stack = undefined;
       throw error;
     }
 
@@ -527,7 +517,6 @@ export const validateReceiptsAndBlock = (
         requestText(blockRequest),
         requestText(receiptsRequest),
       ];
-      error.stack = undefined;
       throw error;
     }
 
@@ -541,7 +530,6 @@ export const validateReceiptsAndBlock = (
         requestText(blockRequest),
         requestText(receiptsRequest),
       ];
-      error.stack = undefined;
       throw error;
     } else if (transaction.hash !== receipt.transactionHash) {
       const error = new RpcProviderError(
@@ -552,7 +540,6 @@ export const validateReceiptsAndBlock = (
         requestText(blockRequest),
         requestText(receiptsRequest),
       ];
-      error.stack = undefined;
       throw error;
     }
   }
@@ -569,7 +556,6 @@ export const validateReceiptsAndBlock = (
       requestText(blockRequest),
       requestText(receiptsRequest),
     ];
-    error.stack = undefined;
     throw error;
   }
 };
@@ -624,7 +610,6 @@ export const standardizeBlock = <
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
   if (block.number === undefined) {
@@ -635,7 +620,6 @@ export const standardizeBlock = <
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
   if (block.timestamp === undefined) {
@@ -646,7 +630,6 @@ export const standardizeBlock = <
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
   if (block.logsBloom === undefined) {
@@ -657,7 +640,6 @@ export const standardizeBlock = <
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
   if (block.parentHash === undefined) {
@@ -668,7 +650,6 @@ export const standardizeBlock = <
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
 
@@ -721,7 +702,6 @@ export const standardizeBlock = <
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
   if (hexToBigInt(block.timestamp) > PG_BIGINT_MAX) {
@@ -732,7 +712,6 @@ export const standardizeBlock = <
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
 
@@ -798,7 +777,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     } else {
       transactionIds.add(transaction.transactionIndex);
@@ -813,7 +791,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (transaction.transactionIndex === undefined) {
@@ -824,7 +801,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (transaction.blockNumber === undefined) {
@@ -835,7 +811,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (transaction.blockHash === undefined) {
@@ -846,7 +821,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (transaction.from === undefined) {
@@ -857,7 +831,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
 
@@ -901,7 +874,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (hexToBigInt(transaction.transactionIndex) > BigInt(PG_INTEGER_MAX)) {
@@ -912,7 +884,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (hexToBigInt(transaction.nonce) > BigInt(PG_INTEGER_MAX)) {
@@ -923,7 +894,6 @@ export const standardizeTransactions = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
   }
@@ -962,7 +932,6 @@ export const standardizeLogs = (
       ];
 
       console.log(logs);
-      error.stack = undefined;
       throw error;
     } else {
       logIds.add(`${log.blockNumber}_${log.logIndex}`);
@@ -977,7 +946,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (log.logIndex === undefined) {
@@ -988,7 +956,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (log.blockHash === undefined) {
@@ -999,7 +966,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (log.address === undefined) {
@@ -1010,7 +976,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (log.topics === undefined) {
@@ -1021,7 +986,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (log.data === undefined) {
@@ -1032,7 +996,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (log.transactionHash === undefined) {
@@ -1055,7 +1018,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (hexToBigInt(log.transactionIndex) > BigInt(PG_INTEGER_MAX)) {
@@ -1066,7 +1028,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (hexToBigInt(log.logIndex) > BigInt(PG_INTEGER_MAX)) {
@@ -1077,7 +1038,6 @@ export const standardizeLogs = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
   }
@@ -1114,7 +1074,6 @@ export const standardizeTrace = (
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
   if (trace.trace.type === undefined) {
@@ -1125,7 +1084,6 @@ export const standardizeTrace = (
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
   if (trace.trace.from === undefined) {
@@ -1136,7 +1094,6 @@ export const standardizeTrace = (
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
   if (trace.trace.input === undefined) {
@@ -1147,7 +1104,6 @@ export const standardizeTrace = (
       "Please report this error to the RPC operator.",
       requestText(request),
     ];
-    error.stack = undefined;
     throw error;
   }
 
@@ -1203,7 +1159,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     } else {
       receiptIds.add(receipt.transactionHash);
@@ -1218,7 +1173,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (receipt.blockNumber === undefined) {
@@ -1229,7 +1183,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (receipt.transactionHash === undefined) {
@@ -1240,7 +1193,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (receipt.transactionIndex === undefined) {
@@ -1251,7 +1203,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (receipt.from === undefined) {
@@ -1262,7 +1213,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (receipt.status === undefined) {
@@ -1273,7 +1223,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
 
@@ -1314,7 +1263,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
     if (hexToBigInt(receipt.transactionIndex) > BigInt(PG_INTEGER_MAX)) {
@@ -1325,7 +1273,6 @@ export const standardizeTransactionReceipts = (
         "Please report this error to the RPC operator.",
         requestText(request),
       ];
-      error.stack = undefined;
       throw error;
     }
   }

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -1,7 +1,11 @@
 import crypto, { type UUID } from "node:crypto";
 import url from "node:url";
 import type { Common } from "@/internal/common.js";
-import { EthGetLogsRangeError, RpcRequestError } from "@/internal/errors.js";
+import {
+  EthGetLogsRangeError,
+  RpcRequestError,
+  ShutdownError,
+} from "@/internal/errors.js";
 import type { Logger } from "@/internal/logger.js";
 import type { Chain, SyncBlock, SyncBlockHeader } from "@/internal/types.js";
 import { eth_getBlockByNumber, standardizeBlock } from "@/rpc/actions.js";
@@ -546,6 +550,10 @@ export const createRpc = ({
           const error = new RpcRequestError(undefined, {
             cause: _error as Error,
           });
+
+          if (common.shutdown.isKilled) {
+            throw new ShutdownError();
+          }
 
           common.metrics.ponder_rpc_request_error_total.inc(
             { method: body.method, chain: chain.name },

--- a/packages/core/src/runtime/historical.ts
+++ b/packages/core/src/runtime/historical.ts
@@ -1,6 +1,6 @@
 import type { Database } from "@/database/index.js";
 import type { Common } from "@/internal/common.js";
-import { ShutdownError } from "@/internal/errors.js";
+// import { ShutdownError } from "@/internal/errors.js";
 import type {
   Chain,
   CrashRecoveryCheckpoint,
@@ -1286,8 +1286,8 @@ export async function* getLocalSyncGenerator(params: {
         params.common.options.command === "dev" ? 10_000 : 50_000,
       );
 
-      closestToTipBlock = await params.database.syncQB
-        .transaction(async (tx) => {
+      closestToTipBlock = await params.database.syncQB.transaction(
+        async (tx) => {
           const syncStore = createSyncStore({ common: params.common, qb: tx });
           const logs = await historicalSync.syncBlockRangeData({
             interval,
@@ -1328,22 +1328,25 @@ export async function* getLocalSyncGenerator(params: {
           }
 
           return closestToTipBlock;
-        })
-        .catch((error) => {
-          if (error instanceof ShutdownError) {
-            throw error;
-          }
+        },
+      );
+      // TODO(kyle) don't log here because it's not a decision boundary, instead
+      // add context to inner errors.
+      // .catch((error) => {
+      //   if (error instanceof ShutdownError) {
+      //     throw error;
+      //   }
 
-          params.common.logger.warn({
-            msg: "Failed to fetch backfill JSON-RPC data",
-            chain: params.chain.name,
-            chain_id: params.chain.id,
-            block_range: JSON.stringify(interval),
-            duration: endClock(),
-            error,
-          });
-          throw error;
-        });
+      //   params.common.logger.warn({
+      //     msg: "Failed to fetch backfill JSON-RPC data",
+      //     chain: params.chain.name,
+      //     chain_id: params.chain.id,
+      //     block_range: JSON.stringify(interval),
+      //     duration: endClock(),
+      //     error,
+      //   });
+      //   throw error;
+      // });
 
       clearTimeout(durationTimer);
 

--- a/packages/core/src/runtime/historical.ts
+++ b/packages/core/src/runtime/historical.ts
@@ -1330,23 +1330,6 @@ export async function* getLocalSyncGenerator(params: {
           return closestToTipBlock;
         },
       );
-      // TODO(kyle) don't log here because it's not a decision boundary, instead
-      // add context to inner errors.
-      // .catch((error) => {
-      //   if (error instanceof ShutdownError) {
-      //     throw error;
-      //   }
-
-      //   params.common.logger.warn({
-      //     msg: "Failed to fetch backfill JSON-RPC data",
-      //     chain: params.chain.name,
-      //     chain_id: params.chain.id,
-      //     block_range: JSON.stringify(interval),
-      //     duration: endClock(),
-      //     error,
-      //   });
-      //   throw error;
-      // });
 
       clearTimeout(durationTimer);
 

--- a/packages/core/src/runtime/isolated.ts
+++ b/packages/core/src/runtime/isolated.ts
@@ -18,11 +18,7 @@ import {
   getEventCount,
 } from "@/indexing/index.js";
 import type { Common } from "@/internal/common.js";
-import {
-  InvalidEventAccessError,
-  NonRetryableUserError,
-  type RetryableError,
-} from "@/internal/errors.js";
+import { InvalidEventAccessError } from "@/internal/errors.js";
 import type {
   CrashRecoveryCheckpoint,
   IndexingBuild,
@@ -93,16 +89,16 @@ export async function runIsolated({
   });
 
   const indexingErrorHandler: IndexingErrorHandler = {
-    getRetryableError: () => {
+    getError: () => {
       return indexingErrorHandler.error;
     },
-    setRetryableError: (error: RetryableError) => {
+    setError: (error: Error) => {
       indexingErrorHandler.error = error;
     },
-    clearRetryableError: () => {
+    clearError: () => {
       indexingErrorHandler.error = undefined;
     },
-    error: undefined as RetryableError | undefined,
+    error: undefined as Error | undefined,
   };
 
   const indexingCache = createIndexingCache({
@@ -421,16 +417,15 @@ export async function runIsolated({
               syncStore,
               events,
             });
-          } else if (error instanceof NonRetryableUserError === false) {
-            common.logger.warn({
-              msg: "Failed to index block range",
-              chain: chain.name,
-              chain_id: chain.id,
-              block_range: JSON.stringify(blockRange),
-              duration: indexStartClock(),
-              error: error as Error,
-            });
           }
+          common.logger.warn({
+            msg: "Failed to index block range",
+            chain: chain.name,
+            chain_id: chain.id,
+            block_range: JSON.stringify(blockRange),
+            duration: indexStartClock(),
+            error: error as Error,
+          });
 
           throw error;
         }
@@ -623,15 +618,13 @@ export async function runIsolated({
               } catch (error) {
                 indexingCache.clear();
 
-                if (error instanceof NonRetryableUserError === false) {
-                  common.logger.warn({
-                    msg: "Failed to index block",
-                    chain: chain.name,
-                    chain_id: chain.id,
-                    number: Number(decodeCheckpoint(checkpoint).blockNumber),
-                    error: error,
-                  });
-                }
+                common.logger.warn({
+                  msg: "Failed to index block",
+                  chain: chain.name,
+                  chain_id: chain.id,
+                  number: Number(decodeCheckpoint(checkpoint).blockNumber),
+                  error: error,
+                });
 
                 throw error;
               }

--- a/packages/core/src/runtime/isolated.ts
+++ b/packages/core/src/runtime/isolated.ts
@@ -401,23 +401,6 @@ export async function runIsolated({
           indexingCache.invalidate();
           indexingCache.clear();
 
-          if (error instanceof InvalidEventAccessError) {
-            common.logger.debug({
-              msg: "Failed to index block range",
-              chain: chain.name,
-              chain_id: chain.id,
-              block_range: JSON.stringify(blockRange),
-              duration: indexStartClock(),
-              error,
-            });
-            events = await refetchHistoricalEvents({
-              common,
-              indexingBuild,
-              perChainSync: new Map([[chain, { childAddresses }]]),
-              syncStore,
-              events,
-            });
-          }
           common.logger.warn({
             msg: "Failed to index block range",
             chain: chain.name,
@@ -426,6 +409,16 @@ export async function runIsolated({
             duration: indexStartClock(),
             error: error as Error,
           });
+
+          if (error instanceof InvalidEventAccessError) {
+            events = await refetchHistoricalEvents({
+              common,
+              indexingBuild,
+              perChainSync: new Map([[chain, { childAddresses }]]),
+              syncStore,
+              events,
+            });
+          }
 
           throw error;
         }

--- a/packages/core/src/runtime/multichain.ts
+++ b/packages/core/src/runtime/multichain.ts
@@ -456,24 +456,6 @@ export async function runMultichain({
           indexingCache.invalidate();
           indexingCache.clear();
 
-          if (error instanceof InvalidEventAccessError) {
-            common.logger.debug({
-              msg: "Failed to index block range",
-              chain: chain.name,
-              chain_id: chain.id,
-              block_range: JSON.stringify(blockRange),
-              duration: indexStartClock(),
-              error,
-            });
-            events = await refetchHistoricalEvents({
-              common,
-              indexingBuild,
-              perChainSync,
-              syncStore,
-              events,
-            });
-          }
-
           common.logger.warn({
             msg: "Failed to index block range",
             chain: chain.name,
@@ -482,6 +464,16 @@ export async function runMultichain({
             duration: indexStartClock(),
             error: error as Error,
           });
+
+          if (error instanceof InvalidEventAccessError) {
+            events = await refetchHistoricalEvents({
+              common,
+              indexingBuild,
+              perChainSync,
+              syncStore,
+              events,
+            });
+          }
 
           throw error;
         }

--- a/packages/core/src/runtime/omnichain.ts
+++ b/packages/core/src/runtime/omnichain.ts
@@ -475,12 +475,13 @@ export async function runOmnichain({
           indexingCache.invalidate();
           indexingCache.clear();
 
+          common.logger.warn({
+            msg: "Failed to index block range",
+            duration: indexStartClock(),
+            error: error as Error,
+          });
+
           if (error instanceof InvalidEventAccessError) {
-            common.logger.debug({
-              msg: "Failed to index block range",
-              duration: indexStartClock(),
-              error,
-            });
             events = await refetchHistoricalEvents({
               common,
               indexingBuild,
@@ -489,11 +490,6 @@ export async function runOmnichain({
               events,
             });
           }
-          common.logger.warn({
-            msg: "Failed to index block range",
-            duration: indexStartClock(),
-            error: error as Error,
-          });
 
           throw error;
         }

--- a/packages/core/src/server/error.ts
+++ b/packages/core/src/server/error.ts
@@ -1,12 +1,12 @@
 import { addStackTrace } from "@/indexing/addStackTrace.js";
 import type { Common } from "@/internal/common.js";
-import type { BaseError } from "@/internal/errors.js";
+import { ServerError } from "@/internal/errors.js";
 import { prettyPrint } from "@/utils/print.js";
 import type { Context, HonoRequest } from "hono";
 import { html } from "hono/html";
 
 export const onError = async (_error: Error, c: Context, common: Common) => {
-  const error = _error as BaseError;
+  const error = new ServerError({ cause: _error });
 
   // Find the filename where the error occurred
   const regex = /(\S+\.(?:js|ts|mjs|cjs)):\d+:\d+/;

--- a/packages/core/src/server/error.ts
+++ b/packages/core/src/server/error.ts
@@ -6,7 +6,7 @@ import type { Context, HonoRequest } from "hono";
 import { html } from "hono/html";
 
 export const onError = async (_error: Error, c: Context, common: Common) => {
-  const error = new ServerError({ cause: _error });
+  const error = new ServerError(undefined, { cause: _error });
 
   // Find the filename where the error occurred
   const regex = /(\S+\.(?:js|ts|mjs|cjs)):\d+:\d+/;

--- a/packages/utils/src/getLogsRetryHelper.ts
+++ b/packages/utils/src/getLogsRetryHelper.ts
@@ -2,13 +2,12 @@ import {
   type Address,
   type Hex,
   type LogTopic,
-  type RpcError,
   hexToBigInt,
   numberToHex,
 } from "viem";
 
 export type GetLogsRetryHelperParameters = {
-  error: RpcError;
+  error: Error;
   params: [
     {
       address?: Address | Address[];
@@ -109,6 +108,7 @@ export const getLogsRetryHelper = ({
 
   // ankr
   match = sError.match("block range is too wide");
+  // @ts-ignore
   if (match !== null && error.code === -32600) {
     const ranges = chunk({ params, range: 3000n });
 


### PR DESCRIPTION
This pr improves the internal error handling of Ponder. Ponder needs to have strictly defined error behavior, exit codes dependent on errors, and useful error logs.

## New approach
- `BaseError` that designates a recognized error within Ponder. Every error that isn't an instance of `BaseError` is an unexpected error (bug).
- Errors are chained together with the "cause" property when errors change across module boundaries.
- A new error class is only defined when it is meaningful and necessary.
- Stack traces are only printed in errors if it points to user code or is unrecognized.

## Remaining
- [ ] `ShutdownError`