### PR TITLE
Add env config option for custom factory address count threshold

### DIFF
--- a/.changeset/neat-parrots-read.md
+++ b/.changeset/neat-parrots-read.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Added support for configuring `factoryAddressCountThreshold` via the `PONDER_FACTORY_ADDRESS_COUNT_THRESHOLD` environment variable.

--- a/packages/core/src/internal/options.ts
+++ b/packages/core/src/internal/options.ts
@@ -110,7 +110,10 @@ export const buildOptions = ({ cliOptions }: { cliOptions: CliOptions }) => {
         ? Number(process.env.PONDER_MAX_THREADS)
         : 4,
 
-    factoryAddressCountThreshold: 1_000,
+    factoryAddressCountThreshold:
+      process.env.PONDER_FACTORY_ADDRESS_COUNT_THRESHOLD !== undefined
+        ? Number(process.env.PONDER_FACTORY_ADDRESS_COUNT_THRESHOLD)
+        : 1_000,
 
     rpcMaxConcurrency: 256,
 


### PR DESCRIPTION
## Summary

Exposes `factoryAddressCountThreshold` via a `PONDER_FACTORY_ADDRESS_COUNT_THRESHOLD` environment variable, mirroring the existing pattern for `PONDER_MAX_THREADS` and `PONDER_CACHE_BYTES`. Default behavior is unchanged (still 1,000).

## Motivation

The threshold controls when factory sync switches from per-child-address `eth_getLogs` calls to a broader scan with in-memory filtering. The right value depends on the RPC provider, the factory's child-address cardinality, and the historical block range — so the default isn't always optimal.

In our case (an NFT-heavy indexer with many factory deployments), the per-address path produces a request volume that overwhelms the RPC, while raising the threshold keeps sync on the broad-scan path and finishes in a fraction of the time. We've been shipping this as a `pnpm patch` against `dist/` for a few releases; an env var lets us (and others in the same boat) drop the patch.

## Test plan

- [x] Existing tests pass (`pnpm test` in `packages/core`)
- [x] Verified locally that setting `PONDER_FACTORY_ADDRESS_COUNT_THRESHOLD=9007199254740991` keeps factory sync on the broad-scan path
- [x] Unset env var → behavior identical to current `main`