### PR TITLE
feat: add context.isRealtime to indexing handlers

### DIFF
--- a/docs/pages/docs/api-reference/ponder/indexing-functions.mdx
+++ b/docs/pages/docs/api-reference/ponder/indexing-functions.mdx
@@ -19,7 +19,7 @@ To register an indexing function, use the `.on(){:ts}` method of the `ponder` ob
 import { ponder } from "ponder:registry";
 
 ponder.on("ContractName:EventName", async ({ event, context }) => { // [!code focus]
-  const { db, chain, client, contracts } = context;
+  const { db, chain, client, contracts, isRealtime } = context;
 
   // ...
 });
@@ -233,8 +233,15 @@ type Context = {
     string,
     { abi: Abi; address?: `0x${string}`; startBlock?: number; endBlock?: number; }
   >;
+  isRealtime: boolean;
 };
 ```
+
+### `isRealtime`
+
+`context.isRealtime` is `true` when the current event is processed by the **live** indexer, and `false` during **historical backfill**. Setup handlers ([`"setup"`](#setup-event)) always see `false`.
+
+Use this when indexing logic should differ between backfill and live (for example, sending webhooks only for new blocks). Note that `true` does **not** mean the indexer is caught up to chain tip—live indexing can still lag behind the remote chain head.
 
 ### Database
 
@@ -337,12 +344,13 @@ A generic type that optionally accepts an event name and returns the `context` o
 import { ponder, type Context } from "ponder:registry";
 
 function helper(context: Context<"Weth:Deposit">) {
-  event;
+  context;
   // ^? {
   //      chain: { name: "mainnet"; id: 1; };
   //      client: ReadonlyClient;
   //      db: { Account: DatabaseModel<{ id: `0x${string}`; balance: bigint; }> };
   //      contracts: { weth9: { abi: ...; address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" } };
+  //      isRealtime: boolean;
   //    }
 }
 ```

--- a/docs/pages/docs/indexing/overview.mdx
+++ b/docs/pages/docs/indexing/overview.mdx
@@ -56,3 +56,5 @@ Internally, the indexing engine has two distinct modes – **backfill** and **li
 
 However, indexing function logic works the same way in both modes. As long as the logic is compatible with the expected onchain activity, indexing will work fine in both modes.
 
+When you need to branch (for example, notify an external service only for live blocks), use [`context.isRealtime`](/docs/api-reference/ponder/indexing-functions#isrealtime) in your handler. It is `false` during backfill and setup, and `true` for events processed by the live indexer. It does not indicate whether you are at chain tip.
+

--- a/docs/pages/docs/migration-guide.mdx
+++ b/docs/pages/docs/migration-guide.mdx
@@ -1,5 +1,17 @@
 # Migration guide [Upgrade to a new version of Ponder]
 
+## 0.17
+
+### Breaking changes
+
+None.
+
+### New features
+
+#### `context.isRealtime`
+
+Indexing functions now receive `context.isRealtime`: `true` when the event is processed by the live indexer, `false` during historical backfill and setup. See the [indexing functions API reference](/docs/api-reference/ponder/indexing-functions#isrealtime). This is not the same as being caught up to chain tip.
+
 ## 0.16
 
 ### Breaking changes

--- a/packages/core/src/indexing/index.test.ts
+++ b/packages/core/src/indexing/index.test.ts
@@ -252,6 +252,7 @@ test("processSetupEvents()", async () => {
       },
       client: expect.any(Object),
       db: expect.any(Object),
+      isRealtime: false,
     },
   });
 });
@@ -351,8 +352,97 @@ test("processEvent()", async () => {
       },
       client: expect.any(Object),
       db: expect.any(Object),
+      isRealtime: true,
     },
   });
