### PR TITLE
Fix live query notify table indexes

### DIFF
--- a/packages/core/src/bin/commands/createViews.ts
+++ b/packages/core/src/bin/commands/createViews.ts
@@ -15,8 +15,8 @@ import {
 } from "@/database/index.js";
 import {
   getLiveQueryChannelName,
+  getLiveQueryNotifyProcedureSql,
   getLiveQueryNotifyProcedureName,
-  getLiveQueryTempTableName,
   getViewsLiveQueryNotifyTriggerName,
 } from "@/drizzle/onchain.js";
 import { sql } from "@/index.js";
@@ -273,32 +273,14 @@ export async function createViews({
   const channel = getLiveQueryChannelName(cliOptions.viewsSchema);
 
   await database.adminQB.wrap((db) =>
-    db.execute(`
-CREATE OR REPLACE FUNCTION "${cliOptions.viewsSchema}".${notifyProcedure}
-RETURNS TRIGGER LANGUAGE plpgsql
-AS $$
-  DECLARE
-    table_names json;
-    table_exists boolean := false;
-  BEGIN
-    SELECT EXISTS (
-      SELECT 1
-      FROM information_schema.tables
-      WHERE table_name = '${getLiveQueryTempTableName()}'
-      AND table_type = 'LOCAL TEMPORARY'
-    ) INTO table_exists;
-
-    IF table_exists THEN
-      SELECT json_agg(table_name) INTO table_names
-      FROM ${getLiveQueryTempTableName()};
-
-      table_names := COALESCE(table_names, '[]'::json);
-      PERFORM pg_notify('${channel}', table_names::text);
-    END IF;
-
-    RETURN NULL;
-  END;
-$$;`),
+    db.execute(
+      getLiveQueryNotifyProcedureSql({
+        schema: cliOptions.viewsSchema!,
+        channel,
+        tableNames: meta[0]!.app.table_names!,
+        stripPartitionSuffix: buildResult.result.ordering === "experimental_isolated",
+      }),
+    ),
   );
 
   const trigger = getViewsLiveQueryNotifyTriggerName(cliOptions.viewsSchema);

--- a/packages/core/src/bin/isolatedController.ts
+++ b/packages/core/src/bin/isolatedController.ts
@@ -102,7 +102,12 @@ export async function isolatedController({
 
         const tables = Object.values(schemaBuild.schema).filter(isTable);
         const views = Object.values(schemaBuild.schema).filter(isView);
-        await createViews(database.adminQB, { tables, views, namespaceBuild });
+        await createViews(database.adminQB, {
+          tables,
+          views,
+          namespaceBuild,
+          ordering: preBuild.ordering,
+        });
 
         common.logger.info({
           msg: "Created database views",

--- a/packages/core/src/build/schema.test.ts
+++ b/packages/core/src/build/schema.test.ts
@@ -27,6 +27,19 @@ test("buildSchema() success", () => {
   buildSchema({ schema, preBuild: { ordering: "multichain" } });
 });
 
+test("buildSchema() success with more than 100 tables", () => {
+  const schema = Object.fromEntries(
+    Array.from({ length: 101 }, (_, i) => [
+      `table${i}`,
+      onchainTable(`table_${i}`, (p) => ({
+        id: p.integer().primaryKey(),
+      })),
+    ]),
+  );
+
+  buildSchema({ schema, preBuild: { ordering: "multichain" } });
+});
+
 test("buildSchema() error with multiple primary key", () => {
   const schema = {
     account: onchainTable("account", (p) => ({

--- a/packages/core/src/build/schema.ts
+++ b/packages/core/src/build/schema.ts
@@ -27,11 +27,6 @@ import {
   getViewConfig,
 } from "drizzle-orm/pg-core";
 
-/**
- * @dev The maximum notify message size is 8KB (8000 / 63 > 100).
- */
-const TABLE_LIMIT = 100;
-
 export const buildSchema = ({
   schema,
   preBuild,
@@ -328,12 +323,6 @@ export const buildSchema = ({
           }
         }
     }
-  }
-
-  if (tableNames.size > TABLE_LIMIT) {
-    throw new Error(
-      `Schema validation failed: the maximum number of tables is ${TABLE_LIMIT}.`,
-    );
   }
 
   return { statements };

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -89,7 +89,8 @@ export const client = ({
 
   const tables = Object.values(schema).filter(isTable);
   const views = Object.values(schema).filter(isView);
-  const tableNames = new Set(tables.map(getTableName));
+  const schemaTableNames = tables.map(getTableName);
+  const tableNames = new Set(schemaTableNames);
   const viewNames = new Set(views.map(getViewName));
 
   // Note: Add system tables to the live query registry.
@@ -137,6 +138,17 @@ export const client = ({
   for (const table of tableNames) {
     perTableResolver.set(table, promiseWithResolvers<void>());
   }
+
+  const decodeNotificationPayload = (payload: string) => {
+    const tableIndexes = JSON.parse(payload) as number[];
+    const tables = tableIndexes.flatMap((index) => {
+      const table = schemaTableNames[index];
+      return table === undefined ? [] : [table];
+    });
+
+    tables.push("_ponder_checkpoint");
+    return tables;
+  };
 
   const parseViewPromise = (async () => {
     const unresolvedViewRelations = new Map<string, Set<string>>();
@@ -192,8 +204,7 @@ export const client = ({
     driver.instance.query(`LISTEN "${channel}"`);
 
     driver.instance.onNotification((_, payload) => {
-      const tables = JSON.parse(payload!) as string[];
-      tables.push("_ponder_checkpoint");
+      const tables = decodeNotificationPayload(payload!);
       let invalidQueryCount = 0;
 
       for (const [queryString, referencedTables] of perQueryReferences) {
@@ -254,20 +265,7 @@ export const client = ({
             });
 
             client.on("notification", (notification) => {
-              let tables = JSON.parse(notification.payload!) as string[];
-
-              // Convert partition names to table names
-              if (
-                globalThis.PONDER_PRE_BUILD.ordering === "experimental_isolated"
-              ) {
-                tables = tables.map((table) => {
-                  const _table = table.split("_");
-                  _table.pop();
-                  return _table.join("_");
-                });
-              }
-
-              tables.push("_ponder_checkpoint");
+              const tables = decodeNotificationPayload(notification.payload!);
               let invalidQueryCount = 0;
 
               for (const [

--- a/packages/core/src/database/actions.test.ts
+++ b/packages/core/src/database/actions.test.ts
@@ -397,6 +397,7 @@ test("empty schema", async () => {
     tables: [],
     views: [],
     namespaceBuild: { schema: "public", viewsSchema: undefined },
+    ordering: "multichain",
   });
   await revertMultichain(database.userQB, {
     tables: [],

--- a/packages/core/src/database/actions.ts
+++ b/packages/core/src/database/actions.ts
@@ -2,6 +2,7 @@ import { getPrimaryKeyColumns } from "@/drizzle/index.js";
 import { getColumnCasing, getReorgTable } from "@/drizzle/kit/index.js";
 import {
   getLiveQueryChannelName,
+  getLiveQueryNotifyProcedureSql,
   getLiveQueryNotifyProcedureName,
   getLiveQueryNotifyTriggerName,
   getLiveQueryProcedureName,
@@ -220,7 +221,15 @@ export const dropLiveQueryTriggers = async (
 
 export const createLiveQueryProcedures = async (
   qb: QB,
-  { namespaceBuild }: { namespaceBuild: NamespaceBuild },
+  {
+    namespaceBuild,
+    tables,
+    ordering,
+  }: {
+    namespaceBuild: NamespaceBuild;
+    tables: Table[];
+    ordering: PreBuild["ordering"];
+  },
   context?: { logger?: Logger },
 ) => {
   await qb.transaction(
@@ -246,37 +255,18 @@ $$;`,
         context,
       );
 
-      const notifyProcedure = getLiveQueryNotifyProcedureName();
       const channel = getLiveQueryChannelName(namespaceBuild.schema);
 
       await tx.wrap(
         (tx) =>
-          tx.execute(`
-CREATE OR REPLACE FUNCTION "${schema}".${notifyProcedure}
-RETURNS TRIGGER LANGUAGE plpgsql
-AS $$
-  DECLARE
-    table_names json;
-    table_exists boolean := false;
-  BEGIN
-    SELECT EXISTS (
-      SELECT 1
-      FROM information_schema.tables
-      WHERE table_name = '${getLiveQueryTempTableName()}'
-      AND table_type = 'LOCAL TEMPORARY'
-    ) INTO table_exists;
-
-    IF table_exists THEN
-      SELECT json_agg(table_name) INTO table_names
-      FROM ${getLiveQueryTempTableName()};
-
-      table_names := COALESCE(table_names, '[]'::json);
-      PERFORM pg_notify('${channel}', table_names::text);
-    END IF;
-
-    RETURN NULL;
-  END;
-$$;`),
+          tx.execute(
+            getLiveQueryNotifyProcedureSql({
+              schema,
+              channel,
+              tableNames: tables.map(getTableName),
+              stripPartitionSuffix: ordering === "experimental_isolated",
+            }),
+          ),
         context,
       );
     },
@@ -291,7 +281,13 @@ export const createViews = async (
     tables,
     views,
     namespaceBuild,
-  }: { tables: Table[]; views: View[]; namespaceBuild: NamespaceBuild },
+    ordering,
+  }: {
+    tables: Table[];
+    views: View[];
+    namespaceBuild: NamespaceBuild;
+    ordering: PreBuild["ordering"];
+  },
   context?: { logger?: Logger },
 ) => {
   await qb.transaction(
@@ -358,41 +354,23 @@ export const createViews = async (
         ),
       );
 
-      const notifyProcedure = getLiveQueryNotifyProcedureName();
       const channel = getLiveQueryChannelName(namespaceBuild.viewsSchema!);
 
       await tx.wrap((tx) =>
-        tx.execute(`
-CREATE OR REPLACE FUNCTION "${namespaceBuild.viewsSchema}".${notifyProcedure}
-RETURNS TRIGGER LANGUAGE plpgsql
-AS $$
-  DECLARE
-    table_names json;
-    table_exists boolean := false;
-  BEGIN
-    SELECT EXISTS (
-      SELECT 1
-      FROM information_schema.tables
-      WHERE table_name = '${getLiveQueryTempTableName()}'
-      AND table_type = 'LOCAL TEMPORARY'
-    ) INTO table_exists;
-
-    IF table_exists THEN
-      SELECT json_agg(table_name) INTO table_names
-      FROM ${getLiveQueryTempTableName()};
-
-      table_names := COALESCE(table_names, '[]'::json);
-      PERFORM pg_notify('${channel}', table_names::text);
-    END IF;
-
-    RETURN NULL;
-  END;
-$$;`),
+        tx.execute(
+          getLiveQueryNotifyProcedureSql({
+            schema: namespaceBuild.viewsSchema!,
+            channel,
+            tableNames: tables.map(getTableName),
+            stripPartitionSuffix: ordering === "experimental_isolated",
+          }),
+        ),
       );
 
       const trigger = getViewsLiveQueryNotifyTriggerName(
         namespaceBuild.viewsSchema!,
       );
+      const notifyProcedure = getLiveQueryNotifyProcedureName();
 
       await tx.wrap((tx) =>
         tx.execute(

--- a/packages/core/src/database/index.test.ts
+++ b/packages/core/src/database/index.test.ts
@@ -825,6 +825,7 @@ test("camelCase", async () => {
     tables: [accountCC],
     views: [accountViewCC],
     namespaceBuild: { schema: "public", viewsSchema: "viewCc" },
+    ordering: "multichain",
   });
 
   await commitBlock(database.userQB, {
@@ -837,6 +838,8 @@ test("camelCase", async () => {
 
   await createLiveQueryProcedures(database.userQB, {
     namespaceBuild: { schema: "public", viewsSchema: "viewCc" },
+    tables: [accountCC],
+    ordering: "multichain",
   });
   await createLiveQueryTriggers(database.userQB, {
     tables: [accountCC],

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -693,7 +693,11 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
             await createViews(tx);
             await createLiveQueryProcedures(
               tx,
-              { namespaceBuild: namespace },
+              {
+                namespaceBuild: namespace,
+                tables,
+                ordering: preBuild.ordering,
+              },
               context,
             );
 
@@ -831,7 +835,11 @@ CREATE TABLE IF NOT EXISTS "${namespace.schema}"."${PONDER_CHECKPOINT_TABLE_NAME
             await createAdminObjects(tx);
             await createLiveQueryProcedures(
               tx,
-              { namespaceBuild: namespace },
+              {
+                namespaceBuild: namespace,
+                tables,
+                ordering: preBuild.ordering,
+              },
               context,
             );
 

--- a/packages/core/src/drizzle/onchain.ts
+++ b/packages/core/src/drizzle/onchain.ts
@@ -70,6 +70,61 @@ export const getLiveQueryNotifyProcedureName = () => {
 export const getLiveQueryTempTableName = () => {
   return "live_query_tables";
 };
+export const getLiveQueryNotifyProcedureSql = ({
+  schema,
+  channel,
+  tableNames,
+  stripPartitionSuffix,
+}: {
+  schema: string;
+  channel: string;
+  tableNames: string[];
+  stripPartitionSuffix: boolean;
+}) => {
+  const escapeSqlString = (value: string) => value.replaceAll("'", "''");
+  const tempTableName = getLiveQueryTempTableName();
+  const tableMapSql =
+    tableNames.length === 0
+      ? "(SELECT NULL::text AS table_name, NULL::integer AS table_index WHERE false)"
+      : `(VALUES ${tableNames
+          .map((tableName, index) => `('${escapeSqlString(tableName)}', ${index})`)
+          .join(", ")})`;
+  const tableNameExpression = stripPartitionSuffix
+    ? "regexp_replace(live_query_tables.table_name, '_[0-9]+$', '')"
+    : "live_query_tables.table_name";
+
+  return `
+CREATE OR REPLACE FUNCTION "${schema}".${getLiveQueryNotifyProcedureName()}
+RETURNS TRIGGER LANGUAGE plpgsql
+AS $$
+  DECLARE
+    table_indexes json;
+    table_exists boolean := false;
+  BEGIN
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_name = '${tempTableName}'
+      AND table_type = 'LOCAL TEMPORARY'
+    ) INTO table_exists;
+
+    IF table_exists THEN
+      SELECT json_agg(table_index ORDER BY table_index) INTO table_indexes
+      FROM (
+        SELECT DISTINCT table_map.table_index
+        FROM ${tempTableName} AS live_query_tables
+        JOIN ${tableMapSql} AS table_map(table_name, table_index)
+        ON table_map.table_name = ${tableNameExpression}
+      ) AS changed_tables;
+
+      table_indexes := COALESCE(table_indexes, '[]'::json);
+      PERFORM pg_notify('${escapeSqlString(channel)}', table_indexes::text);
+    END IF;
+
+    RETURN NULL;
+  END;
+$$;`;
+};
 export const getPartitionName = (table: string | PgTable, chainId: number) => {
   return `${typeof table === "string" ? table : getTableName(table)}_${chainId}`;
 };

--- a/packages/core/src/runtime/multichain.ts
+++ b/packages/core/src/runtime/multichain.ts
@@ -579,7 +579,12 @@ export async function runMultichain({
   if (namespaceBuild.viewsSchema !== undefined) {
     const endClock = startClock();
 
-    await createViews(database.adminQB, { tables, views, namespaceBuild });
+    await createViews(database.adminQB, {
+      tables,
+      views,
+      namespaceBuild,
+      ordering: preBuild.ordering,
+    });
 
     common.logger.info({
       msg: "Created database views",

--- a/packages/core/src/runtime/omnichain.ts
+++ b/packages/core/src/runtime/omnichain.ts
@@ -594,7 +594,12 @@ export async function runOmnichain({
   if (namespaceBuild.viewsSchema !== undefined) {
     const endClock = startClock();
 
-    await createViews(database.adminQB, { tables, views, namespaceBuild });
+    await createViews(database.adminQB, {
+      tables,
+      views,
+      namespaceBuild,
+      ordering: preBuild.ordering,
+    });
 
     common.logger.info({
       msg: "Created database views",


### PR DESCRIPTION
## Summary
- encode live query notifications as table indexes instead of table names
- decode indexes back to schema table names in the client
- preserve isolated ordering behavior by mapping partition names to base table names in SQL
- remove the schema-level 100 table limit
- add coverage for building schemas with more than 100 tables

## Notes
- This PR intentionally does not include notification batching, so it can be compared independently with the batching-only approach.

## Testing
- Not run: node/npm/pnpm/corepack are not available on PATH in this environment
- git diff --check