### PR TITLE
Add experimental range-scan realtime sync to reduce RPC usage on L2 chains

### DIFF
--- a/.changeset/experimental-range-scan.md
+++ b/.changeset/experimental-range-scan.md
@@ -1,0 +1,5 @@
+---
+"ponder": minor
+---
+
+Added an experimental `experimentalRangeScan` chain config option. When enabled, the realtime indexing engine scans each polling interval with a single ranged `eth_getLogs` request instead of fetching every block, so a `pollingInterval` larger than the chain's block time reduces RPC usage. Useful for high-throughput L2 chains. Only applies to chains whose indexed sources are exclusively non-factory `log` events.

--- a/docs/pages/docs/api-reference/ponder/config.mdx
+++ b/docs/pages/docs/api-reference/ponder/config.mdx
@@ -158,6 +158,7 @@ export default createConfig({
 | **pollingInterval**       |  `number`                          | **Default: `1_000`**. Frequency (in ms) used when polling for new events on this chain.                                                                                         |
 | **disableCache**          |  `boolean`                         | **Default: `false`**. Disables the RPC request cache. Use when indexing a [local node](/docs/guides/foundry) like Anvil.                                                        |
 | **ethGetLogsBlockRange** |  `number`                          | **Default: `undefined`**. Maximum block range for `eth_getLogs` requests. If undefined, Ponder will attempt to determine the block range automatically based on error messages. |
+| **experimentalRangeScan** |  `boolean`                         | **Default: `false`**. Experimental. Reduce realtime RPC usage by scanning each polling interval with a single ranged `eth_getLogs` request. Only applies to chains with exclusively non-factory `log` sources. |
 
 ### `contracts`
 

--- a/docs/pages/docs/config/chains.mdx
+++ b/docs/pages/docs/config/chains.mdx
@@ -201,6 +201,8 @@ export default createConfig({
 
 This option only applies to chains whose indexed sources are exclusively `log` events with a static `address`. Chains that use factory, block, transaction, trace, or transfer sources — or a `log` source that matches every address — fall back to the default per-block realtime sync.
 
+Each scan costs about two requests no matter how many blocks elapsed, so this option only reduces RPC usage when `pollingInterval` is several times the chain's block time — roughly 4x or more. Below that it can cost *more* than the default per-block sync, which is why it is not useful on chains with slow blocks. Ponder logs a warning if it observes too few blocks per poll.
+
 This option also ignores the [`ws`](#websocket) option. A `newHeads` subscription delivers every block, which would run one scan per block and cost more than the default per-block sync. Polling bounds the scan rate to `pollingInterval`.
 
 :::warning

--- a/docs/pages/docs/config/chains.mdx
+++ b/docs/pages/docs/config/chains.mdx
@@ -161,7 +161,9 @@ export default createConfig({
 
 The `pollingInterval` option controls how frequently (in milliseconds) the indexing engine checks for a new block in realtime. The default is `1000` (1 second).
 
-If you set `pollingInterval` greater than the chain's block time, it **does not reduce RPC usage**. The indexing engine still fetches every block to check for reorgs. The default is suitable for most chains.
+By default, setting `pollingInterval` greater than the chain's block time **does not reduce RPC usage**. The indexing engine still fetches every block to check for reorgs. The default is suitable for most chains.
+
+To reduce RPC usage on high-throughput chains (e.g. L2s with sub-second block times), enable [`experimentalRangeScan`](#range-scan-experimental) alongside a larger `pollingInterval`.
 
 ```ts [ponder.config.ts]
 import { createConfig } from "ponder";
@@ -176,6 +178,32 @@ export default createConfig({
   },
 });
 ```
+
+## Range scan (experimental)
+
+The `experimentalRangeScan` option reduces realtime RPC usage by scanning each polling interval with a single ranged `eth_getLogs` request instead of fetching every block. When enabled, a `pollingInterval` larger than the chain's block time reduces RPC usage proportionally — useful for high-throughput L2 chains.
+
+```ts [ponder.config.ts]
+import { createConfig } from "ponder";
+
+export default createConfig({
+  chains: {
+    base: {
+      id: 8453,
+      rpc: process.env.PONDER_RPC_URL_8453,
+      pollingInterval: 5_000, // 5 seconds [!code focus]
+      experimentalRangeScan: true, // [!code focus]
+    },
+  },
+  contracts: { /* ... */ },
+});
+```
+
+This option only applies to chains whose indexed sources are exclusively non-factory `log` events. Chains that use factory, block, transaction, trace, or transfer sources fall back to the default per-block realtime sync.
+
+:::warning
+This option is experimental. It changes how reorgs are detected in realtime (by diffing the block hashes of event-bearing blocks rather than tracing a contiguous chain of block hashes). The default is `false`.
+:::
 
 ## Disable caching
 

--- a/docs/pages/docs/config/chains.mdx
+++ b/docs/pages/docs/config/chains.mdx
@@ -201,8 +201,10 @@ export default createConfig({
 
 This option only applies to chains whose indexed sources are exclusively non-factory `log` events. Chains that use factory, block, transaction, trace, or transfer sources fall back to the default per-block realtime sync.
 
+This option also ignores the [`ws`](#websocket) option. A `newHeads` subscription delivers every block, which would run one scan per block and cost more than the default per-block sync. Polling bounds the scan rate to `pollingInterval`.
+
 :::warning
-This option is experimental. It changes how reorgs are detected in realtime (by diffing the block hashes of event-bearing blocks rather than tracing a contiguous chain of block hashes). The default is `false`.
+This option is experimental. It changes how reorgs are detected in realtime (by diffing the block hashes reported by each scan of the unfinalized window rather than tracing a contiguous chain of block hashes). The default is `false`.
 :::
 
 ## Disable caching

--- a/docs/pages/docs/config/chains.mdx
+++ b/docs/pages/docs/config/chains.mdx
@@ -199,7 +199,7 @@ export default createConfig({
 });
 ```
 
-This option only applies to chains whose indexed sources are exclusively non-factory `log` events. Chains that use factory, block, transaction, trace, or transfer sources fall back to the default per-block realtime sync.
+This option only applies to chains whose indexed sources are exclusively `log` events with a static `address`. Chains that use factory, block, transaction, trace, or transfer sources — or a `log` source that matches every address — fall back to the default per-block realtime sync.
 
 This option also ignores the [`ws`](#websocket) option. A `newHeads` subscription delivers every block, which would run one scan per block and cost more than the default per-block sync. Polling bounds the scan rate to `pollingInterval`.
 

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -661,7 +661,10 @@ export const getSimulatedEvent = ({
   return events[0]!;
 };
 
-export const getChain = (params?: { finalityBlockCount?: number }) => {
+export const getChain = (params?: {
+  finalityBlockCount?: number;
+  experimentalRangeScan?: boolean;
+}) => {
   return {
     name: "mainnet",
     id: 1,
@@ -671,6 +674,7 @@ export const getChain = (params?: { finalityBlockCount?: number }) => {
     finalityBlockCount: params?.finalityBlockCount ?? 1,
     disableCache: false,
     ethGetLogsBlockRange: undefined,
+    experimentalRangeScan: params?.experimentalRangeScan ?? false,
     viemChain: anvil,
   } satisfies Chain;
 };

--- a/packages/core/src/build/config.ts
+++ b/packages/core/src/build/config.ts
@@ -1061,6 +1061,7 @@ export function buildConfig({
         finalityBlockCount: getFinalityBlockCount({ chain: matchedChain }),
         disableCache: chain.disableCache ?? false,
         ethGetLogsBlockRange: chain.ethGetLogsBlockRange,
+        experimentalRangeScan: chain.experimentalRangeScan ?? false,
         viemChain: matchedChain,
       } satisfies Chain;
     },

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -109,6 +109,18 @@ type ChainConfig<chain> = {
    * attempt to determine the block range automatically based on error messages.
    */
   ethGetLogsBlockRange?: number;
+  /**
+   * Experimental. Reduce realtime RPC usage by scanning each polling interval
+   * with a single ranged `eth_getLogs` request instead of fetching every block.
+   *
+   * When enabled, a `pollingInterval` larger than the chain's block time
+   * reduces RPC usage proportionally. Useful for high-throughput L2 chains.
+   *
+   * Only applies to chains whose indexed sources are exclusively non-factory
+   * `log` events. Chains using factory, block, transaction, trace, or transfer
+   * sources fall back to the default per-block realtime sync. Default: `false`.
+   */
+  experimentalRangeScan?: boolean;
 };
 
 type ChainsConfig<chains> = {} extends chains

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -305,6 +305,7 @@ export type Chain = {
   finalityBlockCount: number;
   disableCache: boolean;
   ethGetLogsBlockRange: number | undefined;
+  experimentalRangeScan: boolean;
   viemChain: ViemChain | undefined;
 };
 

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -733,15 +733,7 @@ export const createRpc = ({
 
             interval = setInterval(async () => {
               try {
-                // The range-scan path only needs the head block header; full
-                // transactions are fetched per-block as needed. `false` returns
-                // a full header at runtime, but is typed as `LightBlock`.
-                const block = chain.experimentalRangeScan
-                  ? ((await eth_getBlockByNumber(rpc, [
-                      "latest",
-                      false,
-                    ])) as unknown as SyncBlockHeader)
-                  : await eth_getBlockByNumber(rpc, ["latest", true]);
+                const block = await eth_getBlockByNumber(rpc, ["latest", true]);
                 common.logger.trace({
                   msg: "Received successful JSON-RPC polling response",
                   chain: chain.name,

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -702,11 +702,28 @@ export const createRpc = ({
     // @ts-expect-error
     request: (parameters, context) => queue.add({ body: parameters, context }),
     subscribe({ onBlock, onError }) {
+      // The range-scan path scans the entire unfinalized window on every head,
+      // so its cost is per-head, not per-block. A "newHeads" subscription
+      // delivers every block, which would make it more expensive than the
+      // default per-block sync. Use polling to bound the scan rate to
+      // `pollingInterval`.
+      if (chain.ws !== undefined && chain.experimentalRangeScan) {
+        common.logger.warn({
+          msg: "Ignoring 'ws' because 'experimentalRangeScan' is enabled. Using a polling subscription so that realtime RPC usage is bounded by 'pollingInterval'.",
+          chain: chain.name,
+          chain_id: chain.id,
+        });
+      }
+
       (async () => {
         while (true) {
           if (isUnsubscribed) return;
 
-          if (chain.ws === undefined || webSocketErrorCount >= RETRY_COUNT) {
+          if (
+            chain.ws === undefined ||
+            chain.experimentalRangeScan ||
+            webSocketErrorCount >= RETRY_COUNT
+          ) {
             common.logger.debug({
               msg: "Created JSON-RPC polling subscription",
               chain: chain.name,

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -716,7 +716,15 @@ export const createRpc = ({
 
             interval = setInterval(async () => {
               try {
-                const block = await eth_getBlockByNumber(rpc, ["latest", true]);
+                // The range-scan path only needs the head block header; full
+                // transactions are fetched per-block as needed. `false` returns
+                // a full header at runtime, but is typed as `LightBlock`.
+                const block = chain.experimentalRangeScan
+                  ? ((await eth_getBlockByNumber(rpc, [
+                      "latest",
+                      false,
+                    ])) as unknown as SyncBlockHeader)
+                  : await eth_getBlockByNumber(rpc, ["latest", true]);
                 common.logger.trace({
                   msg: "Received successful JSON-RPC polling response",
                   chain: chain.name,

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -1,4 +1,4 @@
-import { getAbiItem, type Hex, parseEther } from "viem";
+import { getAbiItem, type Hex, parseEther, RpcRequestError } from "viem";
 import { beforeEach, expect, test, vi } from "vitest";
 import { ALICE, BOB } from "@/_test/constants.js";
 import { erc20ABI } from "@/_test/generated.js";
@@ -1480,6 +1480,163 @@ test("sync() range scan does not re-emit already scanned blocks", async () => {
     (call) => (call[0] as { method: string }).method,
   );
   expect(methods.filter((m) => m === "eth_getBlockByHash")).toHaveLength(0);
+});
+
+test("sync() range scan constrains eth_getLogs by address and topic", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+
+  // Finalize at block 2 (deploy + mint).
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+
+  const head = await eth_getBlockByNumber(rpc, ["0x3", true]);
+
+  const requestSpy = vi.spyOn(rpc, "request");
+  await drainAsyncGenerator(realtimeSync.sync(head));
+
+  const getLogsRequests = requestSpy.mock.calls
+    .map((call) => call[0] as { method: string; params: unknown[] })
+    .filter((body) => body.method === "eth_getLogs");
+
+  expect(getLogsRequests).toHaveLength(1);
+
+  const params = getLogsRequests[0]!.params[0] as {
+    address: `0x${string}`[];
+    topics: `0x${string}`[][];
+    fromBlock: `0x${string}`;
+    toBlock: `0x${string}`;
+  };
+
+  // The request is constrained to the union of the filters' address and
+  // `topic0`, not an unfiltered chain-wide scan.
+  expect(params.address).toStrictEqual([address]);
+  expect(params.topics).toStrictEqual([
+    [(eventCallbacks[0].filter as LogFilter).topic0],
+  ]);
+  expect(params.fromBlock).toBe("0x3");
+  expect(params.toBlock).toBe("0x3");
+});
+
+test("sync() range scan splits eth_getLogs when the range is too wide", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+
+  // Finalize at block 2 (deploy + mint).
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  // Block 3: matched. Block 4: empty. Block 5: matched.
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+  await simulateBlock();
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+
+  const head5 = await eth_getBlockByNumber(rpc, ["0x5", true]);
+
+  // Reject the first (three block wide) request the way a provider with a
+  // block range cap would.
+  const originalRequest = rpc.request.bind(rpc);
+  let hasRejected = false;
+
+  const requestSpy = vi
+    .spyOn(rpc, "request")
+    // @ts-ignore
+    .mockImplementation(async (body, context) => {
+      if (body.method === "eth_getLogs" && hasRejected === false) {
+        hasRejected = true;
+        throw new RpcRequestError({
+          body,
+          error: { code: -32000, message: "Max range: 1" },
+          url: "http://localhost:8545",
+        });
+      }
+      // @ts-ignore
+      return originalRequest(body, context);
+    });
+
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(head5));
+
+  const blocks = syncResult.filter(
+    (event) => event.type === "block",
+  ) as Extract<RealtimeSyncEvent, { type: "block" }>[];
+
+  // Both matched blocks are ingested despite the rejected request.
+  expect(blocks).toHaveLength(2);
+  expect(blocks[0]!.block.number).toBe("0x3");
+  expect(blocks[0]!.logs).toHaveLength(1);
+  expect(blocks[1]!.block.number).toBe("0x5");
+  expect(blocks[1]!.logs).toHaveLength(1);
+
+  // The rejected request is retried as one request per block.
+  const getLogsRanges = () =>
+    requestSpy.mock.calls
+      .map(
+        (call) => call[0] as { method: string; params: { toBlock: string }[] },
+      )
+      .filter((body) => body.method === "eth_getLogs")
+      .map((body) => body.params[0]!.toBlock);
+
+  expect(getLogsRanges()).toStrictEqual(["0x5", "0x3", "0x4", "0x5"]);
+
+  // The narrowed range is remembered, so the next poll doesn't repeat the
+  // failing request.
+  requestSpy.mockClear();
+  await simulateBlock();
+
+  const head6 = await eth_getBlockByNumber(rpc, ["0x6", true]);
+  await drainAsyncGenerator(realtimeSync.sync(head6));
+
+  expect(getLogsRanges()).toStrictEqual(["0x3", "0x4", "0x5", "0x6"]);
 });
 
 test("sync() ignores range scan when a block filter is present", async () => {

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -1639,6 +1639,105 @@ test("sync() range scan splits eth_getLogs when the range is too wide", async ()
   expect(getLogsRanges()).toStrictEqual(["0x3", "0x4", "0x5", "0x6"]);
 });
 
+test("sync() range scan warns when the polling interval is too short", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  const warnSpy = vi.spyOn(common.logger, "warn");
+
+  // One block per poll, which is not enough for the scan to pay off.
+  for (let i = 0; i < 12; i++) {
+    const { block } = await simulateBlock();
+    await drainAsyncGenerator(realtimeSync.sync(block));
+  }
+
+  const warnings = warnSpy.mock.calls.filter((call) =>
+    (call[0] as { msg: string }).msg.includes(
+      "unlikely to reduce RPC usage at this 'pollingInterval'",
+    ),
+  );
+
+  // Warns exactly once, not on every poll.
+  expect(warnings).toHaveLength(1);
+  expect((warnings[0]![0] as { blocks_per_poll: number }).blocks_per_poll).toBe(
+    1,
+  );
+});
+
+test("sync() range scan does not warn when enough blocks elapse per poll", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  const warnSpy = vi.spyOn(common.logger, "warn");
+
+  // Five blocks per poll.
+  for (let i = 0; i < 12; i++) {
+    await testClient.mine({ blocks: 5 });
+    const block = await eth_getBlockByNumber(rpc, ["latest", true]);
+    await drainAsyncGenerator(realtimeSync.sync(block));
+  }
+
+  const warnings = warnSpy.mock.calls.filter((call) =>
+    (call[0] as { msg: string }).msg.includes(
+      "unlikely to reduce RPC usage at this 'pollingInterval'",
+    ),
+  );
+
+  expect(warnings).toHaveLength(0);
+});
+
 test("sync() ignores range scan when a block filter is present", async () => {
   const { common } = context;
   await setupDatabaseServices();

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -1,4 +1,10 @@
-import { getAbiItem, type Hex, parseEther, RpcRequestError } from "viem";
+import {
+  getAbiItem,
+  type Hex,
+  hexToNumber,
+  parseEther,
+  RpcRequestError,
+} from "viem";
 import { beforeEach, expect, test, vi } from "vitest";
 import { ALICE, BOB } from "@/_test/constants.js";
 import { erc20ABI } from "@/_test/generated.js";
@@ -1590,7 +1596,6 @@ test("sync() range scan splits eth_getLogs when the range is too wide", async ()
 
   const requestSpy = vi
     .spyOn(rpc, "request")
-    // @ts-ignore
     .mockImplementation(async (body, context) => {
       if (body.method === "eth_getLogs" && hasRejected === false) {
         hasRejected = true;
@@ -1600,7 +1605,6 @@ test("sync() range scan splits eth_getLogs when the range is too wide", async ()
           url: "http://localhost:8545",
         });
       }
-      // @ts-ignore
       return originalRequest(body, context);
     });
 
@@ -1679,15 +1683,20 @@ test("sync() range scan warns when the polling interval is too short", async () 
 
   const warnings = warnSpy.mock.calls.filter((call) =>
     (call[0] as { msg: string }).msg.includes(
-      "unlikely to reduce RPC usage at this 'pollingInterval'",
+      "is not reducing RPC usage on this chain",
     ),
   );
 
   // Warns exactly once, not on every poll.
   expect(warnings).toHaveLength(1);
-  expect((warnings[0]![0] as { blocks_per_poll: number }).blocks_per_poll).toBe(
-    1,
-  );
+
+  const details = warnings[0]![0] as {
+    blocks_per_poll: number;
+    requests_per_poll: number;
+  };
+
+  expect(details.blocks_per_poll).toBe(1);
+  expect(details.requests_per_poll).toBe(1);
 });
 
 test("sync() range scan does not warn when enough blocks elapse per poll", async () => {
@@ -1731,11 +1740,201 @@ test("sync() range scan does not warn when enough blocks elapse per poll", async
 
   const warnings = warnSpy.mock.calls.filter((call) =>
     (call[0] as { msg: string }).msg.includes(
-      "unlikely to reduce RPC usage at this 'pollingInterval'",
+      "is not reducing RPC usage on this chain",
     ),
   );
 
   expect(warnings).toHaveLength(0);
+});
+
+test("sync() range scan finalize event", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  // Block 3 is matched, blocks 4-6 are empty. With `finalityBlockCount` 2,
+  // finalization triggers once the head reaches block 6.
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+  await simulateBlock();
+  await simulateBlock();
+
+  const head5 = await eth_getBlockByNumber(rpc, ["0x5", true]);
+  const syncResult1 = await drainAsyncGenerator(realtimeSync.sync(head5));
+
+  expect(syncResult1.filter((event) => event.type === "finalize")).toHaveLength(
+    0,
+  );
+
+  await simulateBlock();
+
+  const head6 = await eth_getBlockByNumber(rpc, ["0x6", true]);
+  const syncResult2 = await drainAsyncGenerator(realtimeSync.sync(head6));
+
+  const finalize = syncResult2.find(
+    (event) => event.type === "finalize",
+  ) as Extract<RealtimeSyncEvent, { type: "finalize" }>;
+
+  // Finalizes to head - finalityBlockCount, and prunes the finalized blocks
+  // from the local chain.
+  expect(finalize).toBeDefined();
+  expect(finalize.block.number).toBe("0x4");
+  expect(
+    realtimeSync.unfinalizedBlocks.every(
+      (block) => hexToNumber(block.number) > 4,
+    ),
+  ).toBe(true);
+});
+
+test("sync() range scan throws for reorg beyond the finalized block", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+
+  // Snapshot at block 1, before the block that will be finalized.
+  const snapshotId = await testClient.snapshot();
+
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  // Reorg the finalized block itself out from under the local chain, so the
+  // new head cannot descend from it.
+  await testClient.revert({ id: snapshotId });
+  await testClient.mine({ blocks: 2 });
+
+  const head3 = await eth_getBlockByNumber(rpc, ["0x3", true]);
+  const block2Prime = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  expect(block2Prime.hash).not.toBe(finalizedBlock.hash);
+
+  const warnSpy = vi.spyOn(common.logger, "warn");
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(head3));
+
+  // The error is caught by `sync()`, so assert on the log it emits first.
+  expect(
+    warnSpy.mock.calls.some((call) =>
+      (call[0] as { msg: string }).msg.includes(
+        "Encountered unrecoverable reorg",
+      ),
+    ),
+  ).toBe(true);
+
+  expect(syncResult).toHaveLength(0);
+  expect(realtimeSync.unfinalizedBlocks).toHaveLength(0);
+});
+
+test("sync() range scan batches large address sets", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+
+  // 51 addresses, so the scan must split into two requests.
+  const filler = Array.from(
+    { length: 50 },
+    (_, i) => `0x${(i + 1).toString(16).padStart(40, "0")}` as `0x${string}`,
+  );
+  (eventCallbacks[0].filter as LogFilter).address = [address, ...filler];
+
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+
+  const head = await eth_getBlockByNumber(rpc, ["0x3", true]);
+
+  const requestSpy = vi.spyOn(rpc, "request");
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(head));
+
+  const addressBatches = requestSpy.mock.calls
+    .map(
+      (call) =>
+        call[0] as unknown as {
+          method: string;
+          params: { address: `0x${string}`[] }[];
+        },
+    )
+    .filter((body) => body.method === "eth_getLogs")
+    .map((body) => body.params[0]!.address.length);
+
+  expect(addressBatches).toStrictEqual([50, 1]);
+
+  // The event is still emitted, from whichever batch matched.
+  const blocks = syncResult.filter(
+    (event) => event.type === "block",
+  ) as Extract<RealtimeSyncEvent, { type: "block" }>[];
+
+  expect(blocks).toHaveLength(1);
+  expect(blocks[0]!.logs).toHaveLength(1);
 });
 
 test("sync() ignores range scan when a block filter is present", async () => {

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -27,6 +27,7 @@ import {
   getChain,
   getErc20IndexingBuild,
   getPairWithFactoryIndexingBuild,
+  testClient,
 } from "@/_test/utils.js";
 import { buildLogFactory } from "@/build/factory.js";
 import type { EventCallback, LogFactory, LogFilter } from "@/internal/types.js";
@@ -1209,4 +1210,170 @@ test("handleReorg() throws error for deep reorg", async () => {
 
   // block 4 is not added to `unfinalizedBlocks`
   expect(realtimeSync.unfinalizedBlocks).toHaveLength(3);
+});
+
+test("sync() range scan emits matched blocks and advances to head", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+
+  // Finalize at block 2 (deploy + mint).
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  // Block 3: matched transfer. Block 4: empty.
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+  await simulateBlock();
+
+  const head = await eth_getBlockByNumber(rpc, ["0x4", true]);
+
+  const requestSpy = vi.spyOn(rpc, "request");
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(head));
+
+  const data = syncResult as Extract<RealtimeSyncEvent, { type: "block" }>[];
+
+  // One matched block (3) plus the empty head (4).
+  expect(syncResult).toHaveLength(2);
+  expect(data[0]!.hasMatchedFilter).toBe(true);
+  expect(data[0]!.block.number).toBe("0x3");
+  expect(data[0]!.logs).toHaveLength(1);
+  expect(data[1]!.hasMatchedFilter).toBe(false);
+  expect(data[1]!.block.number).toBe("0x4");
+  expect(data[1]!.logs).toHaveLength(0);
+
+  expect(realtimeSync.unfinalizedBlocks).toHaveLength(2);
+
+  // A single ranged `eth_getLogs` is used, no per-block `eth_getBlockByNumber`,
+  // and only the matched block is fetched by hash.
+  const methods = requestSpy.mock.calls.map(
+    (call) => (call[0] as { method: string }).method,
+  );
+  expect(methods.filter((m) => m === "eth_getLogs")).toHaveLength(1);
+  expect(methods.filter((m) => m === "eth_getBlockByNumber")).toHaveLength(0);
+  expect(methods.filter((m) => m === "eth_getBlockByHash")).toHaveLength(1);
+});
+
+test("sync() range scan detects reorg of matched block", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+
+  // Finalize at block 2 (deploy + mint).
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  // Snapshot the chain at block 2, then create a matched block 3.
+  const snapshotId = await testClient.snapshot();
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+
+  const head3 = await eth_getBlockByNumber(rpc, ["0x3", true]);
+  const syncResult1 = await drainAsyncGenerator(realtimeSync.sync(head3));
+
+  expect(syncResult1.filter((event) => event.type === "block")).toHaveLength(1);
+  expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
+
+  // Reorg: revert to block 2 and mine a different (empty) block 3'.
+  await testClient.revert({ id: snapshotId });
+  await testClient.mine({ blocks: 1 });
+
+  const head3Prime = await eth_getBlockByNumber(rpc, ["0x3", true]);
+  const syncResult2 = await drainAsyncGenerator(realtimeSync.sync(head3Prime));
+
+  const reorg = syncResult2.find((event) => event.type === "reorg") as Extract<
+    RealtimeSyncEvent,
+    { type: "reorg" }
+  >;
+
+  // The matched block 3 reorged out; the common ancestor is the finalized block.
+  expect(reorg).toBeDefined();
+  expect(reorg.block.number).toBe("0x2");
+  expect(reorg.reorgedBlocks).toHaveLength(1);
+
+  // The new empty head 3' is ingested in its place.
+  expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
+  expect(realtimeSync.unfinalizedBlocks[0]!.hash).toBe(head3Prime.hash);
+});
+
+test("sync() ignores range scan when a block filter is present", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  // Block filters are unsupported on the range-scan path, so the chain falls
+  // back to the default per-block sync.
+  const { eventCallbacks } = getBlocksIndexingBuild({ interval: 1 });
+
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x0", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  const blockData = await simulateBlock();
+  const syncResult = await drainAsyncGenerator(
+    realtimeSync.sync(blockData.block),
+  );
+
+  // The default path matches the block filter on the (otherwise empty) block.
+  expect(syncResult).toHaveLength(1);
+  expect(
+    (syncResult[0] as Extract<RealtimeSyncEvent, { type: "block" }>)
+      .hasMatchedFilter,
+  ).toBe(true);
 });

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -1340,6 +1340,148 @@ test("sync() range scan detects reorg of matched block", async () => {
   expect(realtimeSync.unfinalizedBlocks[0]!.hash).toBe(head3Prime.hash);
 });
 
+test("sync() range scan detects reorg that adds events to an empty block", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+
+  // Finalize at block 2 (deploy + mint).
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  // Snapshot the chain at block 2, then mine an empty block 3. The head is
+  // emitted as an empty block, advancing the local tip past block 3.
+  const snapshotId = await testClient.snapshot();
+  await simulateBlock();
+
+  const head3 = await eth_getBlockByNumber(rpc, ["0x3", true]);
+  const syncResult1 = await drainAsyncGenerator(realtimeSync.sync(head3));
+
+  expect(syncResult1).toHaveLength(1);
+  expect(
+    (syncResult1[0] as Extract<RealtimeSyncEvent, { type: "block" }>)
+      .hasMatchedFilter,
+  ).toBe(false);
+
+  // Reorg: revert to block 2 and mine a different block 3' that *does* contain
+  // a matched transfer.
+  await testClient.revert({ id: snapshotId });
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+
+  const head3Prime = await eth_getBlockByNumber(rpc, ["0x3", true]);
+  const syncResult2 = await drainAsyncGenerator(realtimeSync.sync(head3Prime));
+
+  const reorg = syncResult2.find((event) => event.type === "reorg") as Extract<
+    RealtimeSyncEvent,
+    { type: "reorg" }
+  >;
+
+  // The empty block 3 reorged out, back to the finalized block.
+  expect(reorg).toBeDefined();
+  expect(reorg.block.number).toBe("0x2");
+
+  // The events introduced by the reorg must not be dropped.
+  const blocks = syncResult2.filter(
+    (event) => event.type === "block",
+  ) as Extract<RealtimeSyncEvent, { type: "block" }>[];
+
+  expect(blocks).toHaveLength(1);
+  expect(blocks[0]!.hasMatchedFilter).toBe(true);
+  expect(blocks[0]!.block.number).toBe("0x3");
+  expect(blocks[0]!.block.hash).toBe(head3Prime.hash);
+  expect(blocks[0]!.logs).toHaveLength(1);
+
+  expect(realtimeSync.unfinalizedBlocks).toHaveLength(1);
+  expect(realtimeSync.unfinalizedBlocks[0]!.hash).toBe(head3Prime.hash);
+});
+
+test("sync() range scan does not re-emit already scanned blocks", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({
+    finalityBlockCount: 2,
+    experimentalRangeScan: true,
+  });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({ address });
+
+  // Finalize at block 2 (deploy + mint).
+  const finalizedBlock = await eth_getBlockByNumber(rpc, ["0x2", true]);
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: new Map(),
+  });
+
+  // Block 3: matched transfer.
+  await transferErc20({ erc20: address, to: BOB, amount: 1n, sender: ALICE });
+
+  const head3 = await eth_getBlockByNumber(rpc, ["0x3", true]);
+  await drainAsyncGenerator(realtimeSync.sync(head3));
+
+  // Block 4: empty. Block 3 is still inside the scanned window, so it is
+  // returned by the ranged `eth_getLogs` again, but it must not be re-fetched,
+  // re-emitted, or mistaken for a reorg.
+  await simulateBlock();
+
+  const head4 = await eth_getBlockByNumber(rpc, ["0x4", true]);
+
+  const requestSpy = vi.spyOn(rpc, "request");
+  const syncResult = await drainAsyncGenerator(realtimeSync.sync(head4));
+
+  expect(syncResult.filter((event) => event.type === "reorg")).toHaveLength(0);
+
+  const blocks = syncResult.filter(
+    (event) => event.type === "block",
+  ) as Extract<RealtimeSyncEvent, { type: "block" }>[];
+
+  expect(blocks).toHaveLength(1);
+  expect(blocks[0]!.hasMatchedFilter).toBe(false);
+  expect(blocks[0]!.block.number).toBe("0x4");
+
+  const methods = requestSpy.mock.calls.map(
+    (call) => (call[0] as { method: string }).method,
+  );
+  expect(methods.filter((m) => m === "eth_getBlockByHash")).toHaveLength(0);
+});
+
 test("sync() ignores range scan when a block filter is present", async () => {
   const { common } = context;
   await setupDatabaseServices();

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -1799,13 +1799,15 @@ test("sync() range scan finalize event", async () => {
     (event) => event.type === "finalize",
   ) as Extract<RealtimeSyncEvent, { type: "finalize" }>;
 
-  // Finalizes to head - finalityBlockCount, and prunes the finalized blocks
-  // from the local chain.
+  // Finalizes to the highest local block at or below head - finalityBlockCount,
+  // and prunes the finalized blocks from the local chain. The boundary itself
+  // (block 4) is not in the local chain, because the scan only ingests blocks
+  // with matching logs plus one head block per poll — so block 3 is finalized.
   expect(finalize).toBeDefined();
-  expect(finalize.block.number).toBe("0x4");
+  expect(finalize.block.number).toBe("0x3");
   expect(
     realtimeSync.unfinalizedBlocks.every(
-      (block) => hexToNumber(block.number) > 4,
+      (block) => hexToNumber(block.number) > 3,
     ),
   ).toBe(true);
 });

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -194,8 +194,15 @@ export const createRealtimeSync = (
     });
   }
 
-  /** Hashes of unfinalized blocks that have matched a filter (range-scan path). */
-  const rangeMatchedHashes = new Set<Hash>();
+  /**
+   * Block hashes of unfinalized blocks that the range scan has already
+   * processed, keyed by block number (range-scan path).
+   *
+   * @dev Includes blocks that produced no events after client-side filtering.
+   * A block that was scanned but not emitted must still be recorded, otherwise
+   * it would be re-detected as a reorg on every subsequent poll.
+   */
+  const scannedBlockHashes = new Map<number, Hash>();
 
   /**
    * Build the `address` argument for the range-scan `eth_getLogs` request as the
@@ -1357,8 +1364,9 @@ export const createRealtimeSync = (
   /**
    * Reconcile the chain up to `headBlock` by scanning the entire unfinalized
    * window with a single ranged `eth_getLogs` request. Reorgs are detected by
-   * diffing the block hashes of previously-emitted matched blocks against the
-   * rescan, so blocks without matching events are never fetched.
+   * diffing the block hashes reported by the rescan against the blocks the
+   * scan has already processed, so blocks without matching events are never
+   * fetched.
    *
    * @dev Only used when `canRangeScan` is true.
    */
@@ -1397,16 +1405,65 @@ export const createRealtimeSync = (
     }
 
     // --- Reorg detection ---
-    // Find the lowest previously-emitted matched block whose hash no longer
-    // matches the rescan (changed hash or disappeared).
+    // Find the lowest block at or below the local tip where the rescan
+    // disagrees with what has already been processed. Three cases, all of
+    // which must rewind:
+    //
+    // 1. A processed block has a different hash in the rescan.
+    // 2. A processed block that had matching logs no longer has any.
+    // 3. A block that previously had no matching logs now has some. This is
+    //    the case that a matched-blocks-only diff misses: because the head is
+    //    emitted as an empty block every poll, the local tip advances past
+    //    event-free blocks, and logs introduced into them by a reorg would
+    //    otherwise never be ingested.
+    const tipNumberBeforeReorg = hexToNumber(
+      getLatestUnfinalizedBlock().number,
+    );
+
     let reorgFromNumber: number | undefined;
-    for (const stored of unfinalizedBlocks) {
-      if (rangeMatchedHashes.has(stored.hash) === false) continue;
-      const rescan = logsByBlockNumber.get(hexToNumber(stored.number));
-      if (rescan === undefined || rescan.hash !== stored.hash) {
-        reorgFromNumber = hexToNumber(stored.number);
-        break;
+    const setReorgFrom = (number: number) => {
+      if (reorgFromNumber === undefined || number < reorgFromNumber) {
+        reorgFromNumber = number;
       }
+    };
+
+    for (const [number, hash] of scannedBlockHashes) {
+      if (number > tipNumberBeforeReorg) continue;
+      if (logsByBlockNumber.get(number)?.hash !== hash) setReorgFrom(number);
+    }
+    for (const [number, { hash }] of logsByBlockNumber) {
+      if (number > tipNumberBeforeReorg) continue;
+      if (scannedBlockHashes.get(number) !== hash) setReorgFrom(number);
+    }
+
+    // The head itself may be a reorged replacement of a block that was already
+    // emitted, or may not descend from the local tip. Both are free to check.
+    const storedHeadHash = unfinalizedBlocks.find(
+      (lb) => hexToNumber(lb.number) === headNumber,
+    )?.hash;
+    if (storedHeadHash !== undefined && storedHeadHash !== headBlock.hash) {
+      setReorgFrom(headNumber);
+    } else if (
+      headNumber === tipNumberBeforeReorg + 1 &&
+      headBlock.parentHash !== getLatestUnfinalizedBlock().hash
+    ) {
+      if (unfinalizedBlocks.length === 0) {
+        // The local chain is empty, so the head's parent is the finalized
+        // block. A mismatch means the reorg is beyond the finalized block.
+        args.common.logger.warn({
+          msg: "Encountered unrecoverable reorg",
+          chain: args.chain.name,
+          chain_id: args.chain.id,
+          finalized_block: hexToNumber(finalizedBlock.number),
+          duration: endClock(),
+        });
+
+        throw new Error(
+          `Encountered unrecoverable '${args.chain.name}' reorg beyond finalized block ${hexToNumber(finalizedBlock.number)}`,
+        );
+      }
+
+      setReorgFrom(tipNumberBeforeReorg);
     }
 
     if (reorgFromNumber !== undefined) {
@@ -1417,8 +1474,12 @@ export const createRealtimeSync = (
         (lb) => hexToNumber(lb.number) < reorgFromNumber!,
       );
       for (const block of reorgedBlocks) {
-        rangeMatchedHashes.delete(block.hash);
         childAddressesPerBlock.delete(hexToNumber(block.number));
+      }
+      // Forget every scanned block at or above the fork point so that the
+      // replacement blocks are ingested below rather than treated as seen.
+      for (const number of scannedBlockHashes.keys()) {
+        if (number >= reorgFromNumber) scannedBlockHashes.delete(number);
       }
 
       const commonAncestor = getLatestUnfinalizedBlock();
@@ -1435,9 +1496,17 @@ export const createRealtimeSync = (
     }
 
     // --- Ingest new matched blocks ---
-    const localTipNumber = hexToNumber(getLatestUnfinalizedBlock().number);
-    const newMatchedNumbers = Array.from(logsByBlockNumber.keys())
-      .filter((number) => number > localTipNumber && number <= headNumber)
+    // Ingest every block in the scan that hasn't already been processed at this
+    // hash, rather than only blocks above the local tip. Blocks below the tip
+    // are unchanged in the common case (their hash is already recorded), so
+    // this doesn't refetch anything, but it does pick up blocks that a reorg
+    // rewound above.
+    const newMatchedNumbers = Array.from(logsByBlockNumber.entries())
+      .filter(
+        ([number, { hash }]) =>
+          number <= headNumber && scannedBlockHashes.get(number) !== hash,
+      )
+      .map(([number]) => number)
       .sort((a, b) => a - b);
 
     const matchedBlocks = await Promise.all(
@@ -1455,6 +1524,11 @@ export const createRealtimeSync = (
       const filtered = filterBlockEventData(blockWithEventData);
       const block = filtered.block;
 
+      // Record every block the scan processed, including blocks whose logs were
+      // all dropped by client-side filtering. Recording only matched blocks
+      // would make an unmatched block look like a reorg on every later poll.
+      scannedBlockHashes.set(hexToNumber(block.number), block.hash);
+
       if (filtered.matchedFilters.size === 0) continue;
 
       unfinalizedBlocks.push({
@@ -1463,7 +1537,6 @@ export const createRealtimeSync = (
         number: block.number,
         timestamp: block.timestamp,
       });
-      rangeMatchedHashes.add(block.hash);
 
       blockWithEventData.block.transactions = filtered.block.transactions;
 
@@ -1542,8 +1615,10 @@ export const createRealtimeSync = (
         (lb) => hexToNumber(lb.number) > pendingFinalizedNumber,
       );
       for (const block of finalizedBlocks) {
-        rangeMatchedHashes.delete(block.hash);
         childAddressesPerBlock.delete(hexToNumber(block.number));
+      }
+      for (const number of scannedBlockHashes.keys()) {
+        if (number <= pendingFinalizedNumber) scannedBlockHashes.delete(number);
       }
 
       finalizedBlock = pendingFinalizedBlock;

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -270,6 +270,63 @@ export const createRealtimeSync = (
    */
   let rangeScanBlockRange: number | undefined = args.chain.ethGetLogsBlockRange;
 
+  /**
+   * Average number of blocks that must elapse per poll for the range scan to use
+   * fewer RPC credits than the default per-block sync.
+   *
+   * @dev Each scan costs about two requests (the head header and one
+   * `eth_getLogs`) no matter how many blocks elapsed, whereas the per-block sync
+   * costs about one request per block. Break-even is therefore around four
+   * blocks per poll, using Alchemy's compute unit costs. Below that, a larger
+   * `pollingInterval` is the only thing that helps.
+   */
+  const MIN_RANGE_SCAN_BLOCKS_PER_POLL = 4;
+  /** Number of polls to average before checking the polling interval. */
+  const RANGE_SCAN_SAMPLE_POLLS = 10;
+
+  let rangeScanPollCount = 0;
+  let rangeScanBlockCount = 0;
+  let hasCheckedRangeScanInterval = false;
+
+  /**
+   * Warn once if `pollingInterval` is too short for the range scan to reduce RPC
+   * usage on this chain.
+   *
+   * @dev Measured from observed blocks per poll rather than a configured block
+   * time, so it reflects what the chain is actually doing.
+   */
+  const recordRangeScanPoll = (headNumber: number) => {
+    if (hasCheckedRangeScanInterval) return;
+
+    const tipNumber = hexToNumber(getLatestUnfinalizedBlock().number);
+
+    // Skip the first poll, which covers the gap left by the historical sync
+    // rather than one polling interval.
+    if (rangeScanPollCount === 0 && unfinalizedBlocks.length === 0) {
+      rangeScanPollCount = 1;
+      return;
+    }
+
+    rangeScanPollCount += 1;
+    rangeScanBlockCount += Math.max(headNumber - tipNumber, 0);
+
+    if (rangeScanPollCount <= RANGE_SCAN_SAMPLE_POLLS) return;
+
+    hasCheckedRangeScanInterval = true;
+
+    const blocksPerPoll = rangeScanBlockCount / RANGE_SCAN_SAMPLE_POLLS;
+
+    if (blocksPerPoll < MIN_RANGE_SCAN_BLOCKS_PER_POLL) {
+      args.common.logger.warn({
+        msg: `The 'experimentalRangeScan' option is unlikely to reduce RPC usage at this 'pollingInterval'. Only ${blocksPerPoll.toFixed(1)} blocks elapse per poll on average, but each scan costs about two requests regardless. Increase 'pollingInterval' to at least ${MIN_RANGE_SCAN_BLOCKS_PER_POLL} times the block time, or disable 'experimentalRangeScan'.`,
+        chain: args.chain.name,
+        chain_id: args.chain.id,
+        polling_interval: args.chain.pollingInterval,
+        blocks_per_poll: blocksPerPoll,
+      });
+    }
+  };
+
   const syncTransactionReceipts = async (
     block: SyncBlock,
     transactionHashes: Set<Hash>,
@@ -1479,6 +1536,8 @@ export const createRealtimeSync = (
     const endClock = startClock();
     const headNumber = hexToNumber(headBlock.number);
     const windowFrom = hexToNumber(finalizedBlock.number) + 1;
+
+    recordRangeScanPoll(headNumber);
 
     // We already saw this head, or it is at/under the finalized block. No-op.
     if (

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -1,6 +1,12 @@
 import {
+  type GetLogsRetryHelperParameters,
+  getLogsRetryHelper,
+} from "@ponder/utils";
+import {
   type Address,
   type Hash,
+  type Hex,
+  type RpcError,
   hexToNumber,
   numberToHex,
   zeroHash,
@@ -53,6 +59,7 @@ import {
 } from "@/runtime/filter.js";
 import type { SyncProgress } from "@/runtime/index.js";
 import { isAsyncExecutionChain } from "@/utils/finality.js";
+import { getChunks } from "@/utils/interval.js";
 import { createLock } from "@/utils/mutex.js";
 import { range } from "@/utils/range.js";
 import { startClock } from "@/utils/timer.js";
@@ -184,11 +191,19 @@ export const createRealtimeSync = (
     traceFilters.length === 0 &&
     transactionFilters.length === 0 &&
     transferFilters.length === 0 &&
-    blockFilters.length === 0;
+    blockFilters.length === 0 &&
+    // A filter that matches all addresses would make every scan an unfiltered
+    // chain-wide `eth_getLogs` over the unfinalized window, which is both
+    // slower and more expensive than the default per-block sync.
+    logFilters.every(
+      (filter) =>
+        filter.address !== undefined &&
+        isAddressFactory(filter.address) === false,
+    );
 
   if (args.chain.experimentalRangeScan && canRangeScan === false) {
     args.common.logger.warn({
-      msg: "Ignoring 'experimentalRangeScan' because the chain has factory, block, transaction, trace, or transfer sources. Using the default per-block realtime sync.",
+      msg: "Ignoring 'experimentalRangeScan' because the chain has factory, block, transaction, trace, or transfer sources, or a log source that matches all addresses. Using the default per-block realtime sync.",
       chain: args.chain.name,
       chain_id: args.chain.id,
     });
@@ -205,25 +220,55 @@ export const createRealtimeSync = (
   const scannedBlockHashes = new Map<number, Hash>();
 
   /**
-   * Build the `address` argument for the range-scan `eth_getLogs` request as the
-   * union of all log filter addresses, or `undefined` if any filter matches all
-   * addresses. Topics are intentionally not merged; logs are filtered precisely
-   * client-side.
+   * `address` and `topics` for the range-scan `eth_getLogs` request: the union
+   * of every log filter's address and `topic0`.
+   *
+   * @dev The union matches a superset of each individual filter — `(A₁ ∪ A₂) ∧
+   * (T₁ ∪ T₂)` contains everything `(A₁ ∧ T₁)` and `(A₂ ∧ T₂)` match — so it is
+   * safe to filter precisely client-side afterwards. Constraining the request
+   * matters because the response covers the entire unfinalized window.
    */
-  const getRangeScanAddress = (): Address | Address[] | undefined => {
+  const rangeScanParams = (() => {
     const addresses = new Set<Address>();
+    const topic0s = new Set<Hex>();
+    let hasAllTopic0s = true;
+
     for (const filter of logFilters) {
-      if (filter.address === undefined || isAddressFactory(filter.address)) {
-        return undefined;
-      }
-      if (Array.isArray(filter.address)) {
-        for (const address of filter.address) addresses.add(address);
+      // Note: `canRangeScan` guarantees a non-factory, defined address.
+      const address = filter.address as Address | Address[];
+      if (Array.isArray(address)) {
+        for (const _address of address) addresses.add(_address);
       } else {
-        addresses.add(filter.address);
+        addresses.add(address);
+      }
+
+      if (filter.topic0 === undefined || filter.topic0 === null) {
+        hasAllTopic0s = false;
+      } else {
+        topic0s.add(filter.topic0);
       }
     }
-    return Array.from(addresses);
-  };
+
+    // Note: the `topics` field is fragile for many rpc providers, so only the
+    // first position is included and it is omitted entirely when unconstrained.
+    return {
+      addresses: Array.from(addresses),
+      topics: hasAllTopic0s ? [Array.from(topic0s)] : undefined,
+    };
+  })();
+
+  /**
+   * Maximum number of addresses in a single range-scan `eth_getLogs` request.
+   * Matches the batch size used by the historical sync.
+   */
+  const RANGE_SCAN_ADDRESS_BATCH_SIZE = 50;
+
+  /**
+   * Maximum block range for a range-scan `eth_getLogs` request. Starts at the
+   * user-provided value (if any) and is narrowed when a provider rejects a
+   * request for being too wide, so the same error isn't repeated every poll.
+   */
+  let rangeScanBlockRange: number | undefined = args.chain.ethGetLogsBlockRange;
 
   const syncTransactionReceipts = async (
     block: SyncBlock,
@@ -1259,8 +1304,12 @@ export const createRealtimeSync = (
   };
 
   /**
-   * Fetch all matching logs in `[fromBlock, toBlock]` with a single ranged
-   * `eth_getLogs` request (chunked by `ethGetLogsBlockRange` if configured).
+   * Fetch all logs matching the union of the log filters in
+   * `[fromBlock, toBlock]`.
+   *
+   * Requests are batched by address and chunked by block range. A request
+   * rejected for being too wide is split into the ranges suggested by the
+   * error and retried, and the narrower range is remembered for later polls.
    */
   const getRangeScanLogs = async (
     fromBlock: number,
@@ -1269,29 +1318,82 @@ export const createRealtimeSync = (
     const context = {
       logger: args.common.logger.child({ action: "fetch_block_data" }),
     };
-    const address = getRangeScanAddress();
-    const chunkSize =
-      args.chain.ethGetLogsBlockRange ?? toBlock - fromBlock + 1;
 
-    const requests: Promise<SyncLog[]>[] = [];
-    for (let from = fromBlock; from <= toBlock; from += chunkSize) {
-      const to = Math.min(from + chunkSize - 1, toBlock);
-      requests.push(
-        eth_getLogs(
-          args.rpc,
-          [
-            {
-              address,
-              fromBlock: numberToHex(from),
-              toBlock: numberToHex(to),
-            },
-          ],
-          context,
-        ),
+    const addressBatches: Address[][] = [];
+    for (
+      let i = 0;
+      i < rangeScanParams.addresses.length;
+      i += RANGE_SCAN_ADDRESS_BATCH_SIZE
+    ) {
+      addressBatches.push(
+        rangeScanParams.addresses.slice(i, i + RANGE_SCAN_ADDRESS_BATCH_SIZE),
       );
     }
 
-    const results = await Promise.all(requests);
+    const request = async (
+      address: Address[],
+      from: number,
+      to: number,
+    ): Promise<SyncLog[]> => {
+      const params: Parameters<typeof eth_getLogs>[1] = [
+        {
+          address,
+          topics: rangeScanParams.topics,
+          fromBlock: numberToHex(from),
+          toBlock: numberToHex(to),
+        },
+      ];
+
+      return eth_getLogs(args.rpc, params, context).catch((error) => {
+        // Note: skip the range retry logic if the chain has a custom block
+        // range, matching the historical sync.
+        if (args.chain.ethGetLogsBlockRange !== undefined) throw error;
+        if (from === to) throw error;
+
+        const getLogsErrorResponse = getLogsRetryHelper({
+          params: params as GetLogsRetryHelperParameters["params"],
+          error: error as RpcError,
+        });
+
+        if (getLogsErrorResponse.shouldRetry === false) throw error;
+
+        const range =
+          hexToNumber(getLogsErrorResponse.ranges[0]!.toBlock) -
+          hexToNumber(getLogsErrorResponse.ranges[0]!.fromBlock) +
+          1;
+
+        // Remember the narrower range so that the next poll doesn't repeat the
+        // same failing request.
+        if (rangeScanBlockRange === undefined || range < rangeScanBlockRange) {
+          rangeScanBlockRange = range;
+
+          args.common.logger.debug({
+            msg: "Updated range scan 'eth_getLogs' range",
+            chain: args.chain.name,
+            chain_id: args.chain.id,
+            range,
+          });
+        }
+
+        return Promise.all(
+          getLogsErrorResponse.ranges.map(({ fromBlock, toBlock }) =>
+            request(address, hexToNumber(fromBlock), hexToNumber(toBlock)),
+          ),
+        ).then((logs) => logs.flat());
+      });
+    };
+
+    const chunks = getChunks({
+      interval: [fromBlock, toBlock],
+      maxChunkSize: rangeScanBlockRange ?? toBlock - fromBlock + 1,
+    });
+
+    const results = await Promise.all(
+      chunks.flatMap(([from, to]) =>
+        addressBatches.map((address) => request(address, from, to)),
+      ),
+    );
+
     return results.flat();
   };
 
@@ -1388,8 +1490,8 @@ export const createRealtimeSync = (
     }
 
     // Scan the entire unfinalized window. Used both for reorg detection
-    // (comparing block hashes of previously matched blocks) and to discover
-    // new matched blocks.
+    // (comparing block hashes against the blocks already processed) and to
+    // discover new matched blocks.
     const rangeLogs = await getRangeScanLogs(windowFrom, headNumber);
 
     const logsByBlockNumber = new Map<
@@ -1402,6 +1504,19 @@ export const createRealtimeSync = (
         logsByBlockNumber.set(number, { hash: log.blockHash, logs: [] });
       }
       logsByBlockNumber.get(number)!.logs.push(log);
+    }
+
+    // The request used the union of every filter's address and `topic0`, and
+    // logs from different address batches arrive out of order. Filter each
+    // block's logs precisely and restore `logIndex` order.
+    for (const [number, { logs }] of logsByBlockNumber) {
+      const matchedLogs = logs
+        .filter((log) =>
+          logFilters.some((filter) => isLogFilterMatched({ filter, log })),
+        )
+        .sort((a, b) => hexToNumber(a.logIndex) - hexToNumber(b.logIndex));
+
+      logsByBlockNumber.get(number)!.logs = matchedLogs;
     }
 
     // --- Reorg detection ---
@@ -1501,13 +1616,26 @@ export const createRealtimeSync = (
     // are unchanged in the common case (their hash is already recorded), so
     // this doesn't refetch anything, but it does pick up blocks that a reorg
     // rewound above.
-    const newMatchedNumbers = Array.from(logsByBlockNumber.entries())
+    const newNumbers = Array.from(logsByBlockNumber.entries())
       .filter(
         ([number, { hash }]) =>
           number <= headNumber && scannedBlockHashes.get(number) !== hash,
       )
       .map(([number]) => number)
       .sort((a, b) => a - b);
+
+    // Blocks whose logs were all dropped by client-side filtering are recorded
+    // without being fetched. They must still be recorded, otherwise they would
+    // look like a reorg on every later poll.
+    const newMatchedNumbers: number[] = [];
+    for (const number of newNumbers) {
+      const { hash, logs } = logsByBlockNumber.get(number)!;
+      if (logs.length === 0) {
+        scannedBlockHashes.set(number, hash);
+      } else {
+        newMatchedNumbers.push(number);
+      }
+    }
 
     const matchedBlocks = await Promise.all(
       newMatchedNumbers.map((number) => {
@@ -1524,9 +1652,8 @@ export const createRealtimeSync = (
       const filtered = filterBlockEventData(blockWithEventData);
       const block = filtered.block;
 
-      // Record every block the scan processed, including blocks whose logs were
-      // all dropped by client-side filtering. Recording only matched blocks
-      // would make an unmatched block look like a reorg on every later poll.
+      // Note: recorded after the fetch succeeds, so that a failed poll is
+      // retried from scratch rather than skipping the block.
       scannedBlockHashes.set(hexToNumber(block.number), block.hash);
 
       if (filtered.matchedFilters.size === 0) continue;

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -1876,29 +1876,35 @@ export const createRealtimeSync = (
     ) {
       const pendingFinalizedNumber = headNumber - args.chain.finalityBlockCount;
 
-      // The finalized boundary block may have no events, so fetch it directly.
-      const pendingFinalizedBlock: LightBlock = await eth_getBlockByNumber(
-        args.rpc,
-        [numberToHex(pendingFinalizedNumber), false],
-        { logger: args.common.logger.child({ action: "finalize" }) },
-      ).then((block) => ({
-        hash: block.hash,
-        parentHash: block.parentHash,
-        number: block.number,
-        timestamp: block.timestamp,
-      }));
-
-      const finalizedBlocks = unfinalizedBlocks.filter(
+      // Finalize to the highest local block at or below the boundary rather
+      // than fetching the boundary block itself.
+      //
+      // @dev The local chain is sparse on this path, so the boundary block is
+      // often absent. Finalizing short of it is always safe, and a head block is
+      // appended every poll, so the window stays bounded. Fetching the boundary
+      // block instead would cost a request per finalization and, because it only
+      // needs a header, would return a block without full transactions.
+      const pendingFinalizedBlock = unfinalizedBlocks.findLast(
         (lb) => hexToNumber(lb.number) <= pendingFinalizedNumber,
       );
+
+      // Note: `blockCallback` has already been settled above, so finalization
+      // is simply skipped until a local block falls below the boundary.
+      if (pendingFinalizedBlock === undefined) return;
+
+      const finalizedNumber = hexToNumber(pendingFinalizedBlock.number);
+
+      const finalizedBlocks = unfinalizedBlocks.filter(
+        (lb) => hexToNumber(lb.number) <= finalizedNumber,
+      );
       unfinalizedBlocks = unfinalizedBlocks.filter(
-        (lb) => hexToNumber(lb.number) > pendingFinalizedNumber,
+        (lb) => hexToNumber(lb.number) > finalizedNumber,
       );
       for (const block of finalizedBlocks) {
         childAddressesPerBlock.delete(hexToNumber(block.number));
       }
       for (const number of scannedBlockHashes.keys()) {
-        if (number <= pendingFinalizedNumber) scannedBlockHashes.delete(number);
+        if (number <= finalizedNumber) scannedBlockHashes.delete(number);
       }
 
       finalizedBlock = pendingFinalizedBlock;

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -1778,6 +1778,8 @@ export const createRealtimeSync = (
       }),
     );
 
+    const blockEvents: Extract<RealtimeSyncEvent, { type: "block" }>[] = [];
+
     for (const blockWithEventData of matchedBlocks) {
       const filtered = filterBlockEventData(blockWithEventData);
       const block = filtered.block;
@@ -1797,7 +1799,7 @@ export const createRealtimeSync = (
 
       blockWithEventData.block.transactions = filtered.block.transactions;
 
-      yield {
+      blockEvents.push({
         type: "block",
         hasMatchedFilter: true,
         block: filtered.block,
@@ -1806,7 +1808,7 @@ export const createRealtimeSync = (
         transactionReceipts: filtered.transactionReceipts,
         traces: filtered.traces,
         childAddresses: filtered.childAddresses,
-      };
+      });
     }
 
     // --- Advance to the head block ---
@@ -1828,7 +1830,7 @@ export const createRealtimeSync = (
         timestamp: headBlock.timestamp,
       });
 
-      yield {
+      blockEvents.push({
         type: "block",
         hasMatchedFilter: false,
         block: headBlock,
@@ -1837,10 +1839,23 @@ export const createRealtimeSync = (
         transactionReceipts: [],
         traces: [],
         childAddresses: new Map(),
-      };
+      });
     }
 
-    blockCallback?.(true);
+    // `blockCallback` signals that the head has been fully processed. It must be
+    // attached to the last emitted block event so that the runtime calls it
+    // *after* indexing that block's events, exactly as `reconcileBlock` does.
+    // Calling it here instead reports completion while events are still pending,
+    // which drops them when the chain reaches its end block.
+    if (blockEvents.length === 0) {
+      blockCallback?.(false);
+    } else {
+      for (const [index, blockEvent] of blockEvents.entries()) {
+        yield index === blockEvents.length - 1
+          ? { ...blockEvent, blockCallback }
+          : blockEvent;
+      }
+    }
 
     args.common.logger.debug(
       {

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -6,9 +6,9 @@ import {
   type Address,
   type Hash,
   type Hex,
-  type RpcError,
   hexToNumber,
   numberToHex,
+  type RpcError,
   zeroHash,
 } from "viem";
 import type { Common } from "@/internal/common.js";
@@ -126,6 +126,12 @@ export const createRealtimeSync = (
    * waiting to be finalized. It is an invariant that
    * all blocks are linked to each other,
    * `parentHash` => `hash`.
+   *
+   * @dev The range-scan path is the exception: it only ingests blocks that
+   * contain matching logs, plus one head block per poll, so the list is sparse
+   * and not parent-linked. Consumers key on block number
+   * (`runtime/realtime.ts`), so this only matters for code that walks the list
+   * by hash.
    */
   let unfinalizedBlocks: LightBlock[] = [];
   /** Closest-to-tip block that has been fetched but not yet reconciled. */
@@ -179,10 +185,16 @@ export const createRealtimeSync = (
 
   /**
    * Experimental range-scan fast path. When enabled, each polling interval is
-   * scanned with a single ranged `eth_getLogs` request rather than fetching
-   * every block, so a `pollingInterval` larger than the chain's block time
-   * reduces RPC usage. Only supported when all indexed sources are non-factory
-   * `log` filters; otherwise the default per-block sync is used.
+   * scanned with a ranged `eth_getLogs` request rather than fetching every
+   * block, so a `pollingInterval` larger than the chain's block time reduces RPC
+   * usage. Only supported when all indexed sources are non-factory `log`
+   * filters; otherwise the default per-block sync is used.
+   *
+   * @dev The comparison against the default path assumes its `logsBloom` check
+   * (see `fetchBlockEventData`), which skips `eth_getLogs` for blocks whose
+   * bloom doesn't match any filter. Without it the default path would cost two
+   * requests per block rather than one, and the range scan would win by a much
+   * wider margin than it actually does.
    */
   const canRangeScan =
     args.chain.experimentalRangeScan &&
@@ -231,7 +243,6 @@ export const createRealtimeSync = (
   const rangeScanParams = (() => {
     const addresses = new Set<Address>();
     const topic0s = new Set<Hex>();
-    let hasAllTopic0s = true;
 
     for (const filter of logFilters) {
       // Note: `canRangeScan` guarantees a non-factory, defined address.
@@ -242,18 +253,16 @@ export const createRealtimeSync = (
         addresses.add(address);
       }
 
-      if (filter.topic0 === undefined || filter.topic0 === null) {
-        hasAllTopic0s = false;
-      } else {
-        topic0s.add(filter.topic0);
-      }
+      // Note: `LogFilter["topic0"]` is always defined, one event selector per
+      // log filter.
+      topic0s.add(filter.topic0);
     }
 
     // Note: the `topics` field is fragile for many rpc providers, so only the
-    // first position is included and it is omitted entirely when unconstrained.
+    // first position is included.
     return {
       addresses: Array.from(addresses),
-      topics: hasAllTopic0s ? [Array.from(topic0s)] : undefined,
+      topics: [Array.from(topic0s)],
     };
   })();
 
@@ -269,60 +278,94 @@ export const createRealtimeSync = (
    * request for being too wide, so the same error isn't repeated every poll.
    */
   let rangeScanBlockRange: number | undefined = args.chain.ethGetLogsBlockRange;
+  /** `true` if `rangeScanBlockRange` came from a limit stated by the provider. */
+  let isRangeScanBlockRangeConfirmed =
+    args.chain.ethGetLogsBlockRange !== undefined;
 
   /**
-   * Average number of blocks that must elapse per poll for the range scan to use
-   * fewer RPC credits than the default per-block sync.
+   * Approximate compute unit costs, used only to decide whether to warn that
+   * the range scan isn't paying off. Taken from Alchemy's published table.
    *
-   * @dev Each scan costs about two requests (the head header and one
-   * `eth_getLogs`) no matter how many blocks elapsed, whereas the per-block sync
-   * costs about one request per block. Break-even is therefore around four
-   * blocks per poll, using Alchemy's compute unit costs. Below that, a larger
-   * `pollingInterval` is the only thing that helps.
+   * @dev Providers price differently, so these are indicative. What matters is
+   * the ratio: an `eth_getLogs` costs about three block requests.
    */
-  const MIN_RANGE_SCAN_BLOCKS_PER_POLL = 4;
-  /** Number of polls to average before checking the polling interval. */
+  const CU_BLOCK_REQUEST = 20;
+  const CU_GET_LOGS_REQUEST = 60;
+  /** Number of polls to sample before comparing the two strategies. */
   const RANGE_SCAN_SAMPLE_POLLS = 10;
 
-  let rangeScanPollCount = 0;
-  let rangeScanBlockCount = 0;
-  let hasCheckedRangeScanInterval = false;
+  let rangeScanSampledPolls = 0;
+  let rangeScanSampledBlocks = 0;
+  let rangeScanSampledRequests = 0;
+  let rangeScanSampledMatchedBlocks = 0;
+  let hasSkippedFirstRangeScanPoll = false;
+  let hasCheckedRangeScanCost = false;
 
   /**
-   * Warn once if `pollingInterval` is too short for the range scan to reduce RPC
-   * usage on this chain.
+   * Warn once if the range scan is using more RPC credits than the default
+   * per-block sync would have.
    *
-   * @dev Measured from observed blocks per poll rather than a configured block
-   * time, so it reflects what the chain is actually doing.
+   * @dev Break-even is not a fixed number of blocks per poll: it depends on how
+   * many `eth_getLogs` requests each scan takes (the unfinalized window grows to
+   * `2 * finalityBlockCount` blocks and may be split by block range or address
+   * batch) and on how many blocks contain a matching event. Both are measured
+   * here rather than assumed.
+   *
+   * The per-block path fetches every block and, thanks to the `logsBloom` check
+   * in `fetchBlockEventData`, only issues `eth_getLogs` for blocks whose bloom
+   * matches a filter. Bloom matches aren't observable from this path, so they
+   * are approximated by the number of blocks that had a matching log. That
+   * understates the per-block cost, which makes this warning conservative.
    */
-  const recordRangeScanPoll = (headNumber: number) => {
-    if (hasCheckedRangeScanInterval) return;
-
-    const tipNumber = hexToNumber(getLatestUnfinalizedBlock().number);
+  const recordRangeScanPoll = ({
+    blocks,
+    requests,
+    matchedBlocks,
+  }: {
+    blocks: number;
+    requests: number;
+    matchedBlocks: number;
+  }) => {
+    if (hasCheckedRangeScanCost) return;
 
     // Skip the first poll, which covers the gap left by the historical sync
     // rather than one polling interval.
-    if (rangeScanPollCount === 0 && unfinalizedBlocks.length === 0) {
-      rangeScanPollCount = 1;
+    if (hasSkippedFirstRangeScanPoll === false) {
+      hasSkippedFirstRangeScanPoll = true;
       return;
     }
 
-    rangeScanPollCount += 1;
-    rangeScanBlockCount += Math.max(headNumber - tipNumber, 0);
+    rangeScanSampledPolls += 1;
+    rangeScanSampledBlocks += blocks;
+    rangeScanSampledRequests += requests;
+    rangeScanSampledMatchedBlocks += matchedBlocks;
 
-    if (rangeScanPollCount <= RANGE_SCAN_SAMPLE_POLLS) return;
+    if (rangeScanSampledPolls < RANGE_SCAN_SAMPLE_POLLS) return;
 
-    hasCheckedRangeScanInterval = true;
+    hasCheckedRangeScanCost = true;
 
-    const blocksPerPoll = rangeScanBlockCount / RANGE_SCAN_SAMPLE_POLLS;
+    // Note: a poll where no block elapsed still costs one block request on
+    // either path, hence the `max`.
+    const rangeScanCost =
+      rangeScanSampledPolls * CU_BLOCK_REQUEST +
+      rangeScanSampledRequests * CU_GET_LOGS_REQUEST +
+      rangeScanSampledMatchedBlocks * CU_BLOCK_REQUEST;
+    const perBlockCost =
+      Math.max(rangeScanSampledBlocks, rangeScanSampledPolls) *
+        CU_BLOCK_REQUEST +
+      rangeScanSampledMatchedBlocks * CU_GET_LOGS_REQUEST;
 
-    if (blocksPerPoll < MIN_RANGE_SCAN_BLOCKS_PER_POLL) {
+    if (rangeScanCost >= perBlockCost) {
+      const blocksPerPoll = rangeScanSampledBlocks / rangeScanSampledPolls;
+      const requestsPerPoll = rangeScanSampledRequests / rangeScanSampledPolls;
+
       args.common.logger.warn({
-        msg: `The 'experimentalRangeScan' option is unlikely to reduce RPC usage at this 'pollingInterval'. Only ${blocksPerPoll.toFixed(1)} blocks elapse per poll on average, but each scan costs about two requests regardless. Increase 'pollingInterval' to at least ${MIN_RANGE_SCAN_BLOCKS_PER_POLL} times the block time, or disable 'experimentalRangeScan'.`,
+        msg: `The 'experimentalRangeScan' option is not reducing RPC usage on this chain. Over ${rangeScanSampledPolls} polls it used about ${rangeScanCost} credits versus ${perBlockCost} for the default per-block sync, with ${blocksPerPoll.toFixed(1)} blocks and ${requestsPerPoll.toFixed(1)} 'eth_getLogs' requests per poll. Increase 'pollingInterval', or disable 'experimentalRangeScan'.`,
         chain: args.chain.name,
         chain_id: args.chain.id,
         polling_interval: args.chain.pollingInterval,
         blocks_per_poll: blocksPerPoll,
+        requests_per_poll: requestsPerPoll,
       });
     }
   };
@@ -1371,10 +1414,13 @@ export const createRealtimeSync = (
   const getRangeScanLogs = async (
     fromBlock: number,
     toBlock: number,
-  ): Promise<SyncLog[]> => {
+  ): Promise<{ logs: SyncLog[]; requestCount: number }> => {
     const context = {
       logger: args.common.logger.child({ action: "fetch_block_data" }),
     };
+
+    let requestCount = 0;
+    let didSplit = false;
 
     const addressBatches: Address[][] = [];
     for (
@@ -1401,6 +1447,8 @@ export const createRealtimeSync = (
         },
       ];
 
+      requestCount += 1;
+
       return eth_getLogs(args.rpc, params, context).catch((error) => {
         // Note: skip the range retry logic if the chain has a custom block
         // range, matching the historical sync.
@@ -1413,6 +1461,9 @@ export const createRealtimeSync = (
         });
 
         if (getLogsErrorResponse.shouldRetry === false) throw error;
+
+        didSplit = true;
+        isRangeScanBlockRangeConfirmed = getLogsErrorResponse.isSuggestedRange;
 
         const range =
           hexToNumber(getLogsErrorResponse.ranges[0]!.toBlock) -
@@ -1451,7 +1502,19 @@ export const createRealtimeSync = (
       ),
     );
 
-    return results.flat();
+    // A range narrowed from an error that didn't state a limit may be smaller
+    // than the provider actually allows, and every extra chunk is an extra
+    // request. Grow it back slowly, the same way the historical sync does.
+    if (
+      didSplit === false &&
+      rangeScanBlockRange !== undefined &&
+      isRangeScanBlockRangeConfirmed === false &&
+      args.chain.ethGetLogsBlockRange === undefined
+    ) {
+      rangeScanBlockRange = Math.round(rangeScanBlockRange * 1.05);
+    }
+
+    return { logs: results.flat(), requestCount };
   };
 
   /**
@@ -1537,13 +1600,14 @@ export const createRealtimeSync = (
     const headNumber = hexToNumber(headBlock.number);
     const windowFrom = hexToNumber(finalizedBlock.number) + 1;
 
-    recordRangeScanPoll(headNumber);
+    const tipNumberBeforeScan = hexToNumber(getLatestUnfinalizedBlock().number);
 
     // We already saw this head, or it is at/under the finalized block. No-op.
     if (
       getLatestUnfinalizedBlock().hash === headBlock.hash ||
       headNumber < windowFrom
     ) {
+      recordRangeScanPoll({ blocks: 0, requests: 0, matchedBlocks: 0 });
       blockCallback?.(false);
       return;
     }
@@ -1551,7 +1615,10 @@ export const createRealtimeSync = (
     // Scan the entire unfinalized window. Used both for reorg detection
     // (comparing block hashes against the blocks already processed) and to
     // discover new matched blocks.
-    const rangeLogs = await getRangeScanLogs(windowFrom, headNumber);
+    const { logs: rangeLogs, requestCount } = await getRangeScanLogs(
+      windowFrom,
+      headNumber,
+    );
 
     const logsByBlockNumber = new Map<
       number,
@@ -1590,9 +1657,7 @@ export const createRealtimeSync = (
     //    emitted as an empty block every poll, the local tip advances past
     //    event-free blocks, and logs introduced into them by a reorg would
     //    otherwise never be ingested.
-    const tipNumberBeforeReorg = hexToNumber(
-      getLatestUnfinalizedBlock().number,
-    );
+    const tipNumberBeforeReorg = tipNumberBeforeScan;
 
     let reorgFromNumber: number | undefined;
     const setReorgFrom = (number: number) => {
@@ -1696,6 +1761,12 @@ export const createRealtimeSync = (
       }
     }
 
+    recordRangeScanPoll({
+      blocks: Math.max(headNumber - tipNumberBeforeScan, 0),
+      requests: requestCount,
+      matchedBlocks: newMatchedNumbers.length,
+    });
+
     const matchedBlocks = await Promise.all(
       newMatchedNumbers.map((number) => {
         const { hash } = logsByBlockNumber.get(number)!;
@@ -1741,6 +1812,14 @@ export const createRealtimeSync = (
     // --- Advance to the head block ---
     // Emit the head as an empty block (if it wasn't already emitted as matched)
     // so the realtime checkpoint advances to the tip every poll.
+    //
+    // @dev These blocks are not added to `scannedBlockHashes`, because the scan
+    // never observed them — they contain no matching logs. A reorg that replaces
+    // a log-free head with another log-free block is therefore not detected, and
+    // `syncProgress.current` can briefly hold a non-canonical hash and timestamp.
+    // No events are affected: `hasMatchedFilter: false` blocks are never
+    // persisted, and the next poll's scan re-derives the tip. A reorg that gives
+    // any of these blocks a matching log *is* detected, by case 3 above.
     if (hexToNumber(getLatestUnfinalizedBlock().number) < headNumber) {
       unfinalizedBlocks.push({
         hash: headBlock.hash,

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -170,6 +170,54 @@ export const createRealtimeSync = (
     }
   }
 
+  /**
+   * Experimental range-scan fast path. When enabled, each polling interval is
+   * scanned with a single ranged `eth_getLogs` request rather than fetching
+   * every block, so a `pollingInterval` larger than the chain's block time
+   * reduces RPC usage. Only supported when all indexed sources are non-factory
+   * `log` filters; otherwise the default per-block sync is used.
+   */
+  const canRangeScan =
+    args.chain.experimentalRangeScan &&
+    logFilters.length > 0 &&
+    factories.length === 0 &&
+    traceFilters.length === 0 &&
+    transactionFilters.length === 0 &&
+    transferFilters.length === 0 &&
+    blockFilters.length === 0;
+
+  if (args.chain.experimentalRangeScan && canRangeScan === false) {
+    args.common.logger.warn({
+      msg: "Ignoring 'experimentalRangeScan' because the chain has factory, block, transaction, trace, or transfer sources. Using the default per-block realtime sync.",
+      chain: args.chain.name,
+      chain_id: args.chain.id,
+    });
+  }
+
+  /** Hashes of unfinalized blocks that have matched a filter (range-scan path). */
+  const rangeMatchedHashes = new Set<Hash>();
+
+  /**
+   * Build the `address` argument for the range-scan `eth_getLogs` request as the
+   * union of all log filter addresses, or `undefined` if any filter matches all
+   * addresses. Topics are intentionally not merged; logs are filtered precisely
+   * client-side.
+   */
+  const getRangeScanAddress = (): Address | Address[] | undefined => {
+    const addresses = new Set<Address>();
+    for (const filter of logFilters) {
+      if (filter.address === undefined || isAddressFactory(filter.address)) {
+        return undefined;
+      }
+      if (Array.isArray(filter.address)) {
+        for (const address of filter.address) addresses.add(address);
+      } else {
+        addresses.add(filter.address);
+      }
+    }
+    return Array.from(addresses);
+  };
+
   const syncTransactionReceipts = async (
     block: SyncBlock,
     transactionHashes: Set<Hash>,
@@ -1203,6 +1251,307 @@ export const createRealtimeSync = (
     }
   };
 
+  /**
+   * Fetch all matching logs in `[fromBlock, toBlock]` with a single ranged
+   * `eth_getLogs` request (chunked by `ethGetLogsBlockRange` if configured).
+   */
+  const getRangeScanLogs = async (
+    fromBlock: number,
+    toBlock: number,
+  ): Promise<SyncLog[]> => {
+    const context = {
+      logger: args.common.logger.child({ action: "fetch_block_data" }),
+    };
+    const address = getRangeScanAddress();
+    const chunkSize =
+      args.chain.ethGetLogsBlockRange ?? toBlock - fromBlock + 1;
+
+    const requests: Promise<SyncLog[]>[] = [];
+    for (let from = fromBlock; from <= toBlock; from += chunkSize) {
+      const to = Math.min(from + chunkSize - 1, toBlock);
+      requests.push(
+        eth_getLogs(
+          args.rpc,
+          [
+            {
+              address,
+              fromBlock: numberToHex(from),
+              toBlock: numberToHex(to),
+            },
+          ],
+          context,
+        ),
+      );
+    }
+
+    const results = await Promise.all(requests);
+    return results.flat();
+  };
+
+  /**
+   * Build `BlockWithEventData` for a single block from logs already fetched by
+   * `getRangeScanLogs`. Only valid for the range-scan path (log filters only).
+   */
+  const buildLogBlockData = async (
+    block: SyncBlock,
+    blockLogs: SyncLog[],
+  ): Promise<BlockWithEventData> => {
+    const context = {
+      logger: args.common.logger.child({ action: "fetch_block_data" }),
+    };
+
+    validateLogsAndBlock(
+      blockLogs,
+      block,
+      { method: "eth_getLogs", params: [{ blockHash: block.hash }] },
+      { method: "eth_getBlockByHash", params: [block.hash, true] },
+    );
+
+    const requiredTransactions = new Set<Hash>();
+    const requiredTransactionReceipts = new Set<Hash>();
+
+    const logs = blockLogs.filter((log) => {
+      let isMatched = false;
+      for (const filter of logFilters) {
+        if (isLogFilterMatched({ filter, log })) {
+          isMatched = true;
+          if (log.transactionHash !== zeroHash) {
+            requiredTransactions.add(log.transactionHash);
+            if (filter.hasTransactionReceipt) {
+              requiredTransactionReceipts.add(log.transactionHash);
+              break;
+            }
+          }
+        }
+      }
+      return isMatched;
+    });
+
+    validateTransactionsAndBlock(block, {
+      method: "eth_getBlockByHash",
+      params: [block.hash, true],
+    });
+
+    const transactions = block.transactions.filter((transaction) =>
+      requiredTransactions.has(transaction.hash),
+    );
+
+    const transactionReceipts = await syncTransactionReceipts(
+      block,
+      requiredTransactionReceipts,
+      "eth_getBlockByHash",
+      context,
+    );
+
+    return {
+      block,
+      transactions,
+      transactionReceipts,
+      logs,
+      traces: [],
+      // No factory sources are supported on the range-scan path.
+      childAddresses: new Map(),
+    };
+  };
+
+  /**
+   * Reconcile the chain up to `headBlock` by scanning the entire unfinalized
+   * window with a single ranged `eth_getLogs` request. Reorgs are detected by
+   * diffing the block hashes of previously-emitted matched blocks against the
+   * rescan, so blocks without matching events are never fetched.
+   *
+   * @dev Only used when `canRangeScan` is true.
+   */
+  const reconcileRange = async function* (
+    headBlock: SyncBlock | SyncBlockHeader,
+    blockCallback?: (isAccepted: boolean) => void,
+  ): AsyncGenerator<RealtimeSyncEvent> {
+    const endClock = startClock();
+    const headNumber = hexToNumber(headBlock.number);
+    const windowFrom = hexToNumber(finalizedBlock.number) + 1;
+
+    // We already saw this head, or it is at/under the finalized block. No-op.
+    if (
+      getLatestUnfinalizedBlock().hash === headBlock.hash ||
+      headNumber < windowFrom
+    ) {
+      blockCallback?.(false);
+      return;
+    }
+
+    // Scan the entire unfinalized window. Used both for reorg detection
+    // (comparing block hashes of previously matched blocks) and to discover
+    // new matched blocks.
+    const rangeLogs = await getRangeScanLogs(windowFrom, headNumber);
+
+    const logsByBlockNumber = new Map<
+      number,
+      { hash: Hash; logs: SyncLog[] }
+    >();
+    for (const log of rangeLogs) {
+      const number = hexToNumber(log.blockNumber);
+      if (logsByBlockNumber.has(number) === false) {
+        logsByBlockNumber.set(number, { hash: log.blockHash, logs: [] });
+      }
+      logsByBlockNumber.get(number)!.logs.push(log);
+    }
+
+    // --- Reorg detection ---
+    // Find the lowest previously-emitted matched block whose hash no longer
+    // matches the rescan (changed hash or disappeared).
+    let reorgFromNumber: number | undefined;
+    for (const stored of unfinalizedBlocks) {
+      if (rangeMatchedHashes.has(stored.hash) === false) continue;
+      const rescan = logsByBlockNumber.get(hexToNumber(stored.number));
+      if (rescan === undefined || rescan.hash !== stored.hash) {
+        reorgFromNumber = hexToNumber(stored.number);
+        break;
+      }
+    }
+
+    if (reorgFromNumber !== undefined) {
+      const reorgedBlocks = unfinalizedBlocks.filter(
+        (lb) => hexToNumber(lb.number) >= reorgFromNumber!,
+      );
+      unfinalizedBlocks = unfinalizedBlocks.filter(
+        (lb) => hexToNumber(lb.number) < reorgFromNumber!,
+      );
+      for (const block of reorgedBlocks) {
+        rangeMatchedHashes.delete(block.hash);
+        childAddressesPerBlock.delete(hexToNumber(block.number));
+      }
+
+      const commonAncestor = getLatestUnfinalizedBlock();
+
+      args.common.logger.debug({
+        msg: "Reconciled reorg in local chain",
+        chain: args.chain.name,
+        chain_id: args.chain.id,
+        reorg_depth: reorgedBlocks.length,
+        common_ancestor_block: hexToNumber(commonAncestor.number),
+      });
+
+      yield { type: "reorg", block: commonAncestor, reorgedBlocks };
+    }
+
+    // --- Ingest new matched blocks ---
+    const localTipNumber = hexToNumber(getLatestUnfinalizedBlock().number);
+    const newMatchedNumbers = Array.from(logsByBlockNumber.keys())
+      .filter((number) => number > localTipNumber && number <= headNumber)
+      .sort((a, b) => a - b);
+
+    const matchedBlocks = await Promise.all(
+      newMatchedNumbers.map((number) => {
+        const { hash } = logsByBlockNumber.get(number)!;
+        return eth_getBlockByHash(args.rpc, [hash, true], {
+          logger: args.common.logger.child({ action: "fetch_block_data" }),
+        }).then((block) =>
+          buildLogBlockData(block, logsByBlockNumber.get(number)!.logs),
+        );
+      }),
+    );
+
+    for (const blockWithEventData of matchedBlocks) {
+      const filtered = filterBlockEventData(blockWithEventData);
+      const block = filtered.block;
+
+      if (filtered.matchedFilters.size === 0) continue;
+
+      unfinalizedBlocks.push({
+        hash: block.hash,
+        parentHash: block.parentHash,
+        number: block.number,
+        timestamp: block.timestamp,
+      });
+      rangeMatchedHashes.add(block.hash);
+
+      blockWithEventData.block.transactions = filtered.block.transactions;
+
+      yield {
+        type: "block",
+        hasMatchedFilter: true,
+        block: filtered.block,
+        logs: filtered.logs,
+        transactions: filtered.transactions,
+        transactionReceipts: filtered.transactionReceipts,
+        traces: filtered.traces,
+        childAddresses: filtered.childAddresses,
+      };
+    }
+
+    // --- Advance to the head block ---
+    // Emit the head as an empty block (if it wasn't already emitted as matched)
+    // so the realtime checkpoint advances to the tip every poll.
+    if (hexToNumber(getLatestUnfinalizedBlock().number) < headNumber) {
+      unfinalizedBlocks.push({
+        hash: headBlock.hash,
+        parentHash: headBlock.parentHash,
+        number: headBlock.number,
+        timestamp: headBlock.timestamp,
+      });
+
+      yield {
+        type: "block",
+        hasMatchedFilter: false,
+        block: headBlock,
+        logs: [],
+        transactions: [],
+        transactionReceipts: [],
+        traces: [],
+        childAddresses: new Map(),
+      };
+    }
+
+    blockCallback?.(true);
+
+    args.common.logger.debug(
+      {
+        msg: "Reconciled range",
+        chain: args.chain.name,
+        chain_id: args.chain.id,
+        block_range: JSON.stringify([windowFrom, headNumber]),
+        matched_block_count: newMatchedNumbers.length,
+        duration: endClock(),
+      },
+      ["chain"],
+    );
+
+    // --- Finalization ---
+    if (
+      headNumber >=
+      hexToNumber(finalizedBlock.number) + 2 * args.chain.finalityBlockCount
+    ) {
+      const pendingFinalizedNumber = headNumber - args.chain.finalityBlockCount;
+
+      // The finalized boundary block may have no events, so fetch it directly.
+      const pendingFinalizedBlock: LightBlock = await eth_getBlockByNumber(
+        args.rpc,
+        [numberToHex(pendingFinalizedNumber), false],
+        { logger: args.common.logger.child({ action: "finalize" }) },
+      ).then((block) => ({
+        hash: block.hash,
+        parentHash: block.parentHash,
+        number: block.number,
+        timestamp: block.timestamp,
+      }));
+
+      const finalizedBlocks = unfinalizedBlocks.filter(
+        (lb) => hexToNumber(lb.number) <= pendingFinalizedNumber,
+      );
+      unfinalizedBlocks = unfinalizedBlocks.filter(
+        (lb) => hexToNumber(lb.number) > pendingFinalizedNumber,
+      );
+      for (const block of finalizedBlocks) {
+        rangeMatchedHashes.delete(block.hash);
+        childAddressesPerBlock.delete(hexToNumber(block.number));
+      }
+
+      finalizedBlock = pendingFinalizedBlock;
+
+      yield { type: "finalize", block: pendingFinalizedBlock };
+    }
+  };
+
   const onError = (error: Error, block?: SyncBlock | SyncBlockHeader) => {
     if (args.common.shutdown.isKilled) {
       throw new ShutdownError();
@@ -1275,6 +1624,21 @@ export const createRealtimeSync = (
         // is used to handle this case.
 
         latestFetchedBlock = block;
+
+        if (canRangeScan) {
+          // Note: reconciliation must be called serially.
+          await realtimeSyncLock.lock();
+
+          try {
+            yield* reconcileRange(block, blockCallback);
+          } finally {
+            realtimeSyncLock.unlock();
+          }
+
+          latestFetchedBlock = undefined;
+          fetchAndReconcileLatestBlockErrorCount = 0;
+          return;
+        }
 
         const blockWithEventData = await fetchBlockEventData(block);
 

--- a/simulation-test/apps/basepaint/ponder.config.ts
+++ b/simulation-test/apps/basepaint/ponder.config.ts
@@ -11,7 +11,13 @@ export default createConfig({
     poolConfig: { max: 17 },
   },
   chains: {
-    base: { id: 8453, rpc: process.env.PONDER_RPC_URL_8453! },
+    base: {
+      id: 8453,
+      rpc: process.env.PONDER_RPC_URL_8453!,
+      // Note: unset when building the expected tables, so ground truth always
+      // comes from the default per-block realtime sync.
+      experimentalRangeScan: process.env.EXPERIMENTAL_RANGE_SCAN === "true",
+    },
   },
   contracts: {
     BasePaintBrush: {

--- a/simulation-test/apps/reference-erc20/ponder.config.ts
+++ b/simulation-test/apps/reference-erc20/ponder.config.ts
@@ -10,7 +10,13 @@ export default createConfig({
     poolConfig: { max: 17 },
   },
   chains: {
-    mainnet: { id: 1, rpc: process.env.PONDER_RPC_URL_1 },
+    mainnet: {
+      id: 1,
+      rpc: process.env.PONDER_RPC_URL_1,
+      // Note: unset when building the expected tables, so ground truth always
+      // comes from the default per-block realtime sync.
+      experimentalRangeScan: process.env.EXPERIMENTAL_RANGE_SCAN === "true",
+    },
   },
   contracts: {
     ERC20: {

--- a/simulation-test/src/index.ts
+++ b/simulation-test/src/index.ts
@@ -129,6 +129,14 @@ export const SIM_PARAMS = {
     [true, false],
     "realtime-block-has-transactions",
   ),
+  // Note: only applies to apps whose sources are exclusively `log` filters with
+  // a static address. Other apps fall back to the per-block realtime sync.
+  // `FORCE_RANGE_SCAN` pins the value so a failing seed can be replayed against
+  // both realtime strategies.
+  EXPERIMENTAL_RANGE_SCAN:
+    process.env.FORCE_RANGE_SCAN === undefined
+      ? pick([true, false], "experimental-range-scan")
+      : process.env.FORCE_RANGE_SCAN === "true",
 };
 
 // 1. Setup database
@@ -249,6 +257,9 @@ process.env.DATABASE_URL = `${DATABASE_URL!}/${UUID}`;
 process.env.DATABASE_SCHEMA = "public";
 process.env.SEED = SEED;
 process.env.ORDERING = SIM_PARAMS.ORDERING;
+process.env.EXPERIMENTAL_RANGE_SCAN = String(
+  SIM_PARAMS.EXPERIMENTAL_RANGE_SCAN,
+);
 
 const pwr = promiseWithResolvers<void>();
 


### PR DESCRIPTION
  ## Summary

  Adds an opt-in `experimentalRangeScan` chain config option that lets a larger
  `pollingInterval` actually reduce realtime RPC usage.

  Today, setting `pollingInterval` higher than a chain's block time does not reduce
  RPC usage because the realtime engine fetches **every** block to check for reorgs
  (documented limitation in `config/chains`). On L2s with sub-second block times this
  makes realtime indexing very RPC-expensive.

  ## Motivation

  On high-throughput L2s, a `pollingInterval` of e.g. 4s still triggers ~16
  `eth_getBlockByNumber` calls (plus per-block `eth_getLogs`) per poll, so raising it
  buys nothing. This change makes a larger `pollingInterval` translate into
  proportionally lower RPC usage.

  ## How it works

  When `experimentalRangeScan` is enabled, on each poll the realtime engine:

  1. Fetches the head **header only** (`eth_getBlockByNumber(["latest", false])`).
  2. Scans the entire unfinalized window with a single ranged `eth_getLogs([from, to])`
     instead of fetching every block.
  3. Fetches full block data only for blocks that contain matching events
     (`eth_getBlockByHash`), and emits an empty head event so the realtime checkpoint
     still advances to the tip.

  This makes per-poll RPC cost roughly constant (~2 calls + one per event-bearing
  block) regardless of how many blocks elapsed.

  Reorgs are detected by diffing the block hashes of previously-emitted event-bearing
  blocks against the rescan (a changed or disappeared hash signals a reorg). The
  existing `block` / `reorg` / `finalize` event shapes are reused, so the downstream
  indexing pipeline is unchanged.

  ## Scope

  To keep this a safe, incremental rollout, the fast path is gated:

  - It is **opt-in** via the `experimentalRangeScan` flag (default `false`); existing
    behavior is untouched.
  - It only applies to chains whose indexed sources are **exclusively non-factory
    `log` events**. Chains using factory, block, transaction, trace, or transfer
    sources log a warning and fall back to the default per-block realtime sync.

  ## Tests

  Added realtime sync tests:

  - RPC efficiency: asserts a single ranged `eth_getLogs`, zero per-block
    `eth_getBlockByNumber`, and only event-bearing blocks fetched by hash.
  - Reorg detection of an event-bearing block (via Anvil snapshot/revert).
  - Fallback to the per-block path when an unsupported (block) filter is present.

  Full realtime suite passes (19/19), plus the config-build and rpc suites.

  ## Docs

  Updated `config/chains` and the config API reference to document the new option and
  its limitations, and added a changeset.