### PR TITLE
Fix bytea COPY encoding

### DIFF
--- a/.changeset/bytea-copy-encoding.md
+++ b/.changeset/bytea-copy-encoding.md
@@ -2,4 +2,4 @@
 "ponder": patch
 ---
 
-Fixed bytea encoding when flushing rows to Postgres with COPY.
+Fixed a bug with `p.bytes()` bytea encoding when flushing rows to Postgres with COPY that caused `DelayedInsertError: invalid byte sequence for encoding "UTF8": 0x00`.

--- a/.changeset/bytea-copy-encoding.md
+++ b/.changeset/bytea-copy-encoding.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed bytea encoding when flushing rows to Postgres with COPY.

--- a/packages/core/src/indexing-store/cache.test.ts
+++ b/packages/core/src/indexing-store/cache.test.ts
@@ -15,7 +15,7 @@ import type { RetryableError } from "@/internal/errors.js";
 import type { IndexingErrorHandler } from "@/internal/types.js";
 import { parseEther, zeroAddress } from "viem";
 import { beforeEach, expect, test } from "vitest";
-import { createIndexingCache } from "./cache.js";
+import { createIndexingCache, getCopyText } from "./cache.js";
 import { createIndexingStore } from "./index.js";
 
 beforeEach(setupCommon);
@@ -230,6 +230,7 @@ test("flush() encoding", async () => {
       bigint: p.bigint().notNull(),
       e: e().notNull(),
       array: p.integer().array().notNull(),
+      bytes: p.bytes().notNull(),
       json: p.json().notNull(),
       null: p.text(),
     })),
@@ -262,6 +263,7 @@ test("flush() encoding", async () => {
       bigint: 10n,
       e: "a",
       array: [1, 2, 4],
+      bytes: new Uint8Array([0, 128, 255, 1]),
       json: { a: 1, b: 2 },
       null: null,
     });
@@ -280,6 +282,12 @@ test("flush() encoding", async () => {
             4,
           ],
           "bigint": 10n,
+          "bytes": Uint8Array [
+            0,
+            128,
+            255,
+            1,
+          ],
           "e": "a",
           "hex": "0x0000000000000000000000000000000000000000",
           "json": {
@@ -352,6 +360,18 @@ test("flush() encoding escape", async () => {
 
     expect(result).toStrictEqual(values);
   });
+});
+
+test("getCopyText() encodes bytes", () => {
+  const schema = {
+    test: onchainTable("test", (p) => ({
+      bytes: p.bytes().primaryKey(),
+    })),
+  };
+
+  expect(
+    getCopyText(schema.test, [{ bytes: new Uint8Array([0, 128, 255, 1]) }]),
+  ).toBe("\\\\x0080ff01");
 });
 
 test("prefetch() uses profile metadata", async () => {

--- a/packages/core/src/indexing-store/cache.test.ts
+++ b/packages/core/src/indexing-store/cache.test.ts
@@ -258,20 +258,44 @@ test("flush() encoding", async () => {
     indexingCache.qb = tx;
     indexingStore.qb = tx;
 
-    await indexingStore.db.insert(schema.test).values({
-      hex: zeroAddress,
-      bigint: 10n,
-      e: "a",
-      array: [1, 2, 4],
-      bytes: new Uint8Array([0, 128, 255, 1]),
-      json: { a: 1, b: 2 },
-      null: null,
-    });
+    const values = [
+      {
+        hex: zeroAddress,
+        bigint: 10n,
+        e: "a" as const,
+        array: [1, 2, 4],
+        bytes: new Uint8Array([0, 128, 255, 1]),
+        json: { a: 1, b: 2 },
+        null: null,
+      },
+      {
+        hex: "0x0000000000000000000000000000000000000001" as const,
+        bigint: 11n,
+        e: "b" as const,
+        array: [],
+        bytes: new Uint8Array([]),
+        json: {},
+        null: null,
+      },
+      {
+        hex: "0x0000000000000000000000000000000000000002" as const,
+        bigint: 12n,
+        e: "c" as const,
+        array: [0],
+        bytes: new Uint8Array([0x5c, 0x4e, 0x09, 0x0a, 0x0d]),
+        json: { c: 3 },
+        null: null,
+      },
+    ];
+
+    await indexingStore.db.insert(schema.test).values(values);
 
     await indexingCache.flush();
 
     indexingCache.clear();
-    const result = await indexingStore.db.sql.select().from(schema.test);
+    const result = (await indexingStore.db.sql.select().from(schema.test)).sort(
+      (a, b) => a.hex.localeCompare(b.hex),
+    );
 
     expect(result).toMatchInlineSnapshot(`
       [
@@ -293,6 +317,34 @@ test("flush() encoding", async () => {
           "json": {
             "a": 1,
             "b": 2,
+          },
+          "null": null,
+        },
+        {
+          "array": [],
+          "bigint": 11n,
+          "bytes": Uint8Array [],
+          "e": "b",
+          "hex": "0x0000000000000000000000000000000000000001",
+          "json": {},
+          "null": null,
+        },
+        {
+          "array": [
+            0,
+          ],
+          "bigint": 12n,
+          "bytes": Uint8Array [
+            92,
+            78,
+            9,
+            10,
+            13,
+          ],
+          "e": "c",
+          "hex": "0x0000000000000000000000000000000000000002",
+          "json": {
+            "c": 3,
           },
           "null": null,
         },
@@ -370,8 +422,25 @@ test("getCopyText() encodes bytes", () => {
   };
 
   expect(
-    getCopyText(schema.test, [{ bytes: new Uint8Array([0, 128, 255, 1]) }]),
-  ).toBe("\\\\x0080ff01");
+    getCopyText(schema.test, [
+      { bytes: new Uint8Array([0, 128, 255, 1]) },
+      { bytes: new Uint8Array([]) },
+      { bytes: new Uint8Array([0x5c, 0x4e, 0x09, 0x0a, 0x0d]) },
+    ]),
+  ).toBe("\\\\x0080ff01\n\\\\x\n\\\\x5c4e090a0d");
+
+  const multiColumnSchema = {
+    test: onchainTable("test", (p) => ({
+      bytes: p.bytes().primaryKey(),
+      text: p.text().notNull(),
+    })),
+  };
+
+  expect(
+    getCopyText(multiColumnSchema.test, [
+      { bytes: new Uint8Array([0x5c, 0x4e, 0x09, 0x0a, 0x0d]), text: "ok" },
+    ]),
+  ).toBe("\\\\x5c4e090a0d\tok");
 });
 
 test("prefetch() uses profile metadata", async () => {

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -247,8 +247,10 @@ export const getCopyText = (table: Table, rows: Row[]) => {
             value = column.mapToDriverValue(value);
             if (value === null || value === undefined) {
               result += "\\N";
+            } else if (Buffer.isBuffer(value)) {
+              result += `\\\\x${value.toString("hex")}`;
             } else {
-              result += `${String(value).replace(ESCAPE_REGEX, "\\$1")}`;
+              result += String(value).replace(ESCAPE_REGEX, "\\$1");
             }
           }
         }
@@ -261,6 +263,8 @@ export const getCopyText = (table: Table, rows: Row[]) => {
           }
           if (value === null || value === undefined) {
             result += "\\N\t";
+          } else if (Buffer.isBuffer(value)) {
+            result += `\\\\x${value.toString("hex")}\t`;
           } else {
             result += `${String(value).replace(ESCAPE_REGEX, "\\$1")}\t`;
           }


### PR DESCRIPTION
encodes Buffer driver values as bytea hex in COPY text output to fix `DelayedInsertError: invalid byte sequence for encoding "UTF8": 0x00`
