### PR TITLE
[ClickHouse sink 1/6] Add durable finalized sink delivery

### DIFF
--- a/.changeset/silver-sinks.md
+++ b/.changeset/silver-sinks.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Added durable finalized analytics sink delivery.

--- a/packages/core/src/build/config.test.ts
+++ b/packages/core/src/build/config.test.ts
@@ -2,7 +2,12 @@ import { context, setupAnvil, setupCommon } from "@/_test/setup.js";
 import { TEST_POOL_ID } from "@/_test/utils.js";
 import { factory } from "@/config/address.js";
 import { createConfig } from "@/config/index.js";
-import type { LogFactory, LogFilter, TraceFilter } from "@/internal/types.js";
+import type {
+  IndexingSink,
+  LogFactory,
+  LogFilter,
+  TraceFilter,
+} from "@/internal/types.js";
 import { hyperliquidEvm } from "@/utils/chains.js";
 import {
   type Address,
@@ -39,6 +44,29 @@ const bytes2 =
   "0x0000000000000000000000000000000000000000000000000000000000000002";
 
 beforeEach(setupAnvil);
+
+test("buildConfig() validates sinks", () => {
+  const sink = {
+    name: "analytics",
+    writeFinalizedBatch: async () => {},
+  } satisfies IndexingSink;
+  const config = createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}` },
+    },
+    sinks: [sink],
+  });
+
+  expect(buildConfig({ common: context.common, config }).sinks).toStrictEqual([
+    sink,
+  ]);
+  expect(() =>
+    buildConfig({
+      common: context.common,
+      config: { ...config, sinks: [sink, sink] },
+    }),
+  ).toThrow("Multiple sinks use the name");
+});
 
 test("buildIndexingFunctions() builds topics for multiple events", async () => {
   const config = createConfig({

--- a/packages/core/src/build/config.ts
+++ b/packages/core/src/build/config.ts
@@ -10,6 +10,7 @@ import type {
   FilterAddress,
   IndexingBuild,
   IndexingFunctions,
+  IndexingSink,
   LightBlock,
   LogFilter,
   SetupCallback,
@@ -969,6 +970,7 @@ export function buildConfig({
 }: { common: Common; config: Config }): {
   chains: Chain[];
   rpcs: Rpc[];
+  sinks: readonly IndexingSink[];
   logs: ({ level: "warn" | "info" | "debug"; msg: string } & Record<
     string,
     unknown
@@ -1081,7 +1083,41 @@ export function buildConfig({
     }),
   );
 
-  return { chains, rpcs, logs };
+  const sinks = config.sinks ?? [];
+  const sinkNames = new Set<string>();
+  for (const sink of sinks) {
+    if (
+      typeof sink.name !== "string" ||
+      sink.name === "" ||
+      sink.name !== sink.name.trim()
+    ) {
+      throw new Error(
+        "Validation failed: Sink name must be a non-empty string without leading or trailing whitespace.",
+      );
+    }
+    if (typeof sink.writeFinalizedBatch !== "function") {
+      throw new Error(
+        `Validation failed: Sink '${sink.name}' must define writeFinalizedBatch().`,
+      );
+    }
+    if (
+      (sink.setup !== undefined && typeof sink.setup !== "function") ||
+      (sink.flush !== undefined && typeof sink.flush !== "function") ||
+      (sink.shutdown !== undefined && typeof sink.shutdown !== "function")
+    ) {
+      throw new Error(
+        `Validation failed: Sink '${sink.name}' lifecycle hooks must be functions.`,
+      );
+    }
+    if (sinkNames.has(sink.name)) {
+      throw new Error(
+        `Validation failed: Multiple sinks use the name '${sink.name}'.`,
+      );
+    }
+    sinkNames.add(sink.name);
+  }
+
+  return { chains, rpcs, sinks, logs };
 }
 
 export async function safeBuildIndexingFunctions({
@@ -1131,6 +1167,7 @@ export function safeBuildConfig({
       status: "success",
       chains: result.chains,
       rpcs: result.rpcs,
+      sinks: result.sinks,
       logs: result.logs,
     } as const;
   } catch (_error) {

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -79,12 +79,12 @@ export type Build = {
   }) => Result<SchemaBuild>;
   compileConfig: (params: {
     configResult: Extract<ConfigResult, { status: "success" }>["result"];
-  }) => Result<Pick<IndexingBuild, "chains" | "rpcs">>;
+  }) => Result<Pick<IndexingBuild, "chains" | "rpcs" | "sinks">>;
   compileIndexing: (params: {
     configResult: Extract<ConfigResult, { status: "success" }>["result"];
     schemaResult: Extract<SchemaResult, { status: "success" }>["result"];
     indexingResult: Extract<IndexingResult, { status: "success" }>["result"];
-    configBuild: Pick<IndexingBuild, "chains" | "rpcs">;
+    configBuild: Pick<IndexingBuild, "chains" | "rpcs" | "sinks">;
   }) => Promise<Result<IndexingBuild>>;
   compileApi: (params: {
     apiResult: Extract<ApiResult, { status: "success" }>["result"];
@@ -481,6 +481,7 @@ export const createBuild = async ({
         result: {
           chains: buildConfigResult.chains,
           rpcs: buildConfigResult.rpcs,
+          sinks: buildConfigResult.sinks,
         },
       } as const;
     },
@@ -518,6 +519,7 @@ export const createBuild = async ({
         status: "success",
         result: {
           buildId,
+          sinks: configBuild.sinks,
           chains: buildIndexingFunctionsResult.chains,
           rpcs: buildIndexingFunctionsResult.rpcs,
           finalizedBlocks: buildIndexingFunctionsResult.finalizedBlocks,

--- a/packages/core/src/config/index.test-d.ts
+++ b/packages/core/src/config/index.test-d.ts
@@ -1,6 +1,27 @@
 import { assertType, test } from "vitest";
-import type { IndexingSink } from "../index.js";
+import type { CreateConfigReturnType, IndexingSink } from "../index.js";
 import { createConfig } from "./index.js";
+
+test("CreateConfigReturnType generic defaults", () => {
+  const sink = {
+    name: "analytics",
+    writeFinalizedBatch: async () => {},
+  } satisfies IndexingSink;
+
+  assertType<CreateConfigReturnType<{}, {}, {}, {}>>({
+    chains: {},
+    contracts: {},
+    accounts: {},
+    blocks: {},
+  });
+  assertType<CreateConfigReturnType<{}, {}, {}, {}, readonly [typeof sink]>>({
+    chains: {},
+    contracts: {},
+    accounts: {},
+    blocks: {},
+    sinks: [sink] as const,
+  });
+});
 
 test("createConfig sinks", () => {
   const sink = {

--- a/packages/core/src/config/index.test-d.ts
+++ b/packages/core/src/config/index.test-d.ts
@@ -1,0 +1,33 @@
+import { assertType, test } from "vitest";
+import type { IndexingSink } from "../index.js";
+import { createConfig } from "./index.js";
+
+test("createConfig sinks", () => {
+  const sink = {
+    name: "analytics",
+    writeFinalizedBatch: async () => {},
+  } satisfies IndexingSink;
+  const config = createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: "https://rpc.com" },
+    },
+    sinks: [sink],
+  });
+
+  assertType<readonly IndexingSink[] | undefined>(config.sinks);
+});
+
+test("createConfig rejects invalid sinks", () => {
+  createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: "https://rpc.com" },
+    },
+    sinks: [
+      {
+        name: "analytics",
+        // @ts-expect-error
+        writeFinalizedBatch: undefined,
+      },
+    ],
+  });
+});

--- a/packages/core/src/config/index.test.ts
+++ b/packages/core/src/config/index.test.ts
@@ -1,3 +1,4 @@
+import type { IndexingSink } from "@/internal/types.js";
 import { type Abi, parseAbiItem } from "viem";
 import { expectTypeOf, test } from "vitest";
 import { factory } from "./address.js";
@@ -34,6 +35,23 @@ test("createConfig basic", () => {
       },
     },
   });
+});
+
+test("createConfig sinks", () => {
+  const sink = {
+    name: "analytics",
+    writeFinalizedBatch: async () => {},
+  } satisfies IndexingSink;
+  const config = createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: "https://rpc.com" },
+    },
+    sinks: [sink],
+  });
+
+  expectTypeOf(config.sinks).toMatchTypeOf<
+    readonly IndexingSink[] | undefined
+  >();
 });
 
 test("createConfig no extra properties", () => {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,4 +1,5 @@
 import type { ConnectionOptions } from "node:tls";
+import type { IndexingSink } from "@/internal/types.js";
 import type { Prettify } from "@/types/utils.js";
 import type { Abi } from "abitype";
 import type { PoolConfig } from "pg";
@@ -9,6 +10,8 @@ import type { GetEventFilter } from "./eventFilter.js";
 export type Config = {
   database?: DatabaseConfig;
   ordering?: "omnichain" | "multichain" | "experimental_isolated";
+  /** Finalized analytics sinks. Requires a Postgres database. */
+  sinks?: readonly IndexingSink[];
   chains: { [chainName: string]: ChainConfig<unknown> };
   contracts: { [contractName: string]: GetContract };
   accounts: { [accountName: string]: AccountConfig<unknown> };
@@ -17,31 +20,37 @@ export type Config = {
   };
 };
 
-export type CreateConfigReturnType<chains, contracts, accounts, blocks> = {
-  database?: DatabaseConfig;
-  ordering?: "omnichain" | "multichain" | "experimental_isolated";
-  chains: chains;
-  contracts: contracts;
-  accounts: accounts;
-  blocks: blocks;
-};
+export type CreateConfigReturnType<chains, contracts, accounts, blocks, sinks> =
+  {
+    database?: DatabaseConfig;
+    ordering?: "omnichain" | "multichain" | "experimental_isolated";
+    /** Finalized analytics sinks. Requires a Postgres database. */
+    sinks?: sinks;
+    chains: chains;
+    contracts: contracts;
+    accounts: accounts;
+    blocks: blocks;
+  };
 
 export const createConfig = <
   const chains,
   const contracts = {},
   const accounts = {},
   const blocks = {},
+  const sinks extends readonly IndexingSink[] = [],
 >(config: {
   database?: DatabaseConfig;
   ordering?: "omnichain" | "multichain" | "experimental_isolated";
+  /** Finalized analytics sinks. Requires a Postgres database. */
+  sinks?: sinks;
   // TODO: add jsdoc to these properties.
   chains: ChainsConfig<Narrow<chains>>;
   contracts?: ContractsConfig<chains, Narrow<contracts>>;
   accounts?: AccountsConfig<chains, Narrow<accounts>>;
   blocks?: BlockFiltersConfig<chains, blocks>;
-}): CreateConfigReturnType<chains, contracts, accounts, blocks> =>
+}): CreateConfigReturnType<chains, contracts, accounts, blocks, sinks> =>
   config as Prettify<
-    CreateConfigReturnType<chains, contracts, accounts, blocks>
+    CreateConfigReturnType<chains, contracts, accounts, blocks, sinks>
   >;
 
 // database

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -20,17 +20,22 @@ export type Config = {
   };
 };
 
-export type CreateConfigReturnType<chains, contracts, accounts, blocks, sinks> =
-  {
-    database?: DatabaseConfig;
-    ordering?: "omnichain" | "multichain" | "experimental_isolated";
-    /** Finalized analytics sinks. Requires a Postgres database. */
-    sinks?: sinks;
-    chains: chains;
-    contracts: contracts;
-    accounts: accounts;
-    blocks: blocks;
-  };
+export type CreateConfigReturnType<
+  chains,
+  contracts,
+  accounts,
+  blocks,
+  sinks extends readonly IndexingSink[] = [],
+> = {
+  database?: DatabaseConfig;
+  ordering?: "omnichain" | "multichain" | "experimental_isolated";
+  /** Finalized analytics sinks. Requires a Postgres database. */
+  sinks?: sinks;
+  chains: chains;
+  contracts: contracts;
+  accounts: accounts;
+  blocks: blocks;
+};
 
 export const createConfig = <
   const chains,

--- a/packages/core/src/database/actions.test.ts
+++ b/packages/core/src/database/actions.test.ts
@@ -25,7 +25,9 @@ import {
   createTriggers,
   createViews,
   dropTriggers,
+  finalizeIsolated,
   finalizeMultichain,
+  finalizeOmnichain,
   revertMultichain,
 } from "./actions.js";
 import { type Database, getPonderCheckpointTable } from "./index.js";
@@ -391,6 +393,7 @@ test("empty schema", async () => {
   const { database } = await setupDatabaseServices({
     schemaBuild: { schema: {} },
   });
+  const finalized: string[] = [];
   await createTriggers(database.userQB, { tables: [] });
   await dropTriggers(database.userQB, { tables: [] });
   await createViews(database.userQB, {
@@ -407,7 +410,28 @@ test("empty schema", async () => {
     checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 10n }),
 
     namespaceBuild: { schema: "public", viewsSchema: undefined },
+    onFinalize: async () => {
+      finalized.push("multichain");
+    },
   });
+  await finalizeOmnichain(database.userQB, {
+    tables: [],
+    checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 10n }),
+    namespaceBuild: { schema: "public", viewsSchema: undefined },
+    onFinalize: async () => {
+      finalized.push("omnichain");
+    },
+  });
+  await finalizeIsolated(database.userQB, {
+    tables: [],
+    checkpoint: createCheckpoint({ chainId: 1n, blockNumber: 10n }),
+    namespaceBuild: { schema: "public", viewsSchema: undefined },
+    onFinalize: async () => {
+      finalized.push("isolated");
+    },
+  });
+
+  expect(finalized).toStrictEqual(["multichain", "omnichain", "isolated"]);
 });
 
 async function getUserIndexNames(

--- a/packages/core/src/database/actions.ts
+++ b/packages/core/src/database/actions.ts
@@ -588,10 +588,12 @@ export const finalizeOmnichain = async (
     checkpoint,
     tables,
     namespaceBuild,
+    onFinalize,
   }: {
     checkpoint: string;
     tables: Table[];
     namespaceBuild: NamespaceBuild;
+    onFinalize?: (tx: QB) => Promise<void>;
   },
   context?: { logger?: Logger },
 ) => {
@@ -599,11 +601,18 @@ export const finalizeOmnichain = async (
 
   // TODO(kyle) is this breaking an invariant?
   if (tables.length === 0) {
-    await qb.wrap(
-      (db) =>
-        db
-          .update(PONDER_CHECKPOINT)
-          .set({ finalizedCheckpoint: checkpoint, safeCheckpoint: checkpoint }),
+    await qb.transaction(
+      { label: "finalize" },
+      async (tx) => {
+        await tx.wrap((tx) =>
+          tx.update(PONDER_CHECKPOINT).set({
+            finalizedCheckpoint: checkpoint,
+            safeCheckpoint: checkpoint,
+          }),
+        );
+        await onFinalize?.(tx);
+      },
+      undefined,
       context,
     );
     return;
@@ -626,6 +635,8 @@ export const finalizeOmnichain = async (
             .where(lte(getReorgTable(table).checkpoint, checkpoint)),
         );
       }
+
+      await onFinalize?.(tx);
     },
     undefined,
     context,
@@ -638,10 +649,12 @@ export const finalizeMultichain = async (
     checkpoint,
     tables,
     namespaceBuild,
+    onFinalize,
   }: {
     checkpoint: string;
     tables: Table[];
     namespaceBuild: NamespaceBuild;
+    onFinalize?: (tx: QB) => Promise<void>;
   },
   context?: { logger?: Logger },
 ) => {
@@ -649,11 +662,18 @@ export const finalizeMultichain = async (
 
   // TODO(kyle) is this breaking an invariant?
   if (tables.length === 0) {
-    await qb.wrap(
-      (db) =>
-        db
-          .update(PONDER_CHECKPOINT)
-          .set({ finalizedCheckpoint: checkpoint, safeCheckpoint: checkpoint }),
+    await qb.transaction(
+      { label: "finalize" },
+      async (tx) => {
+        await tx.wrap((tx) =>
+          tx.update(PONDER_CHECKPOINT).set({
+            finalizedCheckpoint: checkpoint,
+            safeCheckpoint: checkpoint,
+          }),
+        );
+        await onFinalize?.(tx);
+      },
+      undefined,
       context,
     );
     return;
@@ -727,6 +747,8 @@ WHERE checkpoint > (
             .where(eq(PONDER_CHECKPOINT.chainId, chain_id as number)),
         );
       }
+
+      await onFinalize?.(tx);
     },
     undefined,
     context,
@@ -739,10 +761,12 @@ export const finalizeIsolated = async (
     checkpoint,
     tables,
     namespaceBuild,
+    onFinalize,
   }: {
     checkpoint: string;
     tables: Table[];
     namespaceBuild: NamespaceBuild;
+    onFinalize?: (tx: QB) => Promise<void>;
   },
   context?: { logger?: Logger },
 ) => {
@@ -750,12 +774,21 @@ export const finalizeIsolated = async (
   const chainId = Number(decodeCheckpoint(checkpoint).chainId);
 
   if (tables.length === 0) {
-    await qb.wrap(
-      (db) =>
-        db
-          .update(PONDER_CHECKPOINT)
-          .set({ finalizedCheckpoint: checkpoint, safeCheckpoint: checkpoint })
-          .where(eq(PONDER_CHECKPOINT.chainId, chainId)),
+    await qb.transaction(
+      { label: "finalize" },
+      async (tx) => {
+        await tx.wrap((tx) =>
+          tx
+            .update(PONDER_CHECKPOINT)
+            .set({
+              finalizedCheckpoint: checkpoint,
+              safeCheckpoint: checkpoint,
+            })
+            .where(eq(PONDER_CHECKPOINT.chainId, chainId)),
+        );
+        await onFinalize?.(tx);
+      },
+      undefined,
       context,
     );
     return;
@@ -780,6 +813,8 @@ export const finalizeIsolated = async (
           ),
       );
     }
+
+    await onFinalize?.(tx);
   });
 };
 

--- a/packages/core/src/database/actions.ts
+++ b/packages/core/src/database/actions.ts
@@ -659,6 +659,7 @@ export const finalizeMultichain = async (
   context?: { logger?: Logger },
 ) => {
   const PONDER_CHECKPOINT = getPonderCheckpointTable(namespaceBuild.schema);
+  const chainId = Number(decodeCheckpoint(checkpoint).chainId);
 
   // TODO(kyle) is this breaking an invariant?
   if (tables.length === 0) {
@@ -666,10 +667,13 @@ export const finalizeMultichain = async (
       { label: "finalize" },
       async (tx) => {
         await tx.wrap((tx) =>
-          tx.update(PONDER_CHECKPOINT).set({
-            finalizedCheckpoint: checkpoint,
-            safeCheckpoint: checkpoint,
-          }),
+          tx
+            .update(PONDER_CHECKPOINT)
+            .set({
+              finalizedCheckpoint: checkpoint,
+              safeCheckpoint: checkpoint,
+            })
+            .where(eq(PONDER_CHECKPOINT.chainId, chainId)),
         );
         await onFinalize?.(tx);
       },
@@ -688,12 +692,7 @@ export const finalizeMultichain = async (
         tx
           .update(PONDER_CHECKPOINT)
           .set({ finalizedCheckpoint: checkpoint })
-          .where(
-            eq(
-              PONDER_CHECKPOINT.chainId,
-              Number(decodeCheckpoint(checkpoint).chainId),
-            ),
-          ),
+          .where(eq(PONDER_CHECKPOINT.chainId, chainId)),
       );
 
       const minOperationId = await tx

--- a/packages/core/src/database/index.test.ts
+++ b/packages/core/src/database/index.test.ts
@@ -97,6 +97,7 @@ test("migrate() succeeds with empty schema", async () => {
   expect(tableNames).toContain("account");
   expect(tableNames).toContain("_reorg__account");
   expect(tableNames).toContain("_ponder_meta");
+  expect(tableNames).toContain("_ponder_sink_delivery");
 
   const metadata = await database.userQB.wrap((db) =>
     db.select().from(sql`_ponder_meta`),
@@ -163,6 +164,7 @@ test("migrate() with empty schema creates tables, views, and enums", async () =>
   expect(tableNames).toContain("_reorg__kyle");
   expect(tableNames).toContain("_ponder_meta");
   expect(tableNames).toContain("_ponder_checkpoint");
+  expect(tableNames).toContain("_ponder_sink_delivery");
 
   const viewNames = await getUserViewNames(database, "public");
   expect(viewNames).toContain("user_view");

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -96,6 +96,7 @@ export const PONDER_META_TABLE_NAME = "_ponder_meta";
  * @dev Used since version 0.11.
  */
 export const PONDER_CHECKPOINT_TABLE_NAME = "_ponder_checkpoint";
+export const PONDER_SINK_DELIVERY_TABLE_NAME = "_ponder_sink_delivery";
 /**
  * @dev Used from version 0.9 to 0.11.
  */
@@ -189,6 +190,26 @@ export const getPonderCheckpointTable = (schema?: string) => {
     safeCheckpoint: t.varchar({ length: 75 }).notNull(),
     latestCheckpoint: t.varchar({ length: 75 }).notNull(),
     finalizedCheckpoint: t.varchar({ length: 75 }).notNull(),
+  }));
+};
+
+export const getPonderSinkDeliveryTable = (schema?: string) => {
+  if (schema === undefined || schema === "public") {
+    return pgTable(PONDER_SINK_DELIVERY_TABLE_NAME, (t) => ({
+      id: t.text().primaryKey(),
+      sinkName: t.text().notNull(),
+      checkpoint: t.varchar({ length: 75 }).notNull(),
+      payload: t.text().notNull(),
+      createdAt: t.bigint({ mode: "number" }).notNull(),
+    }));
+  }
+
+  return pgSchema(schema).table(PONDER_SINK_DELIVERY_TABLE_NAME, (t) => ({
+    id: t.text().primaryKey(),
+    sinkName: t.text().notNull(),
+    checkpoint: t.varchar({ length: 75 }).notNull(),
+    payload: t.text().notNull(),
+    createdAt: t.bigint({ mode: "number" }).notNull(),
   }));
 };
 
@@ -630,6 +651,29 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
         await tx.wrap(
           (tx) =>
             tx.execute(
+              `
+CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_SINK_DELIVERY_TABLE_NAME}" (
+  "id" TEXT PRIMARY KEY,
+  "sink_name" TEXT NOT NULL,
+  "checkpoint" VARCHAR(75) NOT NULL,
+  "payload" TEXT NOT NULL,
+  "created_at" BIGINT NOT NULL
+)`,
+            ),
+          context,
+        );
+
+        await tx.wrap(
+          (tx) =>
+            tx.execute(
+              `CREATE INDEX IF NOT EXISTS "${PONDER_SINK_DELIVERY_TABLE_NAME}_pending_index" ON "${namespace.schema}"."${PONDER_SINK_DELIVERY_TABLE_NAME}" ("sink_name", "checkpoint")`,
+            ),
+          context,
+        );
+
+        await tx.wrap(
+          (tx) =>
+            tx.execute(
               `CREATE SEQUENCE IF NOT EXISTS "${namespace.schema}"."${getReorgSequenceName()}" AS integer INCREMENT BY 1`,
             ),
           context,
@@ -658,7 +702,7 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
           common.logger.debug({
             msg: "Created internal database objects",
             schema: namespace.schema,
-            table_count: 2,
+            table_count: 3,
             trigger_count: 2,
             duration: endClock(),
           });
@@ -804,6 +848,14 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
               (tx) =>
                 tx.execute(
                   `DROP TABLE IF EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME}" CASCADE`,
+                ),
+              context,
+            );
+
+            await tx.wrap(
+              (tx) =>
+                tx.execute(
+                  `DROP TABLE IF EXISTS "${namespace.schema}"."${PONDER_SINK_DELIVERY_TABLE_NAME}" CASCADE`,
                 ),
               context,
             );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,11 @@ export type DatabaseConfig = Prettify<Config["database"]>;
 export type { CreateConfigReturnType } from "@/config/index.js";
 export type { GetEventFilter } from "@/config/eventFilter.js";
 export type { AddressConfig, Factory } from "@/config/address.js";
+export type {
+  FinalizedSinkBatch,
+  FinalizedSinkEvent,
+  IndexingSink,
+} from "@/internal/types.js";
 
 export {
   onchainTable,

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -338,6 +338,8 @@ export type SchemaBuild = {
 export type IndexingBuild = {
   /** Ten character hex string identifier. */
   buildId: string;
+  /** Analytics sinks configured by the user. */
+  sinks: readonly IndexingSink[];
   /** Chains to index. */
   chains: Chain[];
   /** RPCs for all `chains`. */
@@ -354,6 +356,49 @@ export type IndexingBuild = {
   contracts: {
     [name: string]: Contract;
   }[];
+};
+
+/** A finalized event delivered to an {@link IndexingSink}. */
+export type FinalizedSinkEvent = {
+  /** Stable Ponder event identifier. */
+  id: string;
+  /** Ponder checkpoint for this event. */
+  checkpoint: string;
+  /** Chain metadata without RPC client state. */
+  chain: { id: number; name: string };
+  /** Registered indexing callback name. */
+  name: string;
+  /** Event category. */
+  type: Event["type"];
+  /** Decoded event payload. */
+  event: Event["event"];
+};
+
+/** A durable, finalized delivery unit for an {@link IndexingSink}. */
+export type FinalizedSinkBatch = {
+  /** Serialized payload format version. */
+  version: 1;
+  /** Stable identifier reused across delivery retries. */
+  id: string;
+  /** Highest checkpoint contained in `events`. */
+  checkpoint: string;
+  events: FinalizedSinkEvent[];
+};
+
+/**
+ * Optional analytics projection for finalized Ponder events.
+ *
+ * Sink writes are at least once. Implementations must tolerate a batch being
+ * delivered again after a successful write but failed acknowledgement. Sinks
+ * require a Postgres database because PGlite lacks durable transaction
+ * boundaries.
+ */
+export type IndexingSink = {
+  name: string;
+  setup?: () => Promise<void>;
+  writeFinalizedBatch: (batch: FinalizedSinkBatch) => Promise<void>;
+  flush?: () => Promise<void>;
+  shutdown?: () => Promise<void>;
 };
 
 export type ApiBuild = {

--- a/packages/core/src/runtime/isolated.ts
+++ b/packages/core/src/runtime/isolated.ts
@@ -33,6 +33,7 @@ import type {
   Seconds,
 } from "@/internal/types.js";
 import { splitEvents } from "@/runtime/events.js";
+import { createSinkService } from "@/sink/index.js";
 import type { RealtimeSyncEvent } from "@/sync-realtime/index.js";
 import { createSyncStore } from "@/sync-store/index.js";
 import {
@@ -85,6 +86,14 @@ export async function runIsolated({
   const syncStore = createSyncStore({ common, qb: database.syncQB });
 
   const PONDER_CHECKPOINT = getPonderCheckpointTable(namespaceBuild.schema);
+  const sinks = createSinkService({
+    common,
+    database,
+    namespace: namespaceBuild,
+    sinks: indexingBuild.sinks,
+  });
+
+  await sinks.start();
 
   const eventCount = getEventCount(indexingBuild.indexingFunctions);
 
@@ -390,6 +399,8 @@ export async function runIsolated({
             context,
           );
 
+          await sinks.enqueue(tx, events);
+
           common.metrics.ponder_historical_transform_duration.inc(
             { step: "finalize" },
             endClock(),
@@ -441,6 +452,8 @@ export async function runIsolated({
       undefined,
       context,
     );
+
+    await sinks.drain();
 
     cachedViemClient.clear();
     common.metrics.ponder_historical_transform_duration.inc(
@@ -750,9 +763,12 @@ export async function runIsolated({
             checkpoint: event.checkpoint,
             tables,
             namespaceBuild,
+            onFinalize: (tx) => sinks.enqueue(tx, event.events),
           },
           context,
         );
+
+        await sinks.drain();
 
         common.logger.info({
           msg: "Finalized block",

--- a/packages/core/src/runtime/multichain.ts
+++ b/packages/core/src/runtime/multichain.ts
@@ -41,6 +41,7 @@ import type {
   Seconds,
 } from "@/internal/types.js";
 import { splitEvents } from "@/runtime/events.js";
+import { createSinkService } from "@/sink/index.js";
 import type { RealtimeSyncEvent } from "@/sync-realtime/index.js";
 import { createSyncStore } from "@/sync-store/index.js";
 import {
@@ -94,6 +95,14 @@ export async function runMultichain({
 
   const PONDER_CHECKPOINT = getPonderCheckpointTable(namespaceBuild.schema);
   const PONDER_META = getPonderMetaTable(namespaceBuild.schema);
+  const sinks = createSinkService({
+    common,
+    database,
+    namespace: namespaceBuild,
+    sinks: indexingBuild.sinks,
+  });
+
+  await sinks.start();
 
   const eventCount = getEventCount(indexingBuild.indexingFunctions);
 
@@ -445,6 +454,8 @@ export async function runMultichain({
             context,
           );
 
+          await sinks.enqueue(tx, events);
+
           common.metrics.ponder_historical_transform_duration.inc(
             { step: "finalize" },
             endClock(),
@@ -493,6 +504,8 @@ export async function runMultichain({
       undefined,
       context,
     );
+
+    await sinks.drain();
 
     cachedViemClient.clear();
     common.metrics.ponder_historical_transform_duration.inc(
@@ -834,9 +847,12 @@ export async function runMultichain({
             checkpoint: event.checkpoint,
             tables,
             namespaceBuild,
+            onFinalize: (tx) => sinks.enqueue(tx, event.events),
           },
           context,
         );
+
+        await sinks.drain();
 
         common.logger.info({
           msg: "Finalized block",

--- a/packages/core/src/runtime/omnichain.ts
+++ b/packages/core/src/runtime/omnichain.ts
@@ -42,6 +42,7 @@ import type {
   Seconds,
 } from "@/internal/types.js";
 import { splitEvents } from "@/runtime/events.js";
+import { createSinkService } from "@/sink/index.js";
 import type { RealtimeSyncEvent } from "@/sync-realtime/index.js";
 import { createSyncStore } from "@/sync-store/index.js";
 import {
@@ -97,6 +98,14 @@ export async function runOmnichain({
 
   const PONDER_CHECKPOINT = getPonderCheckpointTable(namespaceBuild.schema);
   const PONDER_META = getPonderMetaTable(namespaceBuild.schema);
+  const sinks = createSinkService({
+    common,
+    database,
+    namespace: namespaceBuild,
+    sinks: indexingBuild.sinks,
+  });
+
+  await sinks.start();
 
   const eventCount = getEventCount(indexingBuild.indexingFunctions);
 
@@ -464,6 +473,8 @@ export async function runOmnichain({
               }),
           );
 
+          await sinks.enqueue(tx, events);
+
           common.metrics.ponder_historical_transform_duration.inc(
             { step: "finalize" },
             endClock(),
@@ -506,6 +517,8 @@ export async function runOmnichain({
       undefined,
       context,
     );
+
+    await sinks.drain();
 
     cachedViemClient.clear();
     common.metrics.ponder_historical_transform_duration.inc(
@@ -846,9 +859,12 @@ export async function runOmnichain({
             checkpoint: event.checkpoint,
             tables,
             namespaceBuild,
+            onFinalize: (tx) => sinks.enqueue(tx, event.events),
           },
           context,
         );
+
+        await sinks.drain();
 
         common.logger.info({
           msg: "Finalized block",

--- a/packages/core/src/runtime/realtime.test.ts
+++ b/packages/core/src/runtime/realtime.test.ts
@@ -1,0 +1,50 @@
+import { ZERO_CHECKPOINT, encodeCheckpoint } from "@/utils/checkpoint.js";
+import { expect, test } from "vitest";
+import { getFinalizedEventsMultichain } from "./realtime.js";
+
+const createCheckpoint = ({
+  chainId,
+  blockNumber,
+  blockTimestamp,
+}: {
+  chainId: bigint;
+  blockNumber: bigint;
+  blockTimestamp: bigint;
+}) =>
+  encodeCheckpoint({
+    ...ZERO_CHECKPOINT,
+    chainId,
+    blockNumber,
+    blockTimestamp,
+  });
+
+test("getFinalizedEventsMultichain() does not wait for another chain", () => {
+  const chainA = { id: 1 };
+  const chainB = { id: 2 };
+  const eventA = {
+    id: "a",
+    chain: chainA,
+    checkpoint: createCheckpoint({
+      chainId: 1n,
+      blockNumber: 1n,
+      blockTimestamp: 1n,
+    }),
+  };
+  const eventB = {
+    id: "b",
+    chain: chainB,
+    checkpoint: createCheckpoint({
+      chainId: 2n,
+      blockNumber: 1n,
+      blockTimestamp: 2n,
+    }),
+  };
+
+  const result = getFinalizedEventsMultichain([eventA, eventB], {
+    chain: chainB,
+    checkpoint: eventB.checkpoint,
+  });
+
+  expect(result.finalizedEvents).toStrictEqual([eventB]);
+  expect(result.remainingEvents).toStrictEqual([eventA]);
+});

--- a/packages/core/src/runtime/realtime.ts
+++ b/packages/core/src/runtime/realtime.ts
@@ -56,6 +56,26 @@ export type RealtimeEvent =
   | { type: "reorg"; chain: Chain; checkpoint: string }
   | { type: "finalize"; events: Event[]; chain: Chain; checkpoint: string };
 
+export const getFinalizedEventsMultichain = <
+  T extends { chain: Pick<Chain, "id">; checkpoint: string },
+>(
+  events: T[],
+  { chain, checkpoint }: { chain: Pick<Chain, "id">; checkpoint: string },
+) => {
+  const finalizedEvents: T[] = [];
+  const remainingEvents: T[] = [];
+
+  for (const event of events) {
+    if (event.chain.id === chain.id && event.checkpoint <= checkpoint) {
+      finalizedEvents.push(event);
+    } else {
+      remainingEvents.push(event);
+    }
+  }
+
+  return { finalizedEvents, remainingEvents };
+};
+
 export async function* getRealtimeEventsOmnichain(params: {
   common: Common;
   indexingBuild: Pick<
@@ -515,32 +535,10 @@ export async function* getRealtimeEventsMultichain(params: {
       case "finalize": {
         const checkpoint = syncProgress.getCheckpoint({ tag: "finalized" });
 
-        // index of the first unfinalized event
-        let finalizeIndex: number | undefined = undefined;
-
-        for (const [index, event] of executedEvents.entries()) {
-          const _chain = params.indexingBuild.chains.find(
-            (c) => c.id === event.chain.id,
-          )!;
-          const _checkpoint = params.perChainSync
-            .get(_chain)!
-            .syncProgress.getCheckpoint({ tag: "finalized" });
-
-          if (event.checkpoint > _checkpoint) {
-            finalizeIndex = index;
-            break;
-          }
-        }
-
-        let finalizedEvents: Event[];
-
-        if (finalizeIndex === undefined) {
-          finalizedEvents = executedEvents;
-          executedEvents = [];
-        } else {
-          finalizedEvents = executedEvents.slice(0, finalizeIndex);
-          executedEvents = executedEvents.slice(finalizeIndex);
-        }
+        // A multichain finalization transaction advances one chain checkpoint.
+        const { finalizedEvents, remainingEvents } =
+          getFinalizedEventsMultichain(executedEvents, { chain, checkpoint });
+        executedEvents = remainingEvents;
 
         params.common.logger.trace({
           msg: "Removed finalized events",

--- a/packages/core/src/runtime/realtime.ts
+++ b/packages/core/src/runtime/realtime.ts
@@ -54,7 +54,7 @@ export type RealtimeEvent =
       blockCallback?: (isAccepted: boolean) => void;
     }
   | { type: "reorg"; chain: Chain; checkpoint: string }
-  | { type: "finalize"; chain: Chain; checkpoint: string };
+  | { type: "finalize"; events: Event[]; chain: Chain; checkpoint: string };
 
 export async function* getRealtimeEventsOmnichain(params: {
   common: Common;
@@ -278,7 +278,12 @@ export async function* getRealtimeEventsOmnichain(params: {
           event_count: finalizedEvents.length,
         });
 
-        yield { type: "finalize", chain, checkpoint: to };
+        yield {
+          type: "finalize",
+          events: finalizedEvents,
+          chain,
+          checkpoint: to,
+        };
         break;
       }
       case "reorg": {
@@ -542,7 +547,7 @@ export async function* getRealtimeEventsMultichain(params: {
           event_count: finalizedEvents.length,
         });
 
-        yield { type: "finalize", chain, checkpoint };
+        yield { type: "finalize", events: finalizedEvents, chain, checkpoint };
         break;
       }
       case "reorg": {
@@ -662,6 +667,9 @@ export async function* getRealtimeEventsIsolated(params: {
     bufferCallback,
   );
 
+  /** Events that have been executed but not finalized. */
+  let executedEvents: Event[] = [];
+
   for await (const { chain, event } of eventGenerator) {
     await handleRealtimeSyncEvent(event, {
       common: params.common,
@@ -727,6 +735,8 @@ export async function* getRealtimeEventsIsolated(params: {
           tag: "current",
         });
 
+        executedEvents = executedEvents.concat(events);
+
         yield {
           type: "block",
           events,
@@ -741,13 +751,24 @@ export async function* getRealtimeEventsIsolated(params: {
           tag: "finalized",
         });
 
-        yield { type: "finalize", chain, checkpoint };
+        const finalizedEvents = executedEvents.filter(
+          (event) => event.checkpoint <= checkpoint,
+        );
+        executedEvents = executedEvents.filter(
+          (event) => event.checkpoint > checkpoint,
+        );
+
+        yield { type: "finalize", events: finalizedEvents, chain, checkpoint };
         break;
       }
       case "reorg": {
         const checkpoint = params.syncProgress.getCheckpoint({
           tag: "current",
         });
+
+        executedEvents = executedEvents.filter(
+          (event) => event.checkpoint <= checkpoint,
+        );
 
         yield { type: "reorg", chain, checkpoint };
         break;

--- a/packages/core/src/sink/index.test.ts
+++ b/packages/core/src/sink/index.test.ts
@@ -6,14 +6,23 @@ import {
   setupIsolatedDatabase,
 } from "@/_test/setup.js";
 import { getChain } from "@/_test/utils.js";
-import { type Database, getPonderSinkDeliveryTable } from "@/database/index.js";
+import { finalizeMultichain } from "@/database/actions.js";
+import {
+  type Database,
+  getPonderCheckpointTable,
+  getPonderSinkDeliveryTable,
+} from "@/database/index.js";
+import { onchainTable } from "@/drizzle/onchain.js";
 import { NonRetryableUserError } from "@/internal/errors.js";
 import type {
+  Chain,
   Event,
   FinalizedSinkBatch,
   IndexingSink,
 } from "@/internal/types.js";
+import { getFinalizedEventsMultichain } from "@/runtime/realtime.js";
 import { ZERO_CHECKPOINT, encodeCheckpoint } from "@/utils/checkpoint.js";
+import { eq } from "drizzle-orm";
 import { beforeEach, expect, test, vi } from "vitest";
 import { createSinkService } from "./index.js";
 
@@ -23,16 +32,34 @@ beforeEach(setupCleanup);
 
 const namespace = { schema: "public", viewsSchema: undefined };
 
-const createEvent = (id = "event-1"): Event => {
-  const chain = getChain();
+const createCheckpoint = ({
+  chainId,
+  blockNumber = 0n,
+  blockTimestamp = 0n,
+}: {
+  chainId: number;
+  blockNumber?: bigint;
+  blockTimestamp?: bigint;
+}) =>
+  encodeCheckpoint({
+    ...ZERO_CHECKPOINT,
+    chainId: BigInt(chainId),
+    blockNumber,
+    blockTimestamp,
+  });
 
+const createEvent = ({
+  id = "event-1",
+  chain = getChain(),
+  checkpoint = createCheckpoint({ chainId: chain.id, blockNumber: 1n }),
+}: {
+  id?: string;
+  chain?: Chain;
+  checkpoint?: string;
+} = {}): Event => {
   return {
     type: "block",
-    checkpoint: encodeCheckpoint({
-      ...ZERO_CHECKPOINT,
-      chainId: 1n,
-      blockNumber: 1n,
-    }),
+    checkpoint,
     chain,
     eventCallback: {
       filter: {
@@ -63,6 +90,120 @@ const getPendingDeliveries = (database: Database) => {
 
   return database.userQB.wrap((db) => db.select().from(PONDER_SINK_DELIVERY));
 };
+
+test("replays a multichain delivery after finalizing its chain", async () => {
+  if (context.databaseConfig.kind !== "postgres") return;
+
+  const account = onchainTable("account", (p) => ({
+    id: p.text().primaryKey(),
+  }));
+  const { database } = await setupDatabaseServices({
+    namespaceBuild: namespace,
+    schemaBuild: { schema: { account } },
+  });
+  const chainA = getChain();
+  const chainB = { ...getChain(), id: 2, name: "optimism" };
+  const checkpointA = createCheckpoint({
+    chainId: chainA.id,
+    blockNumber: 1n,
+    blockTimestamp: 1n,
+  });
+  const checkpointB = createCheckpoint({
+    chainId: chainB.id,
+    blockNumber: 1n,
+    blockTimestamp: 2n,
+  });
+  const initialCheckpointA = createCheckpoint({ chainId: chainA.id });
+  const initialCheckpointB = createCheckpoint({ chainId: chainB.id });
+  const PONDER_CHECKPOINT = getPonderCheckpointTable(namespace.schema);
+
+  await database.userQB.wrap((tx) =>
+    tx.insert(PONDER_CHECKPOINT).values([
+      {
+        chainName: chainA.name,
+        chainId: chainA.id,
+        latestCheckpoint: checkpointA,
+        safeCheckpoint: initialCheckpointA,
+        finalizedCheckpoint: initialCheckpointA,
+      },
+      {
+        chainName: chainB.name,
+        chainId: chainB.id,
+        latestCheckpoint: checkpointB,
+        safeCheckpoint: initialCheckpointB,
+        finalizedCheckpoint: initialCheckpointB,
+      },
+    ]),
+  );
+
+  const eventA = createEvent({
+    id: "event-a",
+    chain: chainA,
+    checkpoint: checkpointA,
+  });
+  const eventB = createEvent({
+    id: "event-b",
+    chain: chainB,
+    checkpoint: checkpointB,
+  });
+  const { finalizedEvents } = getFinalizedEventsMultichain([eventA, eventB], {
+    chain: chainB,
+    checkpoint: checkpointB,
+  });
+  const service = createSinkService({
+    common: context.common,
+    database,
+    namespace,
+    sinks: [{ name: "test", writeFinalizedBatch: async () => {} }],
+  });
+
+  await finalizeMultichain(database.userQB, {
+    checkpoint: checkpointB,
+    tables: [account],
+    namespaceBuild: namespace,
+    onFinalize: (tx) => service.enqueue(tx, finalizedEvents),
+  });
+
+  const checkpointARow = await database.userQB.wrap((tx) =>
+    tx
+      .select()
+      .from(PONDER_CHECKPOINT)
+      .where(eq(PONDER_CHECKPOINT.chainId, chainA.id))
+      .then((rows) => rows[0]),
+  );
+  const checkpointBRow = await database.userQB.wrap((tx) =>
+    tx
+      .select()
+      .from(PONDER_CHECKPOINT)
+      .where(eq(PONDER_CHECKPOINT.chainId, chainB.id))
+      .then((rows) => rows[0]),
+  );
+
+  expect(checkpointARow!.finalizedCheckpoint).toBe(initialCheckpointA);
+  expect(checkpointBRow!.finalizedCheckpoint).toBe(checkpointB);
+  expect(await getPendingDeliveries(database)).toHaveLength(1);
+
+  const delivered: FinalizedSinkBatch[] = [];
+  const restartedService = createSinkService({
+    common: context.common,
+    database,
+    namespace,
+    sinks: [
+      {
+        name: "test",
+        writeFinalizedBatch: async (batch) => {
+          delivered.push(batch);
+        },
+      },
+    ],
+  });
+
+  await restartedService.drain();
+
+  expect(delivered).toHaveLength(1);
+  expect(delivered[0]!.events).toMatchObject([{ id: "event-b" }]);
+  expect(await getPendingDeliveries(database)).toHaveLength(0);
+});
 
 test("drains a persisted finalized batch", async () => {
   const { database } = await setupDatabaseServices({

--- a/packages/core/src/sink/index.test.ts
+++ b/packages/core/src/sink/index.test.ts
@@ -12,7 +12,6 @@ import {
   getPonderCheckpointTable,
   getPonderSinkDeliveryTable,
 } from "@/database/index.js";
-import { onchainTable } from "@/drizzle/onchain.js";
 import { NonRetryableUserError } from "@/internal/errors.js";
 import type {
   Chain,
@@ -94,12 +93,8 @@ const getPendingDeliveries = (database: Database) => {
 test("replays a multichain delivery after finalizing its chain", async () => {
   if (context.databaseConfig.kind !== "postgres") return;
 
-  const account = onchainTable("account", (p) => ({
-    id: p.text().primaryKey(),
-  }));
   const { database } = await setupDatabaseServices({
     namespaceBuild: namespace,
-    schemaBuild: { schema: { account } },
   });
   const chainA = getChain();
   const chainB = { ...getChain(), id: 2, name: "optimism" };
@@ -159,7 +154,7 @@ test("replays a multichain delivery after finalizing its chain", async () => {
 
   await finalizeMultichain(database.userQB, {
     checkpoint: checkpointB,
-    tables: [account],
+    tables: [],
     namespaceBuild: namespace,
     onFinalize: (tx) => service.enqueue(tx, finalizedEvents),
   });

--- a/packages/core/src/sink/index.test.ts
+++ b/packages/core/src/sink/index.test.ts
@@ -1,0 +1,218 @@
+import {
+  context,
+  setupCleanup,
+  setupCommon,
+  setupDatabaseServices,
+  setupIsolatedDatabase,
+} from "@/_test/setup.js";
+import { getChain } from "@/_test/utils.js";
+import { type Database, getPonderSinkDeliveryTable } from "@/database/index.js";
+import { NonRetryableUserError } from "@/internal/errors.js";
+import type {
+  Event,
+  FinalizedSinkBatch,
+  IndexingSink,
+} from "@/internal/types.js";
+import { ZERO_CHECKPOINT, encodeCheckpoint } from "@/utils/checkpoint.js";
+import { beforeEach, expect, test, vi } from "vitest";
+import { createSinkService } from "./index.js";
+
+beforeEach(setupCommon);
+beforeEach(setupIsolatedDatabase);
+beforeEach(setupCleanup);
+
+const namespace = { schema: "public", viewsSchema: undefined };
+
+const createEvent = (id = "event-1"): Event => {
+  const chain = getChain();
+
+  return {
+    type: "block",
+    checkpoint: encodeCheckpoint({
+      ...ZERO_CHECKPOINT,
+      chainId: 1n,
+      blockNumber: 1n,
+    }),
+    chain,
+    eventCallback: {
+      filter: {
+        type: "block",
+        chainId: chain.id,
+        sourceId: "Block",
+        interval: 1,
+        offset: 0,
+        fromBlock: undefined,
+        toBlock: undefined,
+        hasTransactionReceipt: false,
+        include: [],
+      },
+      name: "Block",
+      fn: () => {},
+      chain,
+      type: "block",
+    },
+    event: {
+      id,
+      block: { hash: "0x", number: 1n, timestamp: 1n },
+    },
+  };
+};
+
+const getPendingDeliveries = (database: Database) => {
+  const PONDER_SINK_DELIVERY = getPonderSinkDeliveryTable(namespace.schema);
+
+  return database.userQB.wrap((db) => db.select().from(PONDER_SINK_DELIVERY));
+};
+
+test("drains a persisted finalized batch", async () => {
+  const { database } = await setupDatabaseServices({
+    namespaceBuild: namespace,
+  });
+  const writeFinalizedBatch = vi.fn(async (_batch: FinalizedSinkBatch) => {});
+  const sink = {
+    name: "test",
+    writeFinalizedBatch,
+  } satisfies IndexingSink;
+  const service = createSinkService({
+    common: context.common,
+    database,
+    namespace,
+    sinks: [sink],
+  });
+
+  await database.userQB.transaction((tx) =>
+    service.enqueue(tx, [createEvent()]),
+  );
+
+  expect(writeFinalizedBatch).not.toHaveBeenCalled();
+  expect(await getPendingDeliveries(database)).toHaveLength(1);
+
+  await service.drain();
+
+  expect(writeFinalizedBatch).toHaveBeenCalledTimes(1);
+  expect(writeFinalizedBatch.mock.calls[0]![0]).toMatchObject({
+    version: 1,
+    events: [{ id: "event-1", name: "Block", type: "block" }],
+  });
+  expect(
+    writeFinalizedBatch.mock.calls[0]![0].events[0]!.event.block.number,
+  ).toBe(1n);
+  expect(await getPendingDeliveries(database)).toHaveLength(0);
+});
+
+test("replays an unacknowledged delivery", async () => {
+  const { database } = await setupDatabaseServices({
+    namespaceBuild: namespace,
+  });
+  const writeFinalizedBatch = vi
+    .fn(async (_batch: FinalizedSinkBatch) => {})
+    .mockRejectedValueOnce(new Error("unavailable"));
+  const service = createSinkService({
+    common: context.common,
+    database,
+    namespace,
+    sinks: [{ name: "test", writeFinalizedBatch } satisfies IndexingSink],
+  });
+
+  await database.userQB.transaction((tx) =>
+    service.enqueue(tx, [createEvent()]),
+  );
+
+  await expect(service.drain()).rejects.toThrow("unavailable");
+  expect(await getPendingDeliveries(database)).toHaveLength(1);
+
+  const replayedBatches: FinalizedSinkBatch[] = [];
+  const restartedService = createSinkService({
+    common: context.common,
+    database,
+    namespace,
+    sinks: [
+      {
+        name: "test",
+        writeFinalizedBatch: async (batch) => {
+          replayedBatches.push(batch);
+        },
+      },
+    ],
+  });
+
+  await restartedService.drain();
+
+  expect(writeFinalizedBatch).toHaveBeenCalledTimes(1);
+  expect(replayedBatches).toHaveLength(1);
+  expect(replayedBatches[0]!.id).toBe(writeFinalizedBatch.mock.calls[0]![0].id);
+  expect(await getPendingDeliveries(database)).toHaveLength(0);
+});
+
+test("rejects sinks with PGlite", async () => {
+  if (context.databaseConfig.kind === "postgres") return;
+
+  const { database } = await setupDatabaseServices({
+    namespaceBuild: namespace,
+  });
+  const setup = vi.fn(async () => {});
+  const service = createSinkService({
+    common: context.common,
+    database,
+    namespace,
+    sinks: [{ name: "test", setup, writeFinalizedBatch: async () => {} }],
+  });
+
+  await expect(service.start()).rejects.toThrow("require a Postgres database");
+  expect(setup).not.toHaveBeenCalled();
+});
+
+test("does not persist a rolled back delivery", async () => {
+  if (context.databaseConfig.kind !== "postgres") return;
+
+  const { database } = await setupDatabaseServices({
+    namespaceBuild: namespace,
+  });
+  const service = createSinkService({
+    common: context.common,
+    database,
+    namespace,
+    sinks: [{ name: "test", writeFinalizedBatch: async () => {} }],
+  });
+
+  await expect(
+    database.userQB.transaction(async (tx) => {
+      await service.enqueue(tx, [createEvent()]);
+      throw new NonRetryableUserError("rollback");
+    }),
+  ).rejects.toThrow("rollback");
+
+  expect(await getPendingDeliveries(database)).toHaveLength(0);
+});
+
+test("runs the sink lifecycle", async () => {
+  const setup = vi.fn(async () => {});
+  const flush = vi.fn(async () => {});
+  const shutdown = vi.fn(async () => {});
+  const service = createSinkService({
+    common: context.common,
+    database: {
+      userQB: {
+        $dialect: "postgres",
+        wrap: async () => [],
+      },
+    } as unknown as Database,
+    namespace,
+    sinks: [
+      {
+        name: "test",
+        setup,
+        writeFinalizedBatch: async () => {},
+        flush,
+        shutdown,
+      },
+    ],
+  });
+
+  await service.start();
+  await context.common.shutdown.kill();
+
+  expect(setup).toHaveBeenCalledTimes(1);
+  expect(flush).toHaveBeenCalledTimes(1);
+  expect(shutdown).toHaveBeenCalledTimes(1);
+});

--- a/packages/core/src/sink/index.ts
+++ b/packages/core/src/sink/index.ts
@@ -1,0 +1,165 @@
+import { createHash } from "node:crypto";
+import { type Database, getPonderSinkDeliveryTable } from "@/database/index.js";
+import type { QB } from "@/database/queryBuilder.js";
+import type { Common } from "@/internal/common.js";
+import { NonRetryableUserError } from "@/internal/errors.js";
+import type {
+  Event,
+  FinalizedSinkBatch,
+  FinalizedSinkEvent,
+  IndexingSink,
+  NamespaceBuild,
+} from "@/internal/types.js";
+import { asc, eq } from "drizzle-orm";
+import superjson from "superjson";
+
+export type SinkService = {
+  start: () => Promise<void>;
+  enqueue: (tx: QB, events: Event[]) => Promise<void>;
+  drain: () => Promise<void>;
+};
+
+const createFinalizedSinkBatch = (events: Event[]): FinalizedSinkBatch => {
+  const sortedEvents = events
+    .slice()
+    .sort((a, b) => (a.checkpoint < b.checkpoint ? -1 : 1));
+
+  const sinkEvents = sortedEvents.map(
+    (event): FinalizedSinkEvent => ({
+      id: event.event.id,
+      checkpoint: event.checkpoint,
+      chain: { id: event.chain.id, name: event.chain.name },
+      name: event.eventCallback.name,
+      type: event.type,
+      event: event.event,
+    }),
+  );
+
+  const checkpoint = sinkEvents[sinkEvents.length - 1]!.checkpoint;
+  const id = createHash("sha256")
+    .update(
+      sinkEvents
+        .map((event) => `${event.checkpoint}:${event.name}:${event.id}`)
+        .join("\n"),
+    )
+    .digest("hex");
+
+  return { version: 1, id, checkpoint, events: sinkEvents };
+};
+
+const getDeliveryId = ({
+  sinkName,
+  batchId,
+}: {
+  sinkName: string;
+  batchId: string;
+}): string => {
+  return createHash("sha256").update(`${sinkName}:${batchId}`).digest("hex");
+};
+
+export const createSinkService = ({
+  common,
+  database,
+  namespace,
+  sinks,
+}: {
+  common: Common;
+  database: Database;
+  namespace: NamespaceBuild;
+  sinks: readonly IndexingSink[];
+}): SinkService => {
+  const PONDER_SINK_DELIVERY = getPonderSinkDeliveryTable(namespace.schema);
+
+  const drain = async (): Promise<void> => {
+    for (const sink of sinks) {
+      const deliveries = await database.userQB.wrap(
+        { label: "get_sink_delivery" },
+        (db) =>
+          db
+            .select()
+            .from(PONDER_SINK_DELIVERY)
+            .where(eq(PONDER_SINK_DELIVERY.sinkName, sink.name))
+            .orderBy(
+              asc(PONDER_SINK_DELIVERY.checkpoint),
+              asc(PONDER_SINK_DELIVERY.id),
+            ),
+      );
+
+      for (const delivery of deliveries) {
+        const batch = superjson.parse<FinalizedSinkBatch>(delivery.payload);
+
+        try {
+          await sink.writeFinalizedBatch(batch);
+        } catch (error) {
+          common.logger.error({
+            msg: "Failed finalized sink delivery",
+            sink: sink.name,
+            checkpoint: batch.checkpoint,
+            batch_id: batch.id,
+            error: error as Error,
+          });
+          throw error;
+        }
+
+        await database.userQB.wrap({ label: "delete_sink_delivery" }, (db) =>
+          db
+            .delete(PONDER_SINK_DELIVERY)
+            .where(eq(PONDER_SINK_DELIVERY.id, delivery.id)),
+        );
+
+        common.logger.debug({
+          msg: "Delivered finalized sink batch",
+          sink: sink.name,
+          checkpoint: batch.checkpoint,
+          batch_id: batch.id,
+          event_count: batch.events.length,
+        });
+      }
+    }
+  };
+
+  return {
+    async start(): Promise<void> {
+      if (sinks.length > 0 && database.userQB.$dialect === "pglite") {
+        throw new NonRetryableUserError(
+          "Finalized sinks require a Postgres database because PGlite does not provide durable transaction boundaries.",
+        );
+      }
+
+      for (const sink of sinks) {
+        await sink.setup?.();
+      }
+
+      common.shutdown.add(async () => {
+        await Promise.all(
+          sinks.map(async (sink) => {
+            await sink.flush?.();
+            await sink.shutdown?.();
+          }),
+        );
+      });
+
+      await drain();
+    },
+    async enqueue(tx: QB, events: Event[]): Promise<void> {
+      if (sinks.length === 0 || events.length === 0) return;
+
+      const batch = createFinalizedSinkBatch(events);
+      await tx.wrap({ label: "enqueue_sink_delivery" }, (db) =>
+        db
+          .insert(PONDER_SINK_DELIVERY)
+          .values(
+            sinks.map((sink) => ({
+              id: getDeliveryId({ sinkName: sink.name, batchId: batch.id }),
+              sinkName: sink.name,
+              checkpoint: batch.checkpoint,
+              payload: superjson.stringify(batch),
+              createdAt: Date.now(),
+            })),
+          )
+          .onConflictDoNothing(),
+      );
+    },
+    drain,
+  };
+};


### PR DESCRIPTION
Stack: Part 1/6. See the stack [discussion](https://github.com/ponder-sh/ponder/discussions/2307). Base of the ladder.

**What**

Add a generic, finalized-only analytics sink contract and a durable Postgres outbox.

**How**

- Add optional sink configuration with source-compatible defaults.
- Persist each finalized batch in the same transaction as canonical data and checkpoint advancement.
- Drain after commit, acknowledge only after sink success, and reject PGlite.
- Cover historical delivery, realtime finalization, restart replay, failures, and all runtime ordering modes.

**Notes**

- No ClickHouse dependency or SQL enters core.
- Existing projects remain behaviorally and source compatible.
- This is the foundational review: it must land before any vendor package.