### PR TITLE
fix: include public schema in PGLite search_path for raw SQL queries

### DIFF
--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -646,7 +646,12 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
 
           if (dialect === "pglite" || dialect === "pglite_test") {
             await tx.wrap(
-              (tx) => tx.execute(`SET search_path TO "${namespace.schema}"`),
+              (tx) =>
+                tx.execute(
+                  namespace.schema === "public"
+                    ? `SET search_path TO "public"`
+                    : `SET search_path TO "${namespace.schema}", "public"`,
+                ),
               context,
             );
           }
@@ -992,6 +997,19 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
           error.stack = undefined;
           throw error;
         }
+      }
+
+      // Set search_path on the PGlite instance directly (using exec) to
+      // ensure it persists for all subsequent queries, including raw SQL
+      // issued by user code via db.execute(). This is the PGlite equivalent
+      // of the search_path that is set per-connection in createReadonlyPool
+      // for Postgres.
+      if (dialect === "pglite" || dialect === "pglite_test") {
+        const searchPath =
+          namespace.schema === "public"
+            ? `SET search_path TO "public"`
+            : `SET search_path TO "${namespace.schema}", "public"`;
+        await (driver as PGliteDriver).instance.exec(searchPath);
       }
 
       heartbeatInterval = setInterval(async () => {


### PR DESCRIPTION
## Summary
- Raw SQL queries via `db.execute()` return 0 rows in dev mode (PGLite) while Drizzle ORM queries work correctly
- **Root cause:** The `SET search_path` only included the namespace schema, excluding `public`. Drizzle ORM uses schema-qualified names internally so it worked, but raw SQL with unqualified table names failed silently.
- **Fix (two parts):**
  1. Include `public` alongside the namespace schema in the in-migration `SET search_path` when the namespace is not already `public`
  2. Set `search_path` persistently after migration via PGLite's `exec()` method (analogous to how the Postgres driver sets it per-connection via `createReadonlyPool`)

**File:** `packages/core/src/database/index.ts`

Fixes #2235

## Test plan
- [ ] Run ponder in dev mode (PGLite), execute raw SQL via `db.execute(sql\`SELECT * FROM "TableName"\`)` — should return rows
- [ ] Verify Drizzle ORM queries still work
- [ ] Verify production Postgres mode is unaffected