### PR TITLE
refactor: simplify bloom validation with loop over topics

### DIFF
--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -341,39 +341,12 @@ export const createRealtimeSync = (
       );
 
       // Note: Exact `logsBloom` validations were considered too strict to add to `validateLogsAndBlock`.
-      let isInvalidLogsBloom = false;
       for (const log of logs) {
-        if (isInBloom(block.logsBloom, log.address) === false) {
-          isInvalidLogsBloom = true;
-        }
-
-        if (
-          log.topics[0] &&
-          isInBloom(block.logsBloom, log.topics[0]) === false
-        ) {
-          isInvalidLogsBloom = true;
-        }
-
-        if (
-          log.topics[1] &&
-          isInBloom(block.logsBloom, log.topics[1]) === false
-        ) {
-          isInvalidLogsBloom = true;
-        }
-
-        if (
-          log.topics[2] &&
-          isInBloom(block.logsBloom, log.topics[2]) === false
-        ) {
-          isInvalidLogsBloom = true;
-        }
-
-        if (
-          log.topics[3] &&
-          isInBloom(block.logsBloom, log.topics[3]) === false
-        ) {
-          isInvalidLogsBloom = true;
-        }
+        const isInvalidLogsBloom =
+          isInBloom(block.logsBloom, log.address) === false ||
+          log.topics.some(
+            (topic) => topic && isInBloom(block!.logsBloom, topic) === false,
+          );
 
         if (isInvalidLogsBloom) {
           args.common.logger.warn({


### PR DESCRIPTION
## Summary
- Replace 4 copy-pasted if-blocks for `topics[0]`-`topics[3]` bloom validation with a single `log.topics.some()` call
- Same behavior, 27 fewer lines
- Also more resilient if topics array length ever changes

## Test plan
- [x] TypeScript type check passes
- [x] Bloom filter tests pass (7/7)
- [x] Realtime sync tests pass (16/16)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)