### PR TITLE
Remove unsound factory interval fallback in getIntervals()

### DIFF
--- a/.changeset/new-planes-wave.md
+++ b/.changeset/new-planes-wave.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug that caused apps with factories to miss historical events after updating factory config. Affected apps that updated from `v0.14` will refetch block data automatically.

--- a/.changeset/new-planes-wave.md
+++ b/.changeset/new-planes-wave.md
@@ -1,5 +1,5 @@
 ---
-"ponder": patch
+"ponder": minor
 ---
 
 Fixed a bug that caused apps with factories to miss historical events after updating factory config. Affected apps that updated from `v0.14` will refetch block data automatically.

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -4,6 +4,7 @@ import {
   EMPTY_BLOCK_FILTER,
   EMPTY_LOG_FILTER,
 } from "@/_test/constants.js";
+import { factoryABI } from "@/_test/generated.js";
 import {
   setupAnvil,
   setupCleanup,
@@ -25,10 +26,18 @@ import {
   getErc20IndexingBuild,
   getPairWithFactoryIndexingBuild,
 } from "@/_test/utils.js";
+import { buildLogFactory } from "@/build/factory.js";
+import { factory } from "@/config/address.js";
 import type { Factory, LogFilter } from "@/internal/types.js";
 import { orderObject } from "@/utils/order.js";
 import { sql } from "drizzle-orm";
-import { hexToBigInt, hexToNumber, parseEther, zeroAddress } from "viem";
+import {
+  getAbiItem,
+  hexToBigInt,
+  hexToNumber,
+  parseEther,
+  zeroAddress,
+} from "viem";
 import { beforeEach, expect, test } from "vitest";
 import * as ponderSyncSchema from "./schema.js";
 
@@ -262,7 +271,7 @@ test("getIntervals() adjacent intervals", async () => {
   `);
 });
 
-test("getIntervals() 0.15 migration", async () => {
+test("getIntervals() does not copy filter intervals to factory intervals for v0.15 migration", async () => {
   const { syncStore } = await setupDatabaseServices();
 
   const filter = {
@@ -283,6 +292,8 @@ test("getIntervals() 0.15 migration", async () => {
     toBlock: 20,
   } satisfies LogFilter;
 
+  // Simulate a v0.14 cache that only has log filter interval rows, with no
+  // corresponding factory_log interval rows.
   await syncStore.insertIntervals({
     intervals: [
       {
@@ -368,16 +379,48 @@ test("getIntervals() 0.15 migration", async () => {
             "toBlock": 20,
             "type": "factory_log",
           },
-          "intervals": [
-            [
-              10,
-              20,
-            ],
-          ],
+          "intervals": [],
         },
       ],
     }
   `);
+});
+
+test("getIntervals() returns factory intervals when factory_log rows exist", async () => {
+  const { syncStore } = await setupDatabaseServices();
+
+  const factory = {
+    id: "id",
+    type: "log",
+    chainId: 1,
+    sourceId: "factory",
+    address: "0xef2d6d194084c2de36e0dabfce45d046b37d1106",
+    eventSelector:
+      "0x02c69be41d0b7e40352fc85be1cd65eb03d40ef8427a0ca4596b1ead9a00e9fc",
+    childAddressLocation: "topic1",
+    fromBlock: 10,
+    toBlock: 20,
+  } as Factory;
+
+  const filter = {
+    ...EMPTY_LOG_FILTER,
+    address: factory,
+    fromBlock: 10,
+    toBlock: 20,
+  } satisfies LogFilter;
+
+  await syncStore.insertIntervals({
+    intervals: [{ filter, interval: [10, 20] }],
+    factoryIntervals: [{ factory, interval: [10, 20] }],
+    chainId: 1,
+  });
+
+  const intervals = await syncStore.getIntervals({
+    filters: [filter],
+  });
+
+  expect(intervals.get(filter)![0]!.intervals).toEqual([[10, 20]]);
+  expect(intervals.get(factory)![0]!.intervals).toEqual([[10, 20]]);
 });
 
 test("insertIntervals() merges duplicates", async () => {
@@ -1245,4 +1288,78 @@ test("pruneByChain deletes blocks, logs, traces, transactions", async () => {
   expect(traces).toHaveLength(0);
   expect(transactions).toHaveLength(0);
   expect(transactionReceipts).toHaveLength(0);
+});
+
+test("getIntervals() does not infer factory intervals from log filter intervals when factory identity changes", async () => {
+  const { syncStore } = await setupDatabaseServices();
+
+  const { address } = await deployFactory({ sender: ALICE });
+
+  const factoryV1 = buildLogFactory({
+    chainId: 1,
+    sourceId: "Pair",
+    fromBlock: undefined,
+    toBlock: undefined,
+    ...factory({
+      address,
+      event: getAbiItem({ abi: factoryABI, name: "PairCreated" }),
+      parameter: "pair",
+    }),
+  });
+
+  const filterV1: LogFilter = {
+    ...EMPTY_LOG_FILTER,
+    sourceId: "Pair",
+    address: factoryV1,
+  };
+
+  // Simulate a previously synced cache where only the log filter interval
+  // row exists (the factory interval row is absent).
+  await syncStore.insertIntervals({
+    intervals: [{ filter: filterV1, interval: [0, 20] }],
+    factoryIntervals: [],
+    chainId: 1,
+  });
+
+  // Change the factory identity by introducing a fromBlock. This produces a
+  // new factory_log_* fragment ID, while the log_* fragment ID remains the
+  // same because it does not encode fromBlock for factory addresses.
+  const factoryV2 = buildLogFactory({
+    chainId: 1,
+    sourceId: "Pair",
+    fromBlock: 10,
+    toBlock: undefined,
+    ...factory({
+      address,
+      event: getAbiItem({ abi: factoryABI, name: "PairCreated" }),
+      parameter: "pair",
+    }),
+  });
+
+  const filterV2: LogFilter = {
+    ...EMPTY_LOG_FILTER,
+    sourceId: "Pair",
+    address: factoryV2,
+    fromBlock: 10,
+  };
+
+  const intervals = await syncStore.getIntervals({
+    filters: [filterV2],
+  });
+
+  const filterIntervals = intervals
+    .get(filterV2)!
+    .flatMap(({ intervals }) => intervals);
+  const factoryIntervals = intervals
+    .get(factoryV2)!
+    .flatMap(({ intervals }) => intervals);
+
+  // The log filter should still see the previously synced range.
+  expect(filterIntervals).toEqual([[0, 20]]);
+
+  // The factory must NOT inherit the log filter's intervals, because the
+  // factory identity changed and no child addresses have been discovered for
+  // the new factory range. Reporting a complete interval here would cause the
+  // sync engine to skip child discovery and silently miss child events.
+  expect(factoryIntervals).toEqual([]);
 });

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -49,7 +49,6 @@ import type {
   IntervalWithFilter,
 } from "@/runtime/index.js";
 import type { Interval } from "@/utils/interval.js";
-import { intervalUnion } from "@/utils/interval.js";
 import { toLowerCase } from "@/utils/lowercase.js";
 import { orderObject } from "@/utils/order.js";
 import { startClock } from "@/utils/timer.js";
@@ -419,31 +418,6 @@ export const createSyncStore = ({
             index += 1;
 
             result.get(factory)!.push({ fragment, intervals });
-          }
-
-          // Note: This is a stand-in for a migration to the `intervals` table
-          // required in `v0.15`. It is an invariant that filter with factories
-          // have a row in the intervals table for both the filter and the factory.
-          // If this invariant is broken, it must be because of the migration from
-          // `v0.14` to `v0.15`. In this case, we can assume that the factory interval
-          // is the same as the filter interval.
-
-          const filterIntervals = intervalUnion(
-            result.get(filter)!.flatMap(({ intervals }) => intervals),
-          );
-          const factoryIntervals = intervalUnion(
-            result.get(factory)!.flatMap(({ intervals }) => intervals),
-          );
-
-          if (
-            filterIntervals.length > 0 &&
-            factoryIntervals.length === 0 &&
-            filter.fromBlock === factory.fromBlock &&
-            filter.toBlock === factory.toBlock
-          ) {
-            for (const factoryInterval of result.get(factory)!) {
-              factoryInterval.intervals = filterIntervals;
-            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixes #2271.

`getIntervals()` in `packages/core/src/sync-store/index.ts` contained a fallback (originally a stand-in for the v0.14 → v0.15 migration) that copied a log filter's cached intervals into its factory's intervals whenever the factory had no `factory_log_*` interval rows and the filter/factory `fromBlock`/`toBlock` matched.

This is unsound because the two are keyed differently in `ponder_sync.intervals`:

- Log filter rows use a `log_*` fragment ID that does **not** encode `fromBlock`/`toBlock` when the address is a factory.
- Factory rows use a `factory_log_*` fragment ID that **does** encode `fromBlock`/`toBlock`.

So a factory identity change (e.g., changing `fromBlock`, or `toBlock`) produces a new `factory_log_*` fragment with no rows, while the old `log_*` row still matches the updated filter. The fallback then fabricated complete factory intervals, causing the sync engine to skip child-address rediscovery and silently miss child contract events.

This PR removes the fallback entirely. When no `factory_log_*` rows exist, factory intervals are now reported as empty, and the truncation invariant in `runtime/index.ts` invalidates the filter's cached intervals from the first missing factory block onward, forcing rediscovery and a refetch of the affected range.

## Migration path impact

- **Apps on ≥ v0.15 with an intact cache:** No impact. Filter and factory intervals are always written together in both the historical and realtime write paths, so `factory_log_*` rows exist and behavior is unchanged (covered by a new test).
- **Apps upgrading directly from ≤ v0.14:** The migration shim this fallback provided is gone. On the first sync after upgrading, factory intervals will be reported as empty and the affected factory filters will perform a **one-time re-backfill** (child-address discovery plus refetch of logs, blocks, and transactions for the factory filter's range). This refetch is required for correctness: `eth_getLogs` for factory filters is scoped to the child set known at fetch time, so pre-existing `log_*` data can be genuinely incomplete. Note the fallback only ever helped until the first post-upgrade write anyway, since inferred intervals were never persisted.
- **Apps that changed a factory's identity (the bug scenario):** Previously missed child events silently; now they correctly rediscover child addresses and refetch the affected range.
- **Schema:** No `ponder_sync` schema migration is required, no data is deleted or corrupted, and downgrading is safe (the fallback is a pure in-memory code path).

## Tests

- Updated `getIntervals() does not copy filter intervals to factory intervals for v0.15 migration` to assert the new (empty) behavior.
- Added `getIntervals() returns factory intervals when factory_log rows exist` to pin the unchanged happy path.
- Added regression test `getIntervals() does not infer factory intervals from log filter intervals when factory identity changes` reproducing #2271.

`CI=1 pnpm --filter ponder test src/sync-store/index.test.ts` — 32/32 pass; `pnpm --filter ponder typecheck` passes.