### PR TITLE
chore: upgrade to ENSv2 (Universal Resolver)

### DIFF
--- a/examples/feature-accounts/package.json
+++ b/examples/feature-accounts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/feature-api-functions/package.json
+++ b/examples/feature-api-functions/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "hono": "^4.5.0",
     "ponder": "workspace:*",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/feature-blocks/package.json
+++ b/examples/feature-blocks/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/feature-call-traces/package.json
+++ b/examples/feature-call-traces/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/feature-factory/package.json
+++ b/examples/feature-factory/package.json
@@ -15,7 +15,7 @@
     "ponder": "workspace:*",
     "abitype": "^0.10.2",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/feature-filter/package.json
+++ b/examples/feature-filter/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/feature-multichain/package.json
+++ b/examples/feature-multichain/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/feature-proxy/package.json
+++ b/examples/feature-proxy/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/feature-read-contract/package.json
+++ b/examples/feature-read-contract/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/project-friendtech/package.json
+++ b/examples/project-friendtech/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/project-uniswap-v3-flash/package.json
+++ b/examples/project-uniswap-v3-flash/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/reference-erc1155/package.json
+++ b/examples/reference-erc1155/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/reference-erc20/package.json
+++ b/examples/reference-erc20/package.json
@@ -15,7 +15,7 @@
     "ponder": "workspace:*",
     "drizzle-kit": "0.22.8",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/reference-erc4626/package.json
+++ b/examples/reference-erc4626/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/reference-erc721/package.json
+++ b/examples/reference-erc721/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/with-client/ponder/package.json
+++ b/examples/with-client/ponder/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "hono": "^4.5.0",
     "ponder": "workspace:*",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/with-foundry/ponder/package.json
+++ b/examples/with-foundry/ponder/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.9.0",

--- a/examples/with-nextjs/frontend/package.json
+++ b/examples/with-nextjs/frontend/package.json
@@ -15,7 +15,7 @@
     "react": "^18.2.0",
     "react-countup": "^6.5.0",
     "react-dom": "^18",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/examples/with-nextjs/ponder/package.json
+++ b/examples/with-nextjs/ponder/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "ponder": "workspace:*",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/with-offchain/ponder/package.json
+++ b/examples/with-offchain/ponder/package.json
@@ -15,7 +15,7 @@
     "hono": "^4.5.0",
     "pg": "^8.11.3",
     "ponder": "workspace:*",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/with-trpc/ponder/package.json
+++ b/examples/with-trpc/ponder/package.json
@@ -15,7 +15,7 @@
     "ponder": "workspace:*",
     "@trpc/server": "^10.45.2",
     "hono": "^4.5.0",
-    "viem": "^2.21.3",
+    "viem": "^2.35.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint-staged": "^15.1.0",
     "simple-git-hooks": "^2.9.0",
     "typescript": "5.0.4",
-    "viem": "2.30.1"
+    "viem": "2.35.0"
   },
   "lint-staged": {
     "*.ts": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
   "peerDependencies": {
     "hono": ">=4.5",
     "typescript": ">=5.0.4",
-    "viem": ">=2"
+    "viem": ">=2.35"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -9,12 +9,7 @@
     "url": "https://github.com/ponder-sh/ponder",
     "directory": "packages/create-ponder"
   },
-  "files": [
-    "dist",
-    "templates",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "templates", "README.md", "LICENSE"],
   "bin": {
     "create-ponder": "./dist/index.js"
   },
@@ -35,7 +30,7 @@
     "prompts": "^2.4.2",
     "update-check": "^1.5.4",
     "validate-npm-package-name": "^5.0.0",
-    "viem": "^2.21.3",
+    "viem": "^2.35.0",
     "yaml": "^2.3.4"
   },
   "devDependencies": {

--- a/packages/create-ponder/templates/empty/package.json
+++ b/packages/create-ponder/templates/empty/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "ponder": "^0.0.95",
     "hono": "^4.5.0",
-    "viem": "^2.21.3"
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/node": "^20.9.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.4",
-    "viem": ">=2"
+    "viem": ">=2.35"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       viem:
-        specifier: 2.30.1
-        version: 2.30.1(typescript@5.0.4)(zod@3.23.8)
+        specifier: 2.35.0
+        version: 2.35.0(typescript@5.0.4)(zod@3.23.8)
 
   benchmark:
     devDependencies:
@@ -112,8 +112,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -137,8 +137,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -162,8 +162,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -187,8 +187,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -215,8 +215,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -240,8 +240,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -265,8 +265,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -290,8 +290,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -315,8 +315,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -340,8 +340,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -365,8 +365,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -390,8 +390,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -418,8 +418,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -443,8 +443,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -468,8 +468,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -508,8 +508,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -534,7 +534,7 @@ importers:
     dependencies:
       forge-std:
         specifier: github:foundry-rs/forge-std
-        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/799589bfa97698c2bdf0ba8df4d461b607e36c57
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8987040ede9553cea20c95ad40d0455930f9c8e0
 
   examples/with-foundry/ponder:
     dependencies:
@@ -545,8 +545,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -590,8 +590,8 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -624,8 +624,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -676,8 +676,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -718,8 +718,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/core
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -952,8 +952,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       viem:
-        specifier: ^2.21.3
-        version: 2.21.3(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^2.35.0
+        version: 2.35.0(typescript@5.3.3)(zod@3.23.8)
       yaml:
         specifier: ^2.3.4
         version: 2.3.4
@@ -2515,11 +2515,8 @@ packages:
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
-  '@noble/curves@1.4.0':
-    resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
-
-  '@noble/curves@1.9.1':
-    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+  '@noble/curves@1.9.6':
+    resolution: {integrity: sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.3.2':
@@ -2529,14 +2526,6 @@ packages:
   '@noble/hashes@1.3.3':
     resolution: {integrity: sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==}
     engines: {node: '>= 16'}
-
-  '@noble/hashes@1.4.0':
-    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
-    engines: {node: '>= 16'}
-
-  '@noble/hashes@1.5.0':
-    resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
-    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -3391,17 +3380,11 @@ packages:
   '@scure/bip32@1.3.2':
     resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
 
-  '@scure/bip32@1.4.0':
-    resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
-
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
   '@scure/bip39@1.2.1':
     resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
-
-  '@scure/bip39@1.4.0':
-    resolution: {integrity: sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==}
 
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
@@ -3957,6 +3940,17 @@ packages:
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5323,9 +5317,9 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/799589bfa97698c2bdf0ba8df4d461b607e36c57:
-    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/799589bfa97698c2bdf0ba8df4d461b607e36c57}
-    version: 1.12.0
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/8987040ede9553cea20c95ad40d0455930f9c8e0:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8987040ede9553cea20c95ad40d0455930f9c8e0}
+    version: 1.16.0
 
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -5417,11 +5411,12 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -5709,11 +5704,6 @@ packages:
 
   isows@1.0.3:
     resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
-    peerDependencies:
-      ws: '*'
-
-  isows@1.0.4:
-    resolution: {integrity: sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==}
     peerDependencies:
       ws: '*'
 
@@ -6414,8 +6404,8 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
-  ox@0.7.1:
-    resolution: {integrity: sha512-+k9fY9PRNuAMHRFIUbiK9Nt5seYHHzSQs9Bj+iMETcGtlpS7SmBzcGSVUQO3+nqGLEiNK4598pHNFlVRaZbRsg==}
+  ox@0.8.7:
+    resolution: {integrity: sha512-W1f0FiMf9NZqtHPEDEAEkyzZDwbIKfmH2qmQx8NNiQ/9JhxrSblmtLJsSfTtQG5YKowLOnBlLVguCyxm/7ztxw==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -7411,6 +7401,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
@@ -7743,16 +7734,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.21.3:
-    resolution: {integrity: sha512-WwOEsoiJ4v1zHf1OeKdtWth+chMyY/yZbHRLidhZEr0yFsOjTXkyfuvFp5ZykjRv9EtzDr2C6K/MU26CjMkSUw==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  viem@2.30.1:
-    resolution: {integrity: sha512-CkoS5Vv6kiRGmRF2xO2z275Gu90vTrKZHf/ckYXxP2J94UvCnFvUcbRdfit6uebj1I8nFwkGlkkOMuOZDHyO4w==}
+  viem@2.35.0:
+    resolution: {integrity: sha512-u4D4PACHoVTBqfWEM1B3QsraZSP2Pe4rWLxTFRTn4PJbLqQl6IjQuFLMTjyRpw8VgmNw5c0lmCAZwLRgEMe6nw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -7912,9 +7895,6 @@ packages:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
 
-  webauthn-p256@0.0.5:
-    resolution: {integrity: sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg==}
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -7962,30 +7942,6 @@ packages:
 
   ws@8.13.0:
     resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.2:
-    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9225,21 +9181,13 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.2
 
-  '@noble/curves@1.4.0':
-    dependencies:
-      '@noble/hashes': 1.4.0
-
-  '@noble/curves@1.9.1':
+  '@noble/curves@1.9.6':
     dependencies:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.3.3': {}
-
-  '@noble/hashes@1.4.0': {}
-
-  '@noble/hashes@1.5.0': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -10099,26 +10047,15 @@ snapshots:
       '@noble/hashes': 1.3.3
       '@scure/base': 1.1.8
 
-  '@scure/bip32@1.4.0':
-    dependencies:
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.8
-
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.6
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.5
 
   '@scure/bip39@1.2.1':
     dependencies:
       '@noble/hashes': 1.3.3
-      '@scure/base': 1.1.8
-
-  '@scure/bip39@1.4.0':
-    dependencies:
-      '@noble/hashes': 1.5.0
       '@scure/base': 1.1.8
 
   '@scure/bip39@1.6.0':
@@ -10856,6 +10793,21 @@ snapshots:
   abitype@1.0.8(typescript@5.0.4)(zod@3.23.8):
     optionalDependencies:
       typescript: 5.0.4
+      zod: 3.23.8
+
+  abitype@1.0.8(typescript@5.3.3)(zod@3.23.8):
+    optionalDependencies:
+      typescript: 5.3.3
+      zod: 3.23.8
+
+  abitype@1.2.3(typescript@5.0.4)(zod@3.23.8):
+    optionalDependencies:
+      typescript: 5.0.4
+      zod: 3.23.8
+
+  abitype@1.2.3(typescript@5.3.3)(zod@3.23.8):
+    optionalDependencies:
+      typescript: 5.3.3
       zod: 3.23.8
 
   abort-controller@3.0.0:
@@ -12264,7 +12216,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/799589bfa97698c2bdf0ba8df4d461b607e36c57: {}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/8987040ede9553cea20c95ad40d0455930f9c8e0: {}
 
   format@0.2.2: {}
 
@@ -12696,13 +12648,9 @@ snapshots:
     dependencies:
       ws: 8.13.0
 
-  isows@1.0.4(ws@8.17.1):
+  isows@1.0.7(ws@8.18.3):
     dependencies:
-      ws: 8.17.1
-
-  isows@1.0.7(ws@8.18.2):
-    dependencies:
-      ws: 8.18.2
+      ws: 8.18.3
 
   jackspeak@3.4.3:
     dependencies:
@@ -13676,18 +13624,33 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  ox@0.7.1(typescript@5.0.4)(zod@3.23.8):
+  ox@0.8.7(typescript@5.0.4)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.6
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.0.4)(zod@3.23.8)
+      abitype: 1.2.3(typescript@5.0.4)(zod@3.23.8)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.0.4
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.8.7(typescript@5.3.3)(zod@3.23.8):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.3.3)(zod@3.23.8)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - zod
 
@@ -15184,36 +15147,35 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.21.3(typescript@5.3.3)(zod@3.23.8):
+  viem@2.35.0(typescript@5.0.4)(zod@3.23.8):
     dependencies:
-      '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.4.0
-      abitype: 1.0.5(typescript@5.3.3)(zod@3.23.8)
-      isows: 1.0.4(ws@8.17.1)
-      webauthn-p256: 0.0.5
-      ws: 8.17.1
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.0.4)(zod@3.23.8)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.8.7(typescript@5.0.4)(zod@3.23.8)
+      ws: 8.18.3
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.0.4
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
 
-  viem@2.30.1(typescript@5.0.4)(zod@3.23.8):
+  viem@2.35.0(typescript@5.3.3)(zod@3.23.8):
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.6
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.0.4)(zod@3.23.8)
-      isows: 1.0.7(ws@8.18.2)
-      ox: 0.7.1(typescript@5.0.4)(zod@3.23.8)
-      ws: 8.18.2
+      abitype: 1.0.8(typescript@5.3.3)(zod@3.23.8)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.8.7(typescript@5.3.3)(zod@3.23.8)
+      ws: 8.18.3
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.3.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -15583,11 +15545,6 @@ snapshots:
 
   web-streams-polyfill@3.2.1: {}
 
-  webauthn-p256@0.0.5:
-    dependencies:
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.8.0
-
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@4.0.2: {}
@@ -15639,10 +15596,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.13.0: {}
-
-  ws@8.17.1: {}
-
-  ws@8.18.2: {}
 
   ws@8.18.3: {}
 


### PR DESCRIPTION
Hey! I'm Dhaiwat from DevRel at ENS Labs — getting libraries across the ecosystem ready for ENSv2.

This PR tightens the viem peer dep in `packages/core` and `packages/utils` from `>=2` to `>=2.35` (first viem with the Universal Resolver). Without this, downstream indexers can install old viem and silently use legacy ENS resolution — Ponder exposes viem's ENS getters to user-written indexing code.

Bumps pinned viem in examples, templates, and root from `^2.21.3` (and `2.30.1` at root) to `2.35.0` to match the new floor. **Note:** newer 2.x (tested 2.48.4) breaks Ponder's typecheck.

Verification: `ur.integration-tests.eth` → `0x2222222222222222222222222222222222222222` (legacy resolution incorrectly returns `0x1111111111111111111111111111111111111111`).

More: https://docs.ens.domains/web/ensv2-readiness

