### PR TITLE
chore: add npm package links to all README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ If you're interested in contributing to Ponder, please read the [contribution gu
 
 ## Packages
 
-- `ponder`
-- `@ponder/client`
-- `@ponder/react`
-- `@ponder/utils`
-- `create-ponder`
-- `eslint-config-ponder`
+- [`ponder`](https://www.npmjs.com/package/ponder)
+- [`@ponder/client`](https://www.npmjs.com/package/@ponder/client)
+- [`@ponder/react`](https://www.npmjs.com/package/@ponder/react)
+- [`@ponder/utils`](https://www.npmjs.com/package/@ponder/utils)
+- [`create-ponder`](https://www.npmjs.com/package/create-ponder)
+- [`eslint-config-ponder`](https://www.npmjs.com/package/eslint-config-ponder)
 
 ## About
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -165,12 +165,12 @@ If you're interested in contributing to Ponder, please read the [contribution gu
 
 ## Packages
 
-- `ponder`
-- `@ponder/client`
-- `@ponder/react`
-- `@ponder/utils`
-- `create-ponder`
-- `eslint-config-ponder`
+- [`ponder`](https://www.npmjs.com/package/ponder)
+- [`@ponder/client`](https://www.npmjs.com/package/@ponder/client)
+- [`@ponder/react`](https://www.npmjs.com/package/@ponder/react)
+- [`@ponder/utils`](https://www.npmjs.com/package/@ponder/utils)
+- [`create-ponder`](https://www.npmjs.com/package/create-ponder)
+- [`eslint-config-ponder`](https://www.npmjs.com/package/eslint-config-ponder)
 
 ## About
 

--- a/packages/create-ponder/README.md
+++ b/packages/create-ponder/README.md
@@ -165,12 +165,12 @@ If you're interested in contributing to Ponder, please read the [contribution gu
 
 ## Packages
 
-- `ponder`
-- `@ponder/client`
-- `@ponder/react`
-- `@ponder/utils`
-- `create-ponder`
-- `eslint-config-ponder`
+- [`ponder`](https://www.npmjs.com/package/ponder)
+- [`@ponder/client`](https://www.npmjs.com/package/@ponder/client)
+- [`@ponder/react`](https://www.npmjs.com/package/@ponder/react)
+- [`@ponder/utils`](https://www.npmjs.com/package/@ponder/utils)
+- [`create-ponder`](https://www.npmjs.com/package/create-ponder)
+- [`eslint-config-ponder`](https://www.npmjs.com/package/eslint-config-ponder)
 
 ## About
 

--- a/packages/eslint-config-ponder/README.md
+++ b/packages/eslint-config-ponder/README.md
@@ -167,12 +167,12 @@ If you're interested in contributing to Ponder, please read the [contribution gu
 
 ## Packages
 
-- `ponder`
-- `@ponder/client`
-- `@ponder/react`
-- `@ponder/utils`
-- `create-ponder`
-- `eslint-config-ponder`
+- [`ponder`](https://www.npmjs.com/package/ponder)
+- [`@ponder/client`](https://www.npmjs.com/package/@ponder/client)
+- [`@ponder/react`](https://www.npmjs.com/package/@ponder/react)
+- [`@ponder/utils`](https://www.npmjs.com/package/@ponder/utils)
+- [`create-ponder`](https://www.npmjs.com/package/create-ponder)
+- [`eslint-config-ponder`](https://www.npmjs.com/package/eslint-config-ponder)
 
 ## About
 


### PR DESCRIPTION
## Summary
- Add npm package links for all 6 packages in the Packages section
- Updates all 4 README files that share the same content (root, packages/core, packages/create-ponder, packages/eslint-config-ponder)

This extends the changes proposed in #2250 to cover all README files that have the Packages section.
