### PR TITLE
fix: Make pglite in memory work

### DIFF
--- a/docs/pages/docs/api-reference/ponder/config.mdx
+++ b/docs/pages/docs/api-reference/ponder/config.mdx
@@ -44,6 +44,8 @@ Here is the logic Ponder uses to determine which database to use:
 | **kind**      | `"pglite"` |                                                                                 |
 | **directory** |  `string`  | **Default: `.ponder/pglite`**. Directory path to use for PGlite database files. |
 
+Set `directory` to `"memory://"` to use an in-memory database (data will not persist across restarts).
+
 ```ts [ponder.config.ts] {4-7}
 import { createConfig } from "ponder";
 

--- a/packages/core/src/_test/e2e/erc20/erc20.test.ts
+++ b/packages/core/src/_test/e2e/erc20/erc20.test.ts
@@ -72,3 +72,45 @@ test("erc20", async () => {
 
   await shutdown!();
 }, 15_000);
+
+test("erc20 with pglite memory://", async () => {
+  const port = await getFreePort();
+  const client = createClient(`http://localhost:${port}/sql`, { schema });
+
+  const shutdown = await start({
+    cliOptions: {
+      ...cliOptions,
+      config: "ponder.config.memory.ts",
+      command: "start",
+      port,
+      version: "0.0.0",
+    },
+  });
+
+  const { address } = await deployErc20({ sender: ALICE });
+
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+  await waitForIndexedBlock({
+    port,
+    chainName: "mainnet",
+    block: { number: 2 },
+  });
+
+  const result = await client.db.select().from(schema.account);
+
+  expect(result[0]).toMatchObject({
+    address: zeroAddress,
+    balance: -1n * 10n ** 18n,
+  });
+  expect(result[1]).toMatchObject({
+    address: ALICE.toLowerCase(),
+    balance: 10n ** 18n,
+  });
+
+  await shutdown!();
+}, 15_000);

--- a/packages/core/src/_test/e2e/erc20/ponder.config.memory.ts
+++ b/packages/core/src/_test/e2e/erc20/ponder.config.memory.ts
@@ -1,0 +1,21 @@
+import { createConfig } from "../../../config/index.js";
+import { erc20ABI } from "../../generated.js";
+
+const poolId = Number(process.env.VITEST_POOL_ID ?? 1);
+
+export default createConfig({
+  database: { kind: "pglite", directory: "memory://" },
+  chains: {
+    mainnet: {
+      id: 1,
+      rpc: `http://127.0.0.1:8545/${poolId}`,
+    },
+  },
+  contracts: {
+    Erc20: {
+      chain: "mainnet",
+      abi: erc20ABI,
+      address: "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+    },
+  },
+});

--- a/packages/core/src/utils/pglite.ts
+++ b/packages/core/src/utils/pglite.ts
@@ -19,12 +19,11 @@ export function createPglite(options: PGliteOptions) {
   // PGlite uses the memory FS by default, and Windows doesn't like the
   // "memory://" path, so it's better to pass `undefined` here.
   if (options.dataDir === "memory://") {
-    // @ts-expect-error
-    options.dataDir = undefined;
-  } else {
-    mkdirSync(options.dataDir, { recursive: true });
+    const { dataDir: _, ...rest } = options;
+    return new PGlite(rest);
   }
 
+  mkdirSync(options.dataDir, { recursive: true });
   return new PGlite(options);
 }
 


### PR DESCRIPTION
`createPglite()` was mutating options.dataDir to undefined for memory://, which broke downstream code that still referenced the original object. Basically Pglite API expects passing "memory://" string. 