### PR TITLE
feat: add invariant assertion utility with PONDER_DEBUG env var

### DIFF
--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -15,6 +15,7 @@ import type {
   SchemaBuild,
 } from "@/internal/types.js";
 import { dedupe } from "@/utils/dedupe.js";
+import { invariant } from "@/utils/invariant.js";
 import { prettyPrint } from "@/utils/print.js";
 import { promiseAllSettledWithThrow } from "@/utils/promiseAllSettledWithThrow.js";
 import { startClock } from "@/utils/timer.js";
@@ -896,6 +897,10 @@ export const createIndexingCache = ({
           cache.get(table)!.isCacheComplete = false;
           // Note: spillover is not cleared because it is an invariant
           // it is empty
+          invariant(
+            cache.get(table)!.spillover.size === 0,
+            `Spillover set should be empty when evicting cache for table ${getTableName(table)}`,
+          );
 
           common.logger.debug({
             msg: "Evicted cached database rows",

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -54,6 +54,7 @@ import {
   encodeCheckpoint,
 } from "@/utils/checkpoint.js";
 import { dedupe } from "@/utils/dedupe.js";
+import { invariant } from "@/utils/invariant.js";
 import { prettyPrint } from "@/utils/print.js";
 import { startClock } from "@/utils/timer.js";
 import type { Abi, Address } from "viem";
@@ -345,6 +346,10 @@ export const createIndexing = ({
     let include: Filter["include"];
 
     // Note: It's an invariant that all filters have the same type.
+    invariant(
+      filters.every((f) => f.type === filters[0]!.type),
+      `All filters must have the same type, got: ${[...new Set(filters.map((f) => f.type))].join(", ")}`,
+    );
     switch (filters[0]!.type) {
       case "block": {
         include = defaultBlockFilterInclude;

--- a/packages/core/src/runtime/omnichain.ts
+++ b/packages/core/src/runtime/omnichain.ts
@@ -55,6 +55,7 @@ import {
   bufferAsyncGenerator,
   recordAsyncGenerator,
 } from "@/utils/generators.js";
+import { invariant } from "@/utils/invariant.js";
 import { never } from "@/utils/never.js";
 import { startClock } from "@/utils/timer.js";
 import { zipperMany } from "@/utils/zipper.js";
@@ -439,7 +440,10 @@ export async function runOmnichain({
 
           endClock = startClock();
 
-          // Note: It is an invariant that result.result.length > 0
+          invariant(
+            result.result.length > 0,
+            "Expected at least one result from event processing",
+          );
           await tx.wrap({ label: "update_checkpoints" }, (tx) =>
             tx
               .insert(PONDER_CHECKPOINT)

--- a/packages/core/src/utils/invariant.test.ts
+++ b/packages/core/src/utils/invariant.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { hardInvariant, invariant } from "./invariant.js";
+
+describe("invariant", () => {
+  const originalEnv = process.env.PONDER_DEBUG;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      process.env.PONDER_DEBUG = undefined;
+    } else {
+      process.env.PONDER_DEBUG = originalEnv;
+    }
+  });
+
+  test("does not throw in production mode when condition is false", () => {
+    process.env.PONDER_DEBUG = undefined;
+    expect(() => invariant(false, "should not throw")).not.toThrow();
+  });
+
+  test("does not throw when condition is true", () => {
+    process.env.PONDER_DEBUG = "true";
+    expect(() => invariant(true, "should not throw")).not.toThrow();
+  });
+
+  test("throws in debug mode when condition is false", () => {
+    process.env.PONDER_DEBUG = "true";
+    expect(() => invariant(false, "test message")).toThrowError(
+      "Invariant violation: test message",
+    );
+  });
+
+  test("narrows type when condition is true", () => {
+    const value: string | undefined = "hello";
+    invariant(value !== undefined, "value should be defined");
+    // TypeScript should now know `value` is `string`
+    const _length: number = value.length;
+    expect(_length).toBe(5);
+  });
+});
+
+describe("hardInvariant", () => {
+  test("throws when condition is false regardless of env", () => {
+    process.env.PONDER_DEBUG = undefined;
+    expect(() => hardInvariant(false, "test message")).toThrowError(
+      "Invariant violation: test message",
+    );
+  });
+
+  test("does not throw when condition is true", () => {
+    expect(() => hardInvariant(true, "should not throw")).not.toThrow();
+  });
+
+  test("narrows type when condition is true", () => {
+    const value: string | undefined = "hello";
+    hardInvariant(value !== undefined, "value should be defined");
+    const _length: number = value.length;
+    expect(_length).toBe(5);
+  });
+});

--- a/packages/core/src/utils/invariant.ts
+++ b/packages/core/src/utils/invariant.ts
@@ -1,0 +1,31 @@
+/**
+ * Assert that a condition is true. In debug mode (PONDER_DEBUG=true),
+ * throws an error if the condition is false. In production, this is a no-op
+ * unless `alwaysThrow` is set to true.
+ *
+ * Use this to validate internal assumptions that should always hold.
+ * These are NOT for user input validation - use proper error types for that.
+ */
+export function invariant(
+  condition: unknown,
+  message: string,
+): asserts condition {
+  if (!condition) {
+    if (process.env.PONDER_DEBUG === "true") {
+      throw new Error(`Invariant violation: ${message}`);
+    }
+  }
+}
+
+/**
+ * Like `invariant()`, but always throws regardless of PONDER_DEBUG.
+ * Use for conditions that indicate a critical bug if violated.
+ */
+export function hardInvariant(
+  condition: unknown,
+  message: string,
+): asserts condition {
+  if (!condition) {
+    throw new Error(`Invariant violation: ${message}`);
+  }
+}

--- a/packages/core/src/utils/never.ts
+++ b/packages/core/src/utils/never.ts
@@ -1,3 +1,3 @@
 export const never = (_x: never) => {
-  throw "unreachable";
+  throw new Error("Unreachable");
 };


### PR DESCRIPTION
## Summary
- Add `invariant(condition, message)` utility that validates internal assumptions. In debug mode (`PONDER_DEBUG=true`), throws on violation; in production it's a no-op.
- Add `hardInvariant(condition, message)` that always throws regardless of environment, for critical invariants.
- Both functions narrow types via `asserts condition` for TypeScript type safety.
- Convert 3 comment-only invariants to runtime checks:
  - `indexing/index.ts`: all filters must have the same type
  - `runtime/omnichain.ts`: result.result.length must be > 0
  - `indexing-store/cache.ts`: spillover set must be empty on eviction
- Fix `utils/never.ts` to throw proper `Error` instead of a string

The codebase has 19+ documented invariants as comments that are never validated at runtime. This PR establishes the infrastructure to progressively convert them to runtime checks.

## Test plan
- [x] 7 new tests for invariant/hardInvariant covering debug mode, production mode, and type narrowing
- [x] TypeScript type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)