### PR TITLE
chore: update pnpm to 11

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ gh repo fork ponder-sh/ponder --clone
 
 ## Install Node.js and pnpm
 
-Ponder uses [pnpm workspaces](https://pnpm.io/workspaces) to manage multiple projects. You need to install **Node.js v18 or higher** and **pnpm v9 or higher**.
+Ponder uses [pnpm workspaces](https://pnpm.io/workspaces) to manage multiple projects. You need to install **Node.js v18 or higher** and **pnpm v11 or higher**.
 
 You can run the following commands in your terminal to check your local Node.js and pnpm versions:
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Set up pnpm
       uses: pnpm/action-setup@v3
       with:
-        version: 9.10.0
+        version: 11
 
     - name: Set up node
       uses: actions/setup-node@v5

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 9.10.0
+          version: 11
 
       - name: Install Node
         uses: actions/setup-node@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Repository Shape
-- This is a pnpm `9.10.0` workspace; install with `pnpm install --frozen-lockfile` to match CI. Node must be `>=18.14`; CI currently uses Node `24.8` and a pinned Foundry nightly.
+- This is a pnpm `11.x` workspace; install with `pnpm install --frozen-lockfile` to match CI. Node must be `>=18.14`; CI currently uses Node `24.8` and a pinned Foundry nightly.
 - Workspace packages are `packages/*`, `docs`, `examples/**`, `simulation-test`, and `benchmark`.
 - `packages/core` publishes the `ponder` npm package. Public exports start in `packages/core/src/index.ts`; the CLI bin starts in `packages/core/src/bin/ponder.ts`.
 - `packages/core` and `packages/react` build with custom `build.ts` scripts. `packages/client`, `packages/utils`, and `packages/create-ponder` build with tsup.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   },
-  "packageManager": "pnpm@9.10.0",
+  "packageManager": "pnpm@11.0.0",
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": ["node-fetch"]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,7 @@ packages:
   - examples/**
   - packages/*
   - tmp/*
+allowBuilds:
+  '@biomejs/biome': true
+  esbuild: true
+  simple-git-hooks: true

--- a/simulation-test/AGENTS.md
+++ b/simulation-test/AGENTS.md
@@ -7,7 +7,7 @@
 - The goal is to catch regressions in sync, indexing, realtime, crash recovery, and database behavior before they reach users.
 
 ## Prerequisites
-- Use the repository toolchain from the root `AGENTS.md`: pnpm `9.10.0`, Node `>=18.14`, and Bun for this package's scripts.
+- Use the repository toolchain from the root `AGENTS.md`: pnpm `11.x`, Node `>=18.14`, and Bun for this package's scripts.
 - Install workspace dependencies from the repository root with `pnpm install`.
 - Build the publishable packages before running simulations with `pnpm build`; the simulation apps depend on the workspace `ponder` package.
 - Provide a Postgres server connection in `DATABASE_URL`. The URL should omit the app/run database name because scripts append database names themselves, for example `postgresql://postgres@localhost:55432`.


### PR DESCRIPTION
## Summary
- bump the workspace and CI toolchain to pnpm 11
- allow the required workspace packages to build under pnpm 11
- update contributor and agent guidance to match the new toolchain