+});
+
+test("context.isRealtime is false during historical indexing and true during realtime", async () => {
+  const { common } = context;
+  const { syncStore } = await setupDatabaseServices({
+    schemaBuild: { schema },
+  });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  const blockData = await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const chain = getChain();
+  const rpc = createRpc({ common, chain });
+
+  const { eventCallbacks, setupCallbacks, indexingFunctions, contracts } =
+    getErc20IndexingBuild({
+      address,
+    });
+
+  const eventCount = getEventCount(indexingFunctions);
+  const columnAccessPattern = createColumnAccessPattern({
+    indexingBuild: { indexingFunctions },
+  });
+
+  const historicalFlags: boolean[] = [];
+  const realtimeFlags: boolean[] = [];
+
+  eventCallbacks[0]!.fn = async ({ context: ctx }) => {
+    if (ctx.isRealtime) realtimeFlags.push(ctx.isRealtime);
+    else historicalFlags.push(ctx.isRealtime);
+  };
+
+  const cachedViemClient = createCachedViemClient({
+    common,
+    indexingBuild: { chains: [chain], rpcs: [rpc] },
+    syncStore,
+    eventCount,
+  });
+
+  const indexingCache = createIndexingCache({
+    common,
+    schemaBuild: { schema },
+    crashRecoveryCheckpoint: undefined,
+    eventCount,
+  });
+
+  const indexingStore = createIndexingStore({
+    common,
+    schemaBuild: { schema },
+    indexingCache,
+    indexingErrorHandler,
+  });
+
+  const indexing = createIndexing({
+    common,
+    indexingBuild: {
+      eventCallbacks: [eventCallbacks],
+      setupCallbacks: [setupCallbacks],
+      chains: [chain],
+      contracts: [contracts],
+      indexingFunctions,
+    },
+    indexingStore,
+    indexingCache,
+    client: cachedViemClient,
+    indexingErrorHandler,
+    columnAccessPattern,
+    eventCount,
+  });
+
+  const event = getSimulatedEvent({
+    eventCallback: eventCallbacks[0],
+    blockData,
+  });
+
+  await indexing.processHistoricalEvents({
+    events: [event],
+    updateIndexingSeconds: vi.fn(),
+  });
+  await indexing.processRealtimeEvents({ events: [event] });
+
+  expect(historicalFlags).toEqual([false]);
+  expect(realtimeFlags).toEqual([true]);
 });
 
 test("processEvents eventCount", async () => {

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -554,20 +554,17 @@ export const createIndexing = ({
           }
         }
 
-        // @ts-expect-error
-        await executeEvent(
-          { ...event, event: proxyEvent },
-          {
-            isRealtime: false,
-          },
-        );
+        await executeEvent({ ...event, event: proxyEvent } as Event, {
+          isRealtime: false,
+        });
 
         common.metrics.ponder_indexing_completed_events.inc(
           { event: event.eventCallback.name },
           1,
         );
-        columnAccessPattern.get(event.eventCallback.name)!.count++;
-        eventCount[event.eventCallback.name]++;
+        const eventName = event.eventCallback.name;
+        columnAccessPattern.get(eventName)!.count++;
+        eventCount[eventName] = (eventCount[eventName] ?? 0) + 1;
 
         const now = performance.now();
 
@@ -732,7 +729,8 @@ export const createIndexing = ({
           { event: event.eventCallback.name },
           1,
         );
-        eventCount[event.eventCallback.name]++;
+        const eventName = event.eventCallback.name;
+        eventCount[eventName] = (eventCount[eventName] ?? 0) + 1;
       }
     },
   };

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -81,6 +81,8 @@ export type Context = {
       endBlock?: number;
     }
   >;
+  /** `true` when the event is processed by the live indexer; `false` during historical backfill and setup. */
+  isRealtime: boolean;
 };
 
 export type Indexing = {
@@ -173,6 +175,7 @@ export const createIndexing = ({
       contracts: undefined!,
       client: undefined!,
       db: indexingStore.db,
+      isRealtime: false,
     } as Context,
   };
 
@@ -207,6 +210,7 @@ export const createIndexing = ({
 
         lastChainId = event.chain.id;
       }
+      indexingFunctionArg.context.isRealtime = false;
 
       const endClock = startClock();
 
@@ -265,7 +269,10 @@ export const createIndexing = ({
   };
 
   // metric label for "ponder_indexing_function_duration"
-  const executeEvent = async (event: Event): Promise<void> => {
+  const executeEvent = async (
+    event: Event,
+    params: { isRealtime: boolean },
+  ): Promise<void> => {
     try {
       if (event.chain.id !== lastChainId) {
         indexingFunctionArg.context.chain.id = event.chain.id;
@@ -276,6 +283,7 @@ export const createIndexing = ({
 
         lastChainId = event.chain.id;
       }
+      indexingFunctionArg.context.isRealtime = params.isRealtime;
       // @ts-ignore
       indexingFunctionArg.event = event.event;
 
@@ -547,7 +555,12 @@ export const createIndexing = ({
         }
 
         // @ts-expect-error
-        await executeEvent({ ...event, event: proxyEvent });
+        await executeEvent(
+          { ...event, event: proxyEvent },
+          {
+            isRealtime: false,
+          },
+        );
 
         common.metrics.ponder_indexing_completed_events.inc(
           { event: event.eventCallback.name },
@@ -713,7 +726,7 @@ export const createIndexing = ({
 
         client.event = event;
 
-        await executeEvent(event);
+        await executeEvent(event, { isRealtime: true });
 
         common.metrics.ponder_indexing_completed_events.inc(
           { event: event.eventCallback.name },

--- a/packages/core/src/types/virtual.test-d.ts
+++ b/packages/core/src/types/virtual.test-d.ts
@@ -467,5 +467,6 @@ test("Registry", () => {
     context.client;
     context.contracts.c1;
     context.contracts.c2;
+    context.isRealtime;
   });
 });

--- a/packages/core/src/types/virtual.ts
+++ b/packages/core/src/types/virtual.ts
@@ -220,6 +220,8 @@ export namespace Virtual {
         }[keyof sourceChain];
     client: Prettify<ReadonlyClient>;
     db: Db<schema>;
+    /** `true` when the event is processed by the live indexer; `false` during historical backfill. */
+    isRealtime: boolean;
   };
 
   export type IndexingFunctionArgs<


### PR DESCRIPTION
## feat: add `context.isRealtime` to indexing handlers

Indexing functions now receive **`context.isRealtime: boolean`**:

- **`false`** — event is handled during **historical backfill** or in a **`setup`** handler  
- **`true`** — event is handled by the **live** indexer  

Useful when behavior should differ between backfill and live (e.g. webhooks only on new blocks). Documented that **`true` does not mean “caught up to chain tip”** (live can still lag).

**Implementation:** set on the shared handler context from `processHistoricalEvents` / `processRealtimeEvents` (and `false` for setup). Types updated in `Virtual.Context`; API docs, indexing overview, migration guide, and changelog updated; tests assert historical vs realtime.

**Other:** typing/build fixes for the historical path (`Event` assertion for proxied `event`, safe `eventCount` updates under `noUncheckedIndexedAccess`).