### PR TITLE
feat(core): pluggable historical sync provider

### DIFF
--- a/.changeset/pluggable-sync-providers.md
+++ b/.changeset/pluggable-sync-providers.md
@@ -1,0 +1,5 @@
+---
+"ponder": minor
+---
+
+Added `chain.sync` to plug in custom historical sync providers, and exposed the `ponder/sync` extension API. Setting `chain.sync.historical` streams a chain's historical backfill from a custom data source instead of JSON-RPC, without forking core. `ponder/sync` exports the full provider contract (`HistoricalSyncFactory`, the `Sync*` data types, `SyncStore`, filter/interval helpers) so a provider needs no deep imports. The default (no `chain.sync`) is unchanged; realtime and indexing-function reads still use `rpc`. `chain.sync.realtime` is reserved for a future realtime provider seam.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js"
     },
+    "./sync": {
+      "types": "./dist/types/sync.d.ts",
+      "import": "./dist/esm/sync.js"
+    },
     "./virtual": {
       "types": "./src/types.d.ts"
     }

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -668,6 +668,7 @@ export const getChain = (params?: {
     name: "mainnet",
     id: 1,
     rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}`,
+    sync: undefined,
     ws: undefined,
     pollingInterval: 1_000,
     finalityBlockCount: params?.finalityBlockCount ?? 1,

--- a/packages/core/src/build/config.ts
+++ b/packages/core/src/build/config.ts
@@ -1053,6 +1053,7 @@ export function buildConfig({
         id: chain.id,
         name: chainName,
         rpc: chain.rpc,
+        sync: chain.sync,
         ws: chain.ws,
         pollingInterval: chain.pollingInterval ?? 1_000,
         finalityBlockCount: getFinalityBlockCount({ chain: matchedChain }),

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,4 +1,5 @@
 import type { ConnectionOptions } from "node:tls";
+import type { ChainSync } from "@/internal/types.js";
 import type { Prettify } from "@/types/utils.js";
 import type { Abi } from "abitype";
 import type { PoolConfig } from "pg";
@@ -94,6 +95,13 @@ type ChainConfig<chain> = {
   id: chain extends { id: infer id extends number } ? id | number : number;
   /** RPC url. */
   rpc: string | string[] | Transport | undefined;
+  /**
+   * Custom sync providers for this chain. Set `sync.historical` to stream the
+   * historical backfill from a custom data source instead of JSON-RPC;
+   * `sync.realtime` is reserved. Realtime and indexing-function reads still use
+   * `rpc`, which remains required.
+   */
+  sync?: ChainSync;
   ws?: string;
   /** Polling interval (in ms). Default: `1_000`. */
   pollingInterval?: number;

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -1,5 +1,7 @@
 import type { SqlStatements } from "@/drizzle/kit/index.js";
 import type { Rpc } from "@/rpc/index.js";
+import type { HistoricalSyncFactory } from "@/sync-historical/index.js";
+import type { RealtimeSyncFactory } from "@/sync-realtime/index.js";
 import type {
   Block,
   Log,
@@ -296,10 +298,22 @@ export type SetupCallback = {
 
 // Chain
 
+/**
+ * Custom sync providers for a chain. When a field is set, it replaces the
+ * default JSON-RPC sync for that phase: `historical` backs the backfill,
+ * `realtime` (reserved) backs near-head sync. Unset → default RPC sync.
+ */
+export type ChainSync = {
+  historical?: HistoricalSyncFactory;
+  realtime?: RealtimeSyncFactory;
+};
+
 export type Chain = {
   name: string;
   id: number;
   rpc: string | string[] | Transport;
+  /** Custom sync providers. Unset → JSON-RPC sync. */
+  sync: ChainSync | undefined;
   ws: string | undefined;
   pollingInterval: number;
   finalityBlockCount: number;

--- a/packages/core/src/runtime/historical.ts
+++ b/packages/core/src/runtime/historical.ts
@@ -1221,7 +1221,8 @@ export async function* getLocalSyncGenerator(params: {
     });
   }
 
-  const historicalSync = createHistoricalSync(params);
+  const createSync = params.chain.sync?.historical ?? createHistoricalSync;
+  const historicalSync = createSync(params);
 
   const { callback: intervalCallback, generator: intervalGenerator } =
     createCallbackGenerator<{

--- a/packages/core/src/runtime/realtime.ts
+++ b/packages/core/src/runtime/realtime.ts
@@ -765,7 +765,8 @@ export async function* getRealtimeEventGenerator(params: {
   childAddresses: ChildAddresses;
   database: Database;
 }) {
-  const realtimeSync = createRealtimeSync(params);
+  const createSync = params.chain.sync?.realtime ?? createRealtimeSync;
+  const realtimeSync = createSync(params);
 
   let childCount = 0;
   for (const [, factoryChildAddresses] of params.childAddresses) {

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -88,12 +88,21 @@ export type HistoricalSync = {
   }): Promise<SyncBlock | undefined>;
 };
 
-type CreateHistoricalSyncParameters = {
+export type CreateHistoricalSyncParameters = {
   common: Common;
   chain: Chain;
   rpc: Rpc;
   childAddresses: Map<FactoryId, Map<Address, number>>;
 };
+
+/**
+ * Factory for a {@link HistoricalSync} implementation. Pass one via
+ * `chain.sync.historical` to back the historical backfill with a custom data
+ * source instead of JSON-RPC.
+ */
+export type HistoricalSyncFactory = (
+  args: CreateHistoricalSyncParameters,
+) => HistoricalSync;
 
 export const createHistoricalSync = (
   args: CreateHistoricalSyncParameters,

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -90,7 +90,7 @@ export type RealtimeSyncEvent =
   | { type: "finalize"; block: LightBlock }
   | { type: "reorg"; block: LightBlock; reorgedBlocks: LightBlock[] };
 
-type CreateRealtimeSyncParameters = {
+export type CreateRealtimeSyncParameters = {
   common: Common;
   chain: Chain;
   rpc: Rpc;
@@ -98,6 +98,16 @@ type CreateRealtimeSyncParameters = {
   syncProgress: Pick<SyncProgress, "finalized">;
   childAddresses: Map<FactoryId, Map<Address, number>>;
 };
+
+/**
+ * Factory for a {@link RealtimeSync} implementation. Pass one via
+ * `chain.sync.realtime` to back realtime sync with a custom data source instead
+ * of JSON-RPC. Reserved for future use; the default RPC realtime sync is used
+ * when unset.
+ */
+export type RealtimeSyncFactory = (
+  args: CreateRealtimeSyncParameters,
+) => RealtimeSync;
 
 const MAX_LATEST_BLOCK_ATTEMPT_MS = 10 * 60 * 1000; // 10 minutes
 const MAX_QUEUED_BLOCKS = 50;

--- a/packages/core/src/sync.test-d.ts
+++ b/packages/core/src/sync.test-d.ts
@@ -1,0 +1,170 @@
+import { createConfig } from "@/config/index.js";
+// The provider contract, imported entirely from the public extension surface.
+// In-repo this is the `@/sync.js` alias; externally it is `ponder/sync`.
+import {
+  type BlockFilter,
+  type CreateHistoricalSyncParameters,
+  type Factory,
+  type HistoricalSync,
+  type HistoricalSyncFactory,
+  type LogFilter,
+  type SyncBlock,
+  type SyncLog,
+  type SyncStore,
+  type SyncTrace,
+  type SyncTransaction,
+  type TraceFilter,
+  type TransactionFilter,
+  type TransferFilter,
+  getChildAddress,
+  isAddressFactory,
+  isAddressMatched,
+  isBlockFilterMatched,
+  isLogFactoryMatched,
+  isLogFilterMatched,
+  isTraceFilterMatched,
+  isTransactionFilterMatched,
+  isTransferFilterMatched,
+} from "@/sync.js";
+import { http, type Address } from "viem";
+import { test } from "vitest";
+
+// A historical-sync provider implemented using ONLY the exported contract —
+// no `@/...` deep imports, no re-declared core shapes. This is the whole point
+// of `ponder/sync`: the surface is complete enough to build a provider against.
+const provider: HistoricalSyncFactory = (
+  args: CreateHistoricalSyncParameters,
+): HistoricalSync => {
+  // `args` carries everything a provider needs (common / chain / rpc / childAddresses).
+  args.chain.id;
+  args.childAddresses.size;
+  return {
+    async syncBlockRangeData(params) {
+      params.interval satisfies [number, number];
+      params.syncStore satisfies SyncStore;
+      return [] as SyncLog[];
+    },
+    async syncBlockData(params) {
+      params.logs satisfies SyncLog[];
+      return undefined as SyncBlock | undefined;
+    },
+  };
+};
+
+// Ambient samples for the full-filter coverage below. They are never evaluated
+// at runtime: the provider methods that reference them are constructed but never
+// invoked (createConfig stores the factory without calling it).
+declare const sampleLog: SyncLog;
+declare const sampleTrace: SyncTrace["trace"];
+declare const sampleTransaction: SyncTransaction;
+declare const sampleBlock: Pick<SyncBlock, "number">;
+declare const logFilter: LogFilter;
+declare const blockFilter: BlockFilter;
+declare const transactionFilter: TransactionFilter;
+declare const traceFilter: TraceFilter;
+declare const transferFilter: TransferFilter;
+
+// A provider that handles EVERY source type (log / block / transaction / trace /
+// transfer, plus factories). It exercises the full matcher surface so that
+// dropping any per-filter-type helper from `ponder/sync` breaks the build
+// instead of silently regressing a non-log provider that can no longer route
+// those sources without deep imports.
+const fullFilterProvider: HistoricalSyncFactory = (
+  args: CreateHistoricalSyncParameters,
+): HistoricalSync => ({
+  async syncBlockRangeData(params) {
+    // Per-interval filter inputs are a discriminated union on `filter.type`, and
+    // the factory intervals carry the `Factory` shape — all from the surface.
+    for (const { filter, interval } of params.requiredIntervals) {
+      interval satisfies [number, number];
+      if (filter.type === "log") {
+        filter satisfies LogFilter;
+      } else if (filter.type === "block") {
+        filter satisfies BlockFilter;
+      } else if (filter.type === "transaction") {
+        filter satisfies TransactionFilter;
+      } else if (filter.type === "trace") {
+        filter satisfies TraceFilter;
+      } else if (filter.type === "transfer") {
+        filter satisfies TransferFilter;
+      }
+    }
+    for (const { factory, interval } of params.requiredFactoryIntervals) {
+      interval satisfies [number, number];
+      factory satisfies Factory;
+      args.childAddresses.get(factory.id);
+    }
+    return [] as SyncLog[];
+  },
+  async syncBlockData(params) {
+    params.logs satisfies SyncLog[];
+
+    // Every matcher a non-log provider needs must remain a value export.
+    if (isAddressFactory(logFilter.address)) {
+      getChildAddress({ log: sampleLog, factory: logFilter.address });
+      isLogFactoryMatched({ factory: logFilter.address, log: sampleLog });
+    }
+    isAddressMatched({
+      address: sampleLog.address,
+      blockNumber: 0,
+      childAddresses: new Map<Address, number>(),
+    });
+    isLogFilterMatched({ filter: logFilter, log: sampleLog });
+    isBlockFilterMatched({ filter: blockFilter, block: sampleBlock });
+    isTransactionFilterMatched({
+      filter: transactionFilter,
+      transaction: sampleTransaction,
+    });
+    isTraceFilterMatched({
+      filter: traceFilter,
+      trace: sampleTrace,
+      block: sampleBlock,
+    });
+    isTransferFilterMatched({
+      filter: transferFilter,
+      trace: sampleTrace,
+      block: sampleBlock,
+    });
+
+    return undefined as SyncBlock | undefined;
+  },
+});
+
+test("chain.sync.historical accepts a provider implemented from ponder/sync", () => {
+  createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: http(), sync: { historical: provider } },
+    },
+    contracts: {},
+  });
+});
+
+test("chain.sync.historical accepts a full-filter (log/block/transaction/trace/transfer) provider", () => {
+  createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: http(), sync: { historical: fullFilterProvider } },
+    },
+    contracts: {},
+  });
+});
+
+test("chain.sync without a provider is still valid", () => {
+  createConfig({
+    chains: { mainnet: { id: 1, rpc: http() } },
+    contracts: {},
+  });
+});
+
+test("chain.sync.historical rejects a wrong-shaped factory", () => {
+  createConfig({
+    chains: {
+      mainnet: {
+        id: 1,
+        rpc: http(),
+        // @ts-expect-error — must return a HistoricalSync (syncBlockRangeData / syncBlockData)
+        sync: { historical: () => ({ nope: true }) },
+      },
+    },
+    contracts: {},
+  });
+});

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -1,0 +1,110 @@
+/**
+ * `ponder/sync` — public extension API for custom sync providers.
+ *
+ * Implement {@link HistoricalSyncFactory} (and, in the future,
+ * {@link RealtimeSyncFactory}) in your own package and wire it via `chain.sync`
+ * in `ponder.config.ts` to back Ponder's sync with a custom data source instead
+ * of JSON-RPC.
+ *
+ * This module exposes the complete contract a provider needs: the `HistoricalSync`
+ * interface, the internal `Sync*` data types to produce, the `SyncStore` to write
+ * them to, the per-interval `Filter`/`Factory` inputs, and helpers for factory
+ * child discovery and block-interval math — so a provider never has to deep-import
+ * `@/...` internals or re-declare core's shapes.
+ *
+ * Stability: this is a lower-level surface than the main `ponder` entrypoint. It is
+ * versioned with `ponder` and may change in minor releases; pin accordingly.
+ *
+ * @example
+ * ```ts
+ * import type { HistoricalSyncFactory } from "ponder/sync";
+ *
+ * export const myProvider = (opts: { url: string }): HistoricalSyncFactory =>
+ *   (args) => ({
+ *     async syncBlockRangeData({ interval, requiredIntervals, syncStore }) {
+ *       // fetch a range, write Sync* via syncStore, return matched SyncLog[]
+ *     },
+ *     async syncBlockData({ interval, logs, syncStore }) {
+ *       // finalize per-block data, return the tip SyncBlock | undefined
+ *     },
+ *   });
+ * ```
+ */
+
+// Sync contracts + default (RPC) implementations (for composition / gap fallback)
+export {
+  createHistoricalSync,
+  type HistoricalSync,
+  type HistoricalSyncFactory,
+  type CreateHistoricalSyncParameters,
+} from "@/sync-historical/index.js";
+export {
+  createRealtimeSync,
+  type RealtimeSync,
+  type RealtimeSyncFactory,
+  type CreateRealtimeSyncParameters,
+  type RealtimeSyncEvent,
+  type BlockWithEventData,
+} from "@/sync-realtime/index.js";
+
+// Chain + sync descriptor + internal data types a provider produces
+export type {
+  Chain,
+  ChainSync,
+  EventCallback,
+  SyncBlock,
+  SyncBlockHeader,
+  SyncLog,
+  SyncTransaction,
+  SyncTransactionReceipt,
+  SyncTrace,
+  LightBlock,
+  Filter,
+  LogFilter,
+  TraceFilter,
+  TransferFilter,
+  BlockFilter,
+  TransactionFilter,
+  Factory,
+  FactoryId,
+} from "@/internal/types.js";
+
+// Per-interval filter inputs + sync progress passed to a provider
+export type {
+  IntervalWithFilter,
+  IntervalWithFactory,
+  SyncProgress,
+  ChildAddresses,
+} from "@/runtime/index.js";
+
+// Filter helpers (factory child discovery + per-filter-type matching)
+export {
+  getChildAddress,
+  isAddressFactory,
+  isAddressMatched,
+  isBlockFilterMatched,
+  isLogFactoryMatched,
+  isLogFilterMatched,
+  isTraceFilterMatched,
+  isTransactionFilterMatched,
+  isTransferFilterMatched,
+} from "@/runtime/filter.js";
+
+// Block-interval type + utilities
+export {
+  type Interval,
+  getChunks,
+  intervalBounds,
+  intervalDifference,
+  intervalIntersection,
+  intervalIntersectionMany,
+  intervalRange,
+  intervalSum,
+  intervalUnion,
+  sortIntervals,
+} from "@/utils/interval.js";
+
+// Transport, write side, and context
+export type { Rpc } from "@/rpc/index.js";
+export type { SyncStore } from "@/sync-store/index.js";
+export type { Common } from "@/internal/common.js";


### PR DESCRIPTION
## What this adds

A chain can back its historical backfill with a custom data source instead of JSON-RPC. You set one field in `ponder.config.ts`:

```ts
import { myProvider } from "my-sync-provider";

export default createConfig({
  chains: {
    mainnet: {
      id: 1,
      rpc: process.env.PONDER_RPC_URL_1,
      sync: { historical: myProvider({ /* ... */ }) },
    },
  },
  // ...
});
```

When `chain.sync.historical` is set, Ponder streams that chain's historical data from your provider. When it's unset, you get the built-in JSON-RPC sync, unchanged.

## Why

The historical backfill only runs over JSON-RPC. `createHistoricalSync` is wired straight into `runtime/historical.ts`, so there's no seam to swap it. For a large range that's the bottleneck: `eth_getLogs` splitting on size errors, one block at a time, rate limits. Bulk sources serve the same data faster — columnar exports, data lakes, archive dumps — but there's no supported way to feed one in.

A range query is the natural unit, so the seam is a range query. A provider implements two methods — `syncBlockRangeData` (fetch a range, write rows, return matched logs) and `syncBlockData` (finalize per-block data, return the tip block) — and writes `Sync*` rows to the `SyncStore`.

The runtime change is one line at each call site:

```ts
const createSync = params.chain.sync?.historical ?? createHistoricalSync;
const historicalSync = createSync(params);
```

The rest of the diff makes the contract reachable from outside core.

## The `ponder/sync` entrypoint

A provider lives in its own package and can't reach `@/...` internals. This PR adds a `ponder/sync` export with the contract a provider needs: `HistoricalSyncFactory`, the `Sync*` data types it produces, the `SyncStore` it writes to, the per-interval `Filter`/`Factory` inputs, and the filter-matching and block-interval helpers. So a provider needs no deep imports and doesn't re-declare core's shapes.

It's lower-level than the main `ponder` entrypoint, versioned with `ponder`, and may change in minor releases — pin accordingly. The doc comment on `sync.ts` notes this.

## Scope

- Default path (no `chain.sync`) is unchanged.
- `rpc` stays required. Realtime sync and indexing-function reads (`eth_call` and friends) still use it. This only swaps the historical backfill.
- `chain.sync.realtime` is reserved. The seam and `RealtimeSyncFactory` type exist and resolve the same way, but there's no realtime provider yet — unset uses the built-in RPC realtime sync.

## Tests

- `sync.test-d.ts` — type-level tests pinning the `ponder/sync` surface and the factory contract.
- The default path stays covered by the existing `sync-historical` / `sync-realtime` suites, since `chain.sync` defaults to the built-in factories.


Related discussion #2302

