### PR TITLE
fix: simplify event query block bounds

### DIFF
--- a/.changeset/clean-event-query-bounds.md
+++ b/.changeset/clean-event-query-bounds.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved sync performance by removing redundant block range constraints from event queries.

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -1066,21 +1066,26 @@ test("getEventData() applies one block range to logs and traces queries", async 
     limit: 10,
   });
 
-  const logsQuery = querySpy.mock.calls.find(([query]) =>
-    query.includes('from "ponder_sync"."logs"'),
+  const queries = querySpy.mock.calls.map(([query, params]) =>
+    typeof query === "string"
+      ? { text: query, values: params }
+      : (query as { text: string; values: unknown[] }),
   );
-  const tracesQuery = querySpy.mock.calls.find(([query]) =>
-    query.includes('from "ponder_sync"."traces"'),
+  const logsQuery = queries.find(({ text }) =>
+    text.includes('from "ponder_sync"."logs"'),
+  );
+  const tracesQuery = queries.find(({ text }) =>
+    text.includes('from "ponder_sync"."traces"'),
   );
 
   expect(logsQuery).toBeDefined();
-  expect(logsQuery![0].match(/"block_number" >=/g)).toHaveLength(1);
-  expect(logsQuery![0].match(/"block_number" <=/g)).toHaveLength(1);
-  expect(logsQuery![1]).toEqual(expect.arrayContaining([10n, 90n]));
+  expect(logsQuery!.text.match(/"block_number" >=/g)).toHaveLength(1);
+  expect(logsQuery!.text.match(/"block_number" <=/g)).toHaveLength(1);
+  expect(logsQuery!.values).toEqual(expect.arrayContaining([10n, 90n]));
   expect(tracesQuery).toBeDefined();
-  expect(tracesQuery![0].match(/"block_number" >=/g)).toHaveLength(1);
-  expect(tracesQuery![0].match(/"block_number" <=/g)).toHaveLength(1);
-  expect(tracesQuery![1]).toEqual(expect.arrayContaining([30n, 70n]));
+  expect(tracesQuery!.text.match(/"block_number" >=/g)).toHaveLength(1);
+  expect(tracesQuery!.text.match(/"block_number" <=/g)).toHaveLength(1);
+  expect(tracesQuery!.values).toEqual(expect.arrayContaining([30n, 70n]));
 });
 
 test("getEventBlockData() pagination", async () => {

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -1025,25 +1025,11 @@ test("getFilterBlockRange() merges filter and pagination bounds", () => {
 
   expect(
     getFilterBlockRange({
-      filters: [
-        { fromBlock: 0, toBlock: 30 },
-        { fromBlock: 100, toBlock: 110 },
-      ],
+      filters: [{ fromBlock: 0, toBlock: 30 }],
       fromBlock: 20,
       toBlock: 90,
     }),
   ).toEqual({ fromBlock: 20, toBlock: 30 });
-
-  expect(
-    getFilterBlockRange({
-      filters: [
-        { fromBlock: 0, toBlock: 10 },
-        { fromBlock: 100, toBlock: 110 },
-      ],
-      fromBlock: 20,
-      toBlock: 90,
-    }),
-  ).toEqual({ fromBlock: 91, toBlock: 90 });
 
   expect(
     getFilterBlockRange({ filters: [], fromBlock: 20, toBlock: 90 }),

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -6,12 +6,13 @@ import {
   parseEther,
   zeroAddress,
 } from "viem";
-import { beforeEach, expect, test } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 import {
   ALICE,
   BOB,
   EMPTY_BLOCK_FILTER,
   EMPTY_LOG_FILTER,
+  EMPTY_TRACE_FILTER,
 } from "@/_test/constants.js";
 import { factoryABI } from "@/_test/generated.js";
 import {
@@ -39,6 +40,7 @@ import { buildLogFactory } from "@/build/factory.js";
 import { factory } from "@/config/address.js";
 import type { Factory, LogFilter } from "@/internal/types.js";
 import { orderObject } from "@/utils/order.js";
+import { getFilterBlockRange } from "./index.js";
 import * as ponderSyncSchema from "./schema.js";
 
 beforeEach(setupCommon);
@@ -996,6 +998,89 @@ test("getEventBlockData() returns events", async () => {
   });
 
   expect(blocks).toHaveLength(1);
+});
+
+test("getFilterBlockRange() merges filter and pagination bounds", () => {
+  expect(
+    getFilterBlockRange({
+      filters: [
+        { fromBlock: 10, toBlock: 80 },
+        { fromBlock: 20, toBlock: 90 },
+      ],
+      fromBlock: 0,
+      toBlock: 100,
+    }),
+  ).toEqual({ fromBlock: 10, toBlock: 90 });
+
+  expect(
+    getFilterBlockRange({
+      filters: [
+        { fromBlock: 10, toBlock: 80 },
+        { fromBlock: undefined, toBlock: undefined },
+      ],
+      fromBlock: 20,
+      toBlock: 70,
+    }),
+  ).toEqual({ fromBlock: 20, toBlock: 70 });
+
+  expect(
+    getFilterBlockRange({
+      filters: [
+        { fromBlock: 0, toBlock: 30 },
+        { fromBlock: 100, toBlock: 110 },
+      ],
+      fromBlock: 20,
+      toBlock: 90,
+    }),
+  ).toEqual({ fromBlock: 20, toBlock: 30 });
+
+  expect(
+    getFilterBlockRange({
+      filters: [
+        { fromBlock: 0, toBlock: 10 },
+        { fromBlock: 100, toBlock: 110 },
+      ],
+      fromBlock: 20,
+      toBlock: 90,
+    }),
+  ).toEqual({ fromBlock: 91, toBlock: 90 });
+
+  expect(
+    getFilterBlockRange({ filters: [], fromBlock: 20, toBlock: 90 }),
+  ).toEqual({ fromBlock: 20, toBlock: 90 });
+});
+
+test("getEventData() applies one block range to logs and traces queries", async () => {
+  const { database, syncStore } = await setupDatabaseServices();
+  const querySpy = vi.spyOn(database.syncQB.$client, "query");
+
+  await syncStore.getEventData({
+    filters: [
+      { ...EMPTY_LOG_FILTER, fromBlock: 10, toBlock: 80 },
+      { ...EMPTY_LOG_FILTER, fromBlock: 20, toBlock: 90 },
+      { ...EMPTY_TRACE_FILTER, fromBlock: 30, toBlock: 70 },
+    ],
+    fromBlock: 0,
+    toBlock: 100,
+    chainId: 1,
+    limit: 10,
+  });
+
+  const logsQuery = querySpy.mock.calls.find(([query]) =>
+    query.includes('from "ponder_sync"."logs"'),
+  );
+  const tracesQuery = querySpy.mock.calls.find(([query]) =>
+    query.includes('from "ponder_sync"."traces"'),
+  );
+
+  expect(logsQuery).toBeDefined();
+  expect(logsQuery![0].match(/"block_number" >=/g)).toHaveLength(1);
+  expect(logsQuery![0].match(/"block_number" <=/g)).toHaveLength(1);
+  expect(logsQuery![1]).toEqual(expect.arrayContaining([10n, 90n]));
+  expect(tracesQuery).toBeDefined();
+  expect(tracesQuery![0].match(/"block_number" >=/g)).toHaveLength(1);
+  expect(tracesQuery![0].match(/"block_number" <=/g)).toHaveLength(1);
+  expect(tracesQuery![1]).toEqual(expect.arrayContaining([30n, 70n]));
 });
 
 test("getEventBlockData() pagination", async () => {

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -748,18 +748,32 @@ export const createSyncStore = ({
       traces: InternalTrace[];
       cursor: number;
     }> => {
-      const logFilters = filters.filter(
+      const activeFilters = filters.filter((filter) =>
+        isFilterInBlockRange({ filter, fromBlock, toBlock }),
+      );
+      const logFilters = activeFilters.filter(
         (f): f is LogFilter => f.type === "log",
       );
-      const transactionFilters = filters.filter(
+      const transactionFilters = activeFilters.filter(
         (f): f is TransactionFilter => f.type === "transaction",
       );
-      const traceFilters = filters.filter(
+      const traceFilters = activeFilters.filter(
         (f): f is TraceFilter => f.type === "trace",
       );
-      const transferFilters = filters.filter(
+      const transferFilters = activeFilters.filter(
         (f): f is TransferFilter => f.type === "transfer",
       );
+
+      const logBlockRange = getFilterBlockRange({
+        filters: logFilters,
+        fromBlock,
+        toBlock,
+      });
+      const traceBlockRange = getFilterBlockRange({
+        filters: [...traceFilters, ...transferFilters],
+        fromBlock,
+        toBlock,
+      });
 
       const shouldQueryBlocks = true;
       const shouldQueryLogs = logFilters.length > 0;
@@ -767,7 +781,7 @@ export const createSyncStore = ({
         traceFilters.length > 0 || transferFilters.length > 0;
       const shouldQueryTransactions =
         transactionFilters.length > 0 || shouldQueryLogs || shouldQueryTraces;
-      const shouldQueryTransactionReceipts = filters.some(
+      const shouldQueryTransactionReceipts = activeFilters.some(
         (filter) => filter.hasTransactionReceipt,
       );
 
@@ -913,8 +927,14 @@ export const createSyncStore = ({
         .where(
           and(
             eq(PONDER_SYNC.traces.chainId, BigInt(chainId)),
-            gte(PONDER_SYNC.traces.blockNumber, BigInt(fromBlock)),
-            lte(PONDER_SYNC.traces.blockNumber, BigInt(toBlock)),
+            gte(
+              PONDER_SYNC.traces.blockNumber,
+              BigInt(traceBlockRange.fromBlock),
+            ),
+            lte(
+              PONDER_SYNC.traces.blockNumber,
+              BigInt(traceBlockRange.toBlock),
+            ),
             or(
               ...traceFilters.map((filter) => traceFilter(filter)),
               ...transferFilters.map((filter) => transferFilter(filter)),
@@ -944,8 +964,8 @@ export const createSyncStore = ({
         .where(
           and(
             eq(PONDER_SYNC.logs.chainId, BigInt(chainId)),
-            gte(PONDER_SYNC.logs.blockNumber, BigInt(fromBlock)),
-            lte(PONDER_SYNC.logs.blockNumber, BigInt(toBlock)),
+            gte(PONDER_SYNC.logs.blockNumber, BigInt(logBlockRange.fromBlock)),
+            lte(PONDER_SYNC.logs.blockNumber, BigInt(logBlockRange.toBlock)),
             or(...logFilters.map((filter) => logFilter(filter))),
           ),
         )
@@ -1481,6 +1501,44 @@ const addressFilter = (
   return sql`true`;
 };
 
+export const getFilterBlockRange = ({
+  filters,
+  fromBlock,
+  toBlock,
+}: {
+  filters: Pick<Filter, "fromBlock" | "toBlock">[];
+  fromBlock: number;
+  toBlock: number;
+}) => {
+  if (filters.length === 0) return { fromBlock, toBlock };
+
+  const ranges = filters
+    .map((filter) => ({
+      fromBlock: Math.max(fromBlock, filter.fromBlock ?? fromBlock),
+      toBlock: Math.min(toBlock, filter.toBlock ?? toBlock),
+    }))
+    .filter((range) => range.fromBlock <= range.toBlock);
+
+  if (ranges.length === 0) return { fromBlock: toBlock + 1, toBlock };
+
+  return {
+    fromBlock: Math.min(...ranges.map((range) => range.fromBlock)),
+    toBlock: Math.max(...ranges.map((range) => range.toBlock)),
+  };
+};
+
+const isFilterInBlockRange = ({
+  filter,
+  fromBlock,
+  toBlock,
+}: {
+  filter: Pick<Filter, "fromBlock" | "toBlock">;
+  fromBlock: number;
+  toBlock: number;
+}) =>
+  (filter.fromBlock ?? Number.NEGATIVE_INFINITY) <= toBlock &&
+  (filter.toBlock ?? Number.POSITIVE_INFINITY) >= fromBlock;
+
 export const logFilter = (filter: LogFilter): SQL => {
   const conditions: SQL[] = [];
 
@@ -1498,15 +1556,6 @@ export const logFilter = (filter: LogFilter): SQL => {
 
   conditions.push(addressFilter(filter.address, PONDER_SYNC.logs.address));
 
-  if (filter.fromBlock !== undefined) {
-    conditions.push(
-      gte(PONDER_SYNC.logs.blockNumber, BigInt(filter.fromBlock!)),
-    );
-  }
-  if (filter.toBlock !== undefined) {
-    conditions.push(lte(PONDER_SYNC.logs.blockNumber, BigInt(filter.toBlock!)));
-  }
-
   return and(...conditions)!;
 };
 
@@ -1516,13 +1565,6 @@ export const blockFilter = (filter: BlockFilter): SQL => {
   conditions.push(
     sql`(blocks.number - ${filter.offset}) % ${filter.interval} = 0`,
   );
-
-  if (filter.fromBlock !== undefined) {
-    conditions.push(gte(PONDER_SYNC.blocks.number, BigInt(filter.fromBlock!)));
-  }
-  if (filter.toBlock !== undefined) {
-    conditions.push(lte(PONDER_SYNC.blocks.number, BigInt(filter.toBlock!)));
-  }
 
   return and(...conditions)!;
 };
@@ -1535,17 +1577,6 @@ export const transactionFilter = (filter: TransactionFilter): SQL => {
   );
   conditions.push(addressFilter(filter.toAddress, PONDER_SYNC.transactions.to));
 
-  if (filter.fromBlock !== undefined) {
-    conditions.push(
-      gte(PONDER_SYNC.transactions.blockNumber, BigInt(filter.fromBlock!)),
-    );
-  }
-  if (filter.toBlock !== undefined) {
-    conditions.push(
-      lte(PONDER_SYNC.transactions.blockNumber, BigInt(filter.toBlock!)),
-    );
-  }
-
   return and(...conditions)!;
 };
 
@@ -1557,17 +1588,6 @@ export const transferFilter = (filter: TransferFilter): SQL => {
 
   if (filter.includeReverted === false) {
     conditions.push(isNull(PONDER_SYNC.traces.error));
-  }
-
-  if (filter.fromBlock !== undefined) {
-    conditions.push(
-      gte(PONDER_SYNC.traces.blockNumber, BigInt(filter.fromBlock!)),
-    );
-  }
-  if (filter.toBlock !== undefined) {
-    conditions.push(
-      lte(PONDER_SYNC.traces.blockNumber, BigInt(filter.toBlock!)),
-    );
   }
 
   return and(...conditions)!;
@@ -1590,17 +1610,6 @@ export const traceFilter = (filter: TraceFilter): SQL => {
   if (filter.functionSelector !== undefined) {
     conditions.push(
       eq(sql`substring(traces.input from 1 for 10)`, filter.functionSelector),
-    );
-  }
-
-  if (filter.fromBlock !== undefined) {
-    conditions.push(
-      gte(PONDER_SYNC.traces.blockNumber, BigInt(filter.fromBlock!)),
-    );
-  }
-  if (filter.toBlock !== undefined) {
-    conditions.push(
-      lte(PONDER_SYNC.traces.blockNumber, BigInt(filter.toBlock!)),
     );
   }
 

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -1512,14 +1512,11 @@ export const getFilterBlockRange = ({
 }) => {
   if (filters.length === 0) return { fromBlock, toBlock };
 
-  const ranges = filters
-    .map((filter) => ({
-      fromBlock: Math.max(fromBlock, filter.fromBlock ?? fromBlock),
-      toBlock: Math.min(toBlock, filter.toBlock ?? toBlock),
-    }))
-    .filter((range) => range.fromBlock <= range.toBlock);
-
-  if (ranges.length === 0) return { fromBlock: toBlock + 1, toBlock };
+  // Callers prefilter these to filters that overlap the pagination range.
+  const ranges = filters.map((filter) => ({
+    fromBlock: Math.max(fromBlock, filter.fromBlock ?? fromBlock),
+    toBlock: Math.min(toBlock, filter.toBlock ?? toBlock),
+  }));
 
   return {
     fromBlock: Math.min(...ranges.map((range) => range.fromBlock)),

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -1501,6 +1501,9 @@ const addressFilter = (
   return sql`true`;
 };
 
+/**
+ * @dev It's an invariant that the returned `fromBlock <= toBlock`.
+ */
 export const getFilterBlockRange = ({
   filters,
   fromBlock,
@@ -1512,7 +1515,6 @@ export const getFilterBlockRange = ({
 }) => {
   if (filters.length === 0) return { fromBlock, toBlock };
 
-  // Callers prefilter these to filters that overlap the pagination range.
   const ranges = filters.map((filter) => ({
     fromBlock: Math.max(fromBlock, filter.fromBlock ?? fromBlock),
     toBlock: Math.min(toBlock, filter.toBlock ?? toBlock),


### PR DESCRIPTION
## Summary
- merge filter block ranges with pagination so logs and traces queries contain exactly one lower and upper block bound
- skip filters that do not overlap the current page and preserve exact per-filter range checks in memory
- leave event-specific `OR` predicates in place; a follow-up can evaluate merging them with `IN` expressions or dropping very large predicate sets in favor of in-memory filtering

Closes #2208.