### PR TITLE
fix(sync-historical): fetch child events when child filter appears cached during same-batch factory creation

### DIFF
--- a/packages/core/src/runtime/historical.ts
+++ b/packages/core/src/runtime/historical.ts
@@ -1221,7 +1221,10 @@ export async function* getLocalSyncGenerator(params: {
     });
   }
 
-  const historicalSync = createHistoricalSync(params);
+  const historicalSync = createHistoricalSync({
+    ...params,
+    filters: params.eventCallbacks.map(({ filter }) => filter),
+  });
 
   const { callback: intervalCallback, generator: intervalGenerator } =
     createCallbackGenerator<{

--- a/packages/core/src/sync-historical/index.test.ts
+++ b/packages/core/src/sync-historical/index.test.ts
@@ -1142,3 +1142,86 @@ test("syncAddress() handles many addresses", async () => {
   expect(dbLogs).toHaveLength(1);
   expect(factories).toHaveLength(11);
 });
+
+test("sync() with log factory fetches child events even when child filter appears cached", async () => {
+  // Regression test for the "same-batch factory child address miss" bug.
+  //
+  // Scenario: a factory creates a child contract AND the child emits an event
+  // in the same ethGetLogsBlockRange window. If `cachedIntervals` causes the
+  // child filter to appear fully cached (not in `requiredIntervals`) while the
+  // factory IS in `requiredFactoryIntervals`, child events for newly discovered
+  // addresses must still be fetched.
+  //
+  // This can happen after a v0.14→v0.15 migration (migration compat marks factory
+  // as cached but child addresses may be missing) or in other stale-cache scenarios.
+
+  const { syncStore, database } = await setupDatabaseServices();
+
+  const chain = getChain();
+  const rpc = createRpc({
+    chain,
+    common: context.common,
+  });
+
+  const { address } = await deployFactory({ sender: ALICE });
+  const { address: pair } = await createPair({
+    factory: address,
+    sender: ALICE,
+  });
+  await swapPair({
+    pair,
+    amount0Out: 1n,
+    amount1Out: 1n,
+    to: ALICE,
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getPairWithFactoryIndexingBuild({
+    address,
+  });
+
+  const historicalSync = createHistoricalSync({
+    common: context.common,
+    chain,
+    rpc,
+    childAddresses: setupChildAddresses(eventCallbacks),
+    filters: eventCallbacks.map(({ filter }) => filter),
+  });
+
+  // Compute the normal required intervals so we have the factory intervals.
+  const allRequiredIntervals = getRequiredIntervalsWithFilters({
+    interval: [1, 3],
+    filters: eventCallbacks.map(({ filter }) => filter),
+    cachedIntervals: setupCachedIntervals(eventCallbacks),
+  });
+
+  // Simulate the full bug: both calls get empty child filter intervals (as if the
+  // child filter appeared fully cached in cachedIntervals for the entire batch range).
+  // The factory IS in requiredFactoryIntervals so syncAddressFactory runs and adds
+  // the pair to childAddresses. The supplementary fetch must then return the Swap
+  // log; the syncBlockData fallback must store it despite logFilters being empty.
+  const logs = await historicalSync.syncBlockRangeData({
+    interval: [1, 3],
+    requiredIntervals: [],
+    requiredFactoryIntervals: allRequiredIntervals.factoryIntervals,
+    syncStore,
+  });
+
+  await historicalSync.syncBlockData({
+    interval: [1, 3],
+    requiredIntervals: [],
+    logs,
+    syncStore,
+  });
+
+  const dbLogs = await database.syncQB.wrap((db) =>
+    db.select().from(ponderSyncSchema.logs).execute(),
+  );
+  const factories = await database.syncQB.wrap((db) =>
+    db.select().from(ponderSyncSchema.factories).execute(),
+  );
+
+  // The Swap event from the newly discovered child must be present.
+  expect(dbLogs).toHaveLength(1);
+  expect(factories).toHaveLength(1);
+});

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -4,6 +4,7 @@ import type {
   Chain,
   Factory,
   FactoryId,
+  Filter,
   LogFilter,
   SyncBlock,
   SyncLog,
@@ -93,6 +94,7 @@ type CreateHistoricalSyncParameters = {
   chain: Chain;
   rpc: Rpc;
   childAddresses: Map<FactoryId, Map<Address, number>>;
+  filters?: Filter[];
 };
 
 export const createHistoricalSync = (
@@ -579,6 +581,35 @@ export const createHistoricalSync = (
         }
       }
 
+      // Supplementary fetch: when new child addresses are discovered by the factory scan
+      // in this batch, ensure their events are fetched for the full batch interval.
+      // This guards against the case where the child filter appears cached in
+      // cachedIntervals (not in requiredIntervals) but those cached intervals were
+      // recorded before this child address existed, so the child's events were never
+      // fetched. The dedupe call below removes any resulting duplicate eth_getLogs params.
+      for (const [factoryId, newAddresses] of childAddresses.entries()) {
+        if (newAddresses.size === 0) continue;
+
+        const newAddressList = Array.from(newAddresses.keys());
+        const threshold = args.common.options.factoryAddressCountThreshold;
+
+        for (const filter of args.filters ?? []) {
+          if (filter.type !== "log") continue;
+          if (!isAddressFactory(filter.address)) continue;
+          if (filter.address.id !== factoryId) continue;
+
+          singleEthGetLogsParams.push({
+            address:
+              newAddressList.length >= threshold ? undefined : newAddressList,
+            topic0: filter.topic0,
+            topic1: filter.topic1,
+            topic2: filter.topic2,
+            topic3: filter.topic3,
+            interval,
+          });
+        }
+      }
+
       const ethGetLogsParams = dedupe(
         [
           ...singleEthGetLogsParams,
@@ -740,6 +771,36 @@ export const createHistoricalSync = (
 
                   // skip to next log
                   break;
+                }
+              }
+            }
+
+            // Supplementary match: logs fetched by the factory-address scan in
+            // syncBlockRangeData for child filters that appeared cached (absent from
+            // requiredIntervals / logFilters) but were recorded before this child
+            // address was created, so the child's events were never actually stored.
+            if (!isMatched) {
+              for (const filter of args.filters ?? []) {
+                if (filter.type !== "log") continue;
+                if (!isAddressFactory(filter.address)) continue;
+                const factoryAddresses = args.childAddresses.get(
+                  filter.address.id,
+                );
+                if (!factoryAddresses) continue;
+                if (
+                  isLogFilterMatched({ filter, log }) &&
+                  isAddressMatched({
+                    address: log.address,
+                    blockNumber,
+                    childAddresses: factoryAddresses,
+                  })
+                ) {
+                  isMatched = true;
+                  requiredTransactions.add(log.transactionHash);
+                  if (filter.hasTransactionReceipt) {
+                    requiredTransactionReceipts.add(log.transactionHash);
+                    break;
+                  }
                 }
               }
             }
@@ -1038,7 +1099,7 @@ export const createHistoricalSync = (
         100,
       );
 
-      if (requiredIntervals.length > 0) {
+      if (requiredIntervals.length > 0 || logs.length > 0) {
         const queue = createQueue({
           browser: false,
           initialStart: true,


### PR DESCRIPTION
## Problem

When a factory creates a child contract **and** the child emits an event in the same `ethGetLogsBlockRange` batch window, the child's events are silently dropped on a cold re-index.

**Root cause:** When `syncBlockRangeData` processes batch `[A, B]`, it calls `syncAddressFactory` to discover new child addresses. If a child is created at block X within `[A, B]` and also emits events at block X, those events are never fetched — because the child's filter was not in `requiredIntervals` at the start of the batch (the child didn't exist yet), and the initial `eth_getLogs` did not include it. After the batch completes, `[A, B]` is marked as processed for the child filter, so the events from the creation block are permanently missed on any subsequent restart.

**Observed symptom:** A position contract created and denied in the same eth_getLogs batch shows `denied: false` after a full re-index — the `PositionDenied` event was never stored.

## Fix (3 parts)

1. **Pass event filters into `createHistoricalSync`** via a new optional `filters` parameter so the sync instance knows which child topics to look for.

2. **Supplementary `eth_getLogs` fetch in `syncBlockRangeData`:** after `syncAddressFactory` discovers newly created child addresses, immediately issue additional `eth_getLogs` calls for those addresses using their matching filter `topic0`. The existing dedupe step eliminates duplicates.

3. **Relax the `syncBlockData` processing guard** from `requiredIntervals.length > 0` to `requiredIntervals.length > 0 || logs.length > 0` so supplementary logs are not silently discarded when the child filter has no required intervals. Also adds a fallback log-matching path in `syncBlockData` that checks `args.filters` when `logFilters` is empty.

## Test

Added a regression test in `sync-historical/index.test.ts` that simulates the full bug scenario: empty `requiredIntervals` for both `syncBlockRangeData` and `syncBlockData` while the factory IS in `requiredFactoryIntervals`. The test verifies the child's Swap log is stored.

## Verification

End-to-end verified against a production Frankencoin ponder indexer: position `0xf35378277191c1f0d90869426f7177aa0393f77d` (created and denied in the same batch) now correctly returns `denied: true` after a full re-index with this patch applied -- and many more "dropped" events are found, comparing the patch against the production instance and on-chain data.