### PR TITLE
fix: indexing build for colocated tests

### DIFF
--- a/.changeset/calm-colocated-tests.md
+++ b/.changeset/calm-colocated-tests.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed indexing builds to ignore colocated test files in `src`.

--- a/packages/core/src/build/index.test.ts
+++ b/packages/core/src/build/index.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Common } from "@/internal/common.js";
+import { createLogger } from "@/internal/logger.js";
+import { MetricsService } from "@/internal/metrics.js";
+import { buildOptions } from "@/internal/options.js";
+import { createShutdown } from "@/internal/shutdown.js";
+import { createTelemetry } from "@/internal/telemetry.js";
+import { expect, test } from "vitest";
+import { createBuild } from "./index.js";
+
+const write = (file: string, contents: string) => {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents);
+};
+
+test("executeIndexingFunctions() ignores colocated test files", async () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "ponder-build-"));
+  let common: Common | undefined;
+
+  try {
+    write(
+      path.join(rootDir, "src", "index.ts"),
+      'import { ponder } from "ponder:registry";\nponder.on("A:Event", () => {});\n',
+    );
+    write(
+      path.join(rootDir, "src", "business.test.ts"),
+      'throw new Error("colocated test file was executed");\n',
+    );
+    write(
+      path.join(rootDir, "src", "business.spec.ts"),
+      'throw new Error("colocated spec file was executed");\n',
+    );
+    write(
+      path.join(rootDir, "src", "business.test-d.ts"),
+      'throw new Error("colocated type test file was executed");\n',
+    );
+    write(
+      path.join(rootDir, "src", "__tests__", "business.ts"),
+      'throw new Error("__tests__ file was executed");\n',
+    );
+    write(path.join(rootDir, "ponder.config.ts"), "export default {};\n");
+    write(path.join(rootDir, "ponder.schema.ts"), "\n");
+
+    const cliOptions = {
+      command: "start",
+      root: rootDir,
+      config: "ponder.config.ts",
+      logLevel: "silent",
+      logFormat: "pretty",
+      version: "0.0.0",
+    } as const;
+    const options = {
+      ...buildOptions({ cliOptions }),
+      telemetryDisabled: true,
+    };
+    const logger = createLogger({ level: "silent" });
+    const shutdown = createShutdown();
+    common = {
+      options,
+      logger,
+      metrics: new MetricsService(),
+      telemetry: createTelemetry({ options, logger, shutdown }),
+      shutdown,
+      apiShutdown: shutdown,
+      buildShutdown: shutdown,
+    };
+
+    const build = await createBuild({ common, cliOptions });
+    const result = await build.executeIndexingFunctions();
+
+    if (result.status === "error") throw result.error;
+
+    expect(result.result.indexingFunctions.map((fn) => fn.name)).toEqual([
+      "A:Event",
+    ]);
+  } finally {
+    await common?.buildShutdown.kill();
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -122,6 +122,21 @@ export const createBuild = async ({
     .join(common.options.apiDir, "**/*.{js,mjs,ts,mts}")
     .replace(/\\/g, "/");
 
+  const isIgnoredIndexingFile = (file: string) => {
+    const normalized = file.replace(/\\/g, "/");
+    return (
+      normalized.includes("/__tests__/") ||
+      /\.(test|spec)(-d)?\.(js|mjs|ts|mts)$/.test(normalized)
+    );
+  };
+
+  const getIndexingFiles = () =>
+    glob
+      .sync(indexingPattern, {
+        ignore: apiPattern,
+      })
+      .filter((file) => isIgnoredIndexingFile(file) === false);
+
   const viteLogger = {
     warnedMessages: new Set<string>(),
     loggedErrors: new WeakSet<Error>(),
@@ -276,9 +291,7 @@ export const createBuild = async ({
       } as const;
     },
     async executeIndexingFunctions(): Promise<IndexingResult> {
-      const files = glob.sync(indexingPattern, {
-        ignore: apiPattern,
-      });
+      const files = getIndexingFiles();
 
       for (const file of files) {
         const executeResult = await executeFileWithTimeout({ file });
@@ -608,7 +621,10 @@ export const createBuild = async ({
         );
 
         const hasIndexingUpdate = Array.from(invalidated).some(
-          (file) => indexingRegex.test(file) && file !== common.options.apiFile,
+          (file) =>
+            indexingRegex.test(file) &&
+            file !== common.options.apiFile &&
+            isIgnoredIndexingFile(file) === false,
         );
         const hasApiUpdate = Array.from(invalidated).some(
           (file) => file === common.options.apiFile,
@@ -653,11 +669,7 @@ export const createBuild = async ({
           viteNodeRunner.moduleCache.invalidateDepTree([
             common.options.schemaFile,
           ]);
-          viteNodeRunner.moduleCache.invalidateDepTree(
-            glob.sync(indexingPattern, {
-              ignore: apiPattern,
-            }),
-          );
+          viteNodeRunner.moduleCache.invalidateDepTree(getIndexingFiles());
           viteNodeRunner.moduleCache.invalidateDepTree(glob.sync(apiPattern));
           viteNodeRunner.moduleCache.deleteByModuleId("ponder:registry");
           viteNodeRunner.moduleCache.deleteByModuleId("ponder:api");


### PR DESCRIPTION
## Summary

- Ignore colocated test files when collecting indexing files
- Reuse the same ignore predicate for build hashing and dev reloads
- Add regression coverage for `.test`, `.spec`, `.test-d`, and `__tests__`

## Testing

- `pnpm lint packages/core/src/build/index.ts packages/core/src/build/index.test.ts .changeset/calm-colocated-tests.md`
- `pnpm --filter ponder test src/build/index.test.ts`
- `pnpm --filter ponder typecheck`
