### PR TITLE
Fix Changesets release formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
         id: changesets
         uses: changesets/action@v1.7.0
         with:
-          commitMode: github-api 
           title: "chore: version packages"
           commit: "chore: version packages"
           version: pnpm changeset:version

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "bench:ponder:ci": "pnpm --filter \"./benchmarks\" bench:ponder:ci",
     "bench:subgraph:ci": "pnpm --filter \"./benchmarks\" bench:subgraph:ci",
     "build": "pnpm --filter \"./packages/**\" --recursive build",
-    "changeset:version": "changeset version && pnpm install --lockfile-only",
+    "changeset:version": "changeset version && pnpm install --lockfile-only && biome format package.json packages/*/package.json --write",
     "changeset:release": "pnpm build && changeset publish",
     "format": "biome format . --write",
     "lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "bench:ponder:ci": "pnpm --filter \"./benchmarks\" bench:ponder:ci",
     "bench:subgraph:ci": "pnpm --filter \"./benchmarks\" bench:subgraph:ci",
     "build": "pnpm --filter \"./packages/**\" --recursive build",
-    "changeset:version": "changeset version && pnpm install --lockfile-only && biome format package.json packages/*/package.json --write",
+    "changeset:version": "changeset version && pnpm install --lockfile-only",
     "changeset:release": "pnpm build && changeset publish",
     "format": "biome format . --write",
     "lint": "biome check .",

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -9,12 +9,7 @@
     "url": "https://github.com/ponder-sh/ponder",
     "directory": "packages/create-ponder"
   },
-  "files": [
-    "dist",
-    "templates",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "templates", "README.md", "LICENSE"],
   "bin": {
     "create-ponder": "./dist/index.js"
   },


### PR DESCRIPTION
## Summary
- restore Changesets action git-cli commit mode by removing `commitMode: github-api`
- reformat the current `create-ponder` package.json diff that broke lint on `main`

## Root Cause
The regression was introduced by [`5116886f`](https://github.com/ponder-sh/ponder/commit/5116886f6582dc558f53ab55767b38e2e6077558) (`improve changesets action`) on Mar 10, 2026, about 4 months ago. That commit upgraded `changesets/action` from `v1.4.5` to `v1.7.0` and added `commitMode: github-api`, changing release PR commits from the action's default `git-cli` mode to GitHub API commits.

Changesets rewrites touched `package.json` files with `JSON.stringify`, which expands inline arrays. That behavior is present in both `@changesets/apply-release-plan` `7.0.12` and `7.1.0`, so this is not a new Changesets version regression.

The issue started surfacing because `github-api` commits bypass local `git commit`, which also bypasses the repo pre-commit hook. Previously, the default `git-cli` mode ran `git commit`, allowing `lint-staged`/Biome to reformat the generated release commit before it was pushed. Restoring the default git-cli commit mode lets the existing hook run again.

## Verification
- `pnpm lint`