### PR TITLE
fix: prevent flush() crashes from concurrent calls and mid-flush qb mutation

### DIFF
--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -528,12 +528,13 @@ export const createIndexingCache = ({
     },
     async flush({ tableNames } = {}) {
       const sp = `flush_${++_flushId}`;
+      const currentQb = qb; // snapshot to prevent external mutation between SAVEPOINT and RELEASE
       const context = {
         logger: common.logger.child({ action: "flush_database_rows" }),
       };
       const flushEndClock = startClock();
 
-      const copy = getCopyHelper(qb, chainId);
+      const copy = getCopyHelper(currentQb, chainId);
 
       const flushTable = async (table: Table) => {
         const shouldRecordBytes = cache.get(table)!.isCacheComplete;
@@ -567,7 +568,7 @@ export const createIndexingCache = ({
 
             await copy(table, text);
           } else {
-            await qb.wrap(
+            await currentQb.wrap(
               (db) =>
                 db.insert(table).values(insertValues.map(({ row }) => row)),
               context,
@@ -627,7 +628,7 @@ export const createIndexingCache = ({
                 .map(({ sql }) => `target."${sql}" = source."${sql}"`)
                 .join(" AND ")};`;
 
-            await qb.wrap((db) => db.execute(createTempTableQuery), context);
+            await currentQb.wrap((db) => db.execute(createTempTableQuery), context);
 
             const text = getCopyText(
               table,
@@ -636,13 +637,13 @@ export const createIndexingCache = ({
             await new Promise(setImmediate);
 
             await copy(table, text, false);
-            await qb.wrap((db) => db.execute(updateQuery), context);
-            await qb.wrap(
+            await currentQb.wrap((db) => db.execute(updateQuery), context);
+            await currentQb.wrap(
               (db) => db.execute(`TRUNCATE TABLE "${target}"`),
               context,
             );
           } else {
-            await qb.wrap(
+            await currentQb.wrap(
               (db) =>
                 db
                   .insert(table)
@@ -697,14 +698,14 @@ export const createIndexingCache = ({
       };
 
       try {
-        if (qb.$dialect === "postgres") {
-          await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
+        if (currentQb.$dialect === "postgres") {
+          await currentQb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
 
           await promiseAllSettledWithThrow(
             Array.from(cache.keys()).map(flushTable),
           );
 
-          await qb.wrap((db) => db.execute(`RELEASE ${sp}`), context);
+          await currentQb.wrap((db) => db.execute(`RELEASE ${sp}`), context);
         } else {
           // Note: pglite must run sequentially
           for (const table of cache.keys()) {
@@ -713,7 +714,7 @@ export const createIndexingCache = ({
         }
       } catch (_error) {
         let error = _error as Error;
-        if (error instanceof ShutdownError || qb.$dialect === "pglite") {
+        if (error instanceof ShutdownError || currentQb.$dialect === "pglite") {
           throw error;
         }
 
@@ -721,7 +722,7 @@ export const createIndexingCache = ({
         // function takes an optimized fast path, with support for small batch sizes. PGlite always takes
         // the fast path because it doesn't support delayed insert errors.
 
-        await qb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
+        await currentQb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
 
         for (const table of cache.keys()) {
           if (
@@ -742,19 +743,19 @@ export const createIndexingCache = ({
           if (insertValues.length > 0) {
             const endClock = startClock();
 
-            await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
+            await currentQb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
 
             const result = await recoverBatchError(
               insertValues,
               async (values) => {
-                await qb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
+                await currentQb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
                 const text = getCopyText(
                   table,
                   values.map(({ row }) => row),
                 );
                 await copy(table, text);
 
-                await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
+                await currentQb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
               },
             );
 
@@ -808,24 +809,24 @@ export const createIndexingCache = ({
 
             const endClock = startClock();
 
-            await qb.wrap((db) => db.execute(createTempTableQuery), context);
-            await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
+            await currentQb.wrap((db) => db.execute(createTempTableQuery), context);
+            await currentQb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
 
             const result = await recoverBatchError(
               updateValues,
               async (values) => {
-                await qb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
+                await currentQb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
                 const text = getCopyText(
                   table,
                   values.map(({ row }) => row),
                 );
                 await copy(table, text, false);
 
-                await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
+                await currentQb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
               },
             );
 
-            await qb.wrap(
+            await currentQb.wrap(
               (db) => db.execute(`TRUNCATE TABLE "${target}"`),
               context,
             );

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -355,6 +355,7 @@ export const createIndexingCache = ({
 }): IndexingCache => {
   let event: Event | undefined;
   let qb: QB = undefined!;
+  let _flushId = 0;
 
   const cache: Cache = new Map();
   const insertBuffer: Buffer = new Map();
@@ -526,6 +527,7 @@ export const createIndexingCache = ({
       return inInsertBuffer || inUpdateBuffer || inDb;
     },
     async flush({ tableNames } = {}) {
+      const sp = `flush_${++_flushId}`;
       const context = {
         logger: common.logger.child({ action: "flush_database_rows" }),
       };
@@ -696,13 +698,13 @@ export const createIndexingCache = ({
 
       try {
         if (qb.$dialect === "postgres") {
-          await qb.wrap((db) => db.execute("SAVEPOINT flush"), context);
+          await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
 
           await promiseAllSettledWithThrow(
             Array.from(cache.keys()).map(flushTable),
           );
 
-          await qb.wrap((db) => db.execute("RELEASE flush"), context);
+          await qb.wrap((db) => db.execute(`RELEASE ${sp}`), context);
         } else {
           // Note: pglite must run sequentially
           for (const table of cache.keys()) {
@@ -719,7 +721,7 @@ export const createIndexingCache = ({
         // function takes an optimized fast path, with support for small batch sizes. PGlite always takes
         // the fast path because it doesn't support delayed insert errors.
 
-        await qb.wrap((db) => db.execute("ROLLBACK to flush"), context);
+        await qb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
 
         for (const table of cache.keys()) {
           if (
@@ -740,19 +742,19 @@ export const createIndexingCache = ({
           if (insertValues.length > 0) {
             const endClock = startClock();
 
-            await qb.wrap((db) => db.execute("SAVEPOINT flush"), context);
+            await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
 
             const result = await recoverBatchError(
               insertValues,
               async (values) => {
-                await qb.wrap((db) => db.execute("ROLLBACK to flush"), context);
+                await qb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
                 const text = getCopyText(
                   table,
                   values.map(({ row }) => row),
                 );
                 await copy(table, text);
 
-                await qb.wrap((db) => db.execute("SAVEPOINT flush"), context);
+                await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
               },
             );
 
@@ -807,19 +809,19 @@ export const createIndexingCache = ({
             const endClock = startClock();
 
             await qb.wrap((db) => db.execute(createTempTableQuery), context);
-            await qb.wrap((db) => db.execute("SAVEPOINT flush"), context);
+            await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
 
             const result = await recoverBatchError(
               updateValues,
               async (values) => {
-                await qb.wrap((db) => db.execute("ROLLBACK to flush"), context);
+                await qb.wrap((db) => db.execute(`ROLLBACK to ${sp}`), context);
                 const text = getCopyText(
                   table,
                   values.map(({ row }) => row),
                 );
                 await copy(table, text, false);
 
-                await qb.wrap((db) => db.execute("SAVEPOINT flush"), context);
+                await qb.wrap((db) => db.execute(`SAVEPOINT ${sp}`), context);
               },
             );
 


### PR DESCRIPTION
## Problem

Two related bugs cause `savepoint \"flush_N\" does not exist` crashes in multichain realtime mode, crashing the process via `unhandledRejection`.

### Bug 1 — Concurrent flush() calls collide on savepoint name

When multiple concurrent `context.db.sql` calls are made from the same block handler (e.g. via `Promise.all`), each triggers `indexingCache.flush()`. All used the hardcoded savepoint name `\"flush\"`, corrupting each other:

```
Call 1: SAVEPOINT flush   ← creates \"flush\"
Call 2: SAVEPOINT flush   ← replaces \"flush\" in the savepoint stack
Call 1: RELEASE flush     ← releases Call 2's savepoint, not Call 1's
Call 2: RELEASE flush     ← savepoint \"flush\" does not exist → crash
```

### Bug 2 — `qb` is mutated externally between SAVEPOINT and RELEASE

`indexingCache.qb` is set externally by `multichain.ts` — reset to the raw pool connection before each blockchain block's RPC prefetch, then reset to the active DB transaction inside the block. If this reset happens **while a `flush()` is in progress** (between the `SAVEPOINT` and `RELEASE` calls), the `RELEASE` runs on a different connection that never had the savepoint:

```
flush():     SAVEPOINT flush_N   ← runs on tx connection
multichain:  indexingCache.qb = pool  ← resets qb mid-flush
flush():     RELEASE flush_N    ← now runs on pool, savepoint doesn't exist → crash
```

This is the root cause in multichain realtime mode: `qb` changes between async operations within a single `flush()` invocation.

## Reproduction

```typescript
// In a realtime block handler (both chains active):
await Promise.all([
  context.db.sql.select(...),
  context.db.sql.select(...),
]);
// → crash: savepoint \"flush_N\" does not exist → unhandledRejection → process.exit()
```

Also triggered by a single `context.db.sql` call if `multichain.ts` resets `qb` to pool during the async `flushTable` operations.

## Fix

Two changes to `createIndexingCache`:

**1. Unique savepoint name per invocation** — prevents concurrent flush() calls from colliding:

```ts
let _flushId = 0;

async flush({ tableNames } = {}) {
  const sp = `flush_${++_flushId}`;
  // use sp instead of \"flush\" throughout
```

**2. Snapshot `qb` at flush() start** — prevents mid-flush external mutation from affecting in-progress SAVEPOINT/RELEASE/ROLLBACK TO:

```ts
async flush({ tableNames } = {}) {
  const sp = `flush_${++_flushId}`;
  const currentQb = qb; // snapshot — external changes to indexingCache.qb won't affect this flush
  const copy = getCopyHelper(currentQb, chainId);
  // use currentQb.wrap(...) and currentQb.$dialect throughout
```

## Notes

- `_flushId` is per-instance (scoped to `createIndexingCache`) — different cache instances don't share state
- The retry logic inside `flush()` reuses the same `sp` for inner savepoints — correct, as they belong to the same flush invocation
- Both fixes are required: unique names prevent concurrent-call collisions; the `qb` snapshot prevents mid-flush mutation crashes (which can occur even with a single `flush()` call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)