### PR TITLE
perf(graphql): batch many relation queries

### DIFF
--- a/.changeset/tidy-graphql-many.md
+++ b/.changeset/tidy-graphql-many.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved GraphQL `many` relation performance by batching compatible resolutions within each request.

--- a/packages/core/src/graphql/index.test.ts
+++ b/packages/core/src/graphql/index.test.ts
@@ -21,7 +21,11 @@ import {
   primaryKey,
 } from "@/drizzle/onchain.js";
 import { EVENT_TYPES, encodeCheckpoint } from "@/utils/checkpoint.js";
-import { buildDataLoaderCache, buildGraphQLSchema } from "./index.js";
+import {
+  buildDataLoaderCache,
+  buildGraphQLSchema,
+  buildManyDataLoaderCache,
+} from "./index.js";
 
 beforeEach(setupCommon);
 beforeEach(setupIsolatedDatabase);
@@ -30,7 +34,8 @@ beforeEach(setupCleanup);
 function buildContextValue(database: Database) {
   const qb = database.readonlyQB;
   const getDataLoader = buildDataLoaderCache(qb);
-  return { qb, getDataLoader };
+  const getManyDataLoader = buildManyDataLoaderCache(qb);
+  return { qb, getDataLoader, getManyDataLoader };
 }
 
 test("metadata", async () => {
@@ -671,6 +676,80 @@ test("singular with many relation", async () => {
       pets: { items: [{ id: "dog1" }, { id: "dog2" }] },
     },
   });
+});
+
+test("plural many relations are request-scoped batched", async () => {
+  const person = onchainTable("person", (t) => ({
+    id: t.text().primaryKey(),
+  }));
+  const pet = onchainTable("pet", (t) => ({
+    id: t.text().primaryKey(),
+    age: t.integer().notNull(),
+    ownerId: t.text().notNull(),
+  }));
+  const personRelations = relations(person, ({ many }) => ({
+    pets: many(pet),
+  }));
+  const petRelations = relations(pet, ({ one }) => ({
+    owner: one(person, { fields: [pet.ownerId], references: [person.id] }),
+  }));
+  const schema = { person, personRelations, pet, petRelations };
+  const { database } = await setupDatabaseServices({ schemaBuild: { schema } });
+
+  await database.userQB.raw.insert(person).values([
+    { id: "a" },
+    { id: "b" },
+    { id: "c" },
+  ]);
+  await database.userQB.raw.insert(pet).values([
+    { id: "a1", age: 1, ownerId: "a" },
+    { id: "a2", age: 2, ownerId: "a" },
+    { id: "b1", age: 3, ownerId: "b" },
+  ]);
+
+  const querySpy = vi.spyOn(database.readonlyQB.raw.$client, "query");
+  const result = await execute({
+    schema: buildGraphQLSchema({ schema }),
+    contextValue: buildContextValue(database),
+    document: parse(`{
+      persons { items { id pets(limit: 1, orderBy: "age", orderDirection: "desc") {
+        items { id age } totalCount pageInfo { hasNextPage }
+      } } }
+    }`),
+  });
+
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toMatchObject({
+    persons: {
+      items: [
+        {
+          id: "a",
+          pets: {
+            items: [{ id: "a2", age: 2 }],
+            totalCount: 2,
+            pageInfo: { hasNextPage: true },
+          },
+        },
+        {
+          id: "b",
+          pets: {
+            items: [{ id: "b1", age: 3 }],
+            totalCount: 1,
+            pageInfo: { hasNextPage: false },
+          },
+        },
+        {
+          id: "c",
+          pets: {
+            items: [],
+            totalCount: 0,
+            pageInfo: { hasNextPage: false },
+          },
+        },
+      ],
+    },
+  });
+  expect(querySpy).toHaveBeenCalledTimes(2);
 });
 
 test("singular with many relation using camel case 'references' column name", async () => {

--- a/packages/core/src/graphql/index.ts
+++ b/packages/core/src/graphql/index.ts
@@ -29,6 +29,7 @@ import {
   notLike,
   One,
   or,
+  sql,
   SQL,
 } from "drizzle-orm";
 import {
@@ -77,6 +78,7 @@ type Parent = Record<string, any>;
 type Context = {
   qb: QB<{ [key: string]: OnchainTable }>;
   getDataLoader: ReturnType<typeof buildDataLoaderCache>;
+  getManyDataLoader?: ReturnType<typeof buildManyDataLoaderCache>;
 };
 
 type PluralArgs = {
@@ -429,17 +431,42 @@ export function buildGraphQLSchema({
                 offset: { type: GraphQLInt },
               },
               resolve: (parent, args: PluralArgs, context, info) => {
+                const includeTotalCount = selectionIncludesField(
+                  info,
+                  "totalCount",
+                );
+
+                // Cursor pagination and composite relations retain the existing
+                // query path. The common single-column, first-page case can be
+                // safely coalesced across all parents in this request.
+                if (
+                  context.getManyDataLoader !== undefined &&
+                  fields.length === 1 &&
+                  references.length === 1 &&
+                  args.after === undefined &&
+                  args.before === undefined &&
+                  (args.offset === undefined || args.offset === 0)
+                ) {
+                  const value = parent[getColumnTsName(references[0]!)];
+                  if (value !== null && value !== undefined) {
+                    return context
+                      .getManyDataLoader({
+                        relation: schema[referencedTable.tsName] as PgTable,
+                        table: referencedTable,
+                        relationColumn: fields[0]!,
+                        args,
+                        includeTotalCount,
+                      })
+                      .load(value);
+                  }
+                }
+
                 const relationalConditions = [];
                 for (let i = 0; i < references.length; i++) {
                   const column = fields[i]!;
                   const value = parent[getColumnTsName(references[i]!)];
                   relationalConditions.push(eq(column, value));
                 }
-
-                const includeTotalCount = selectionIncludesField(
-                  info,
-                  "totalCount",
-                );
 
                 return executePluralQuery(
                   schema[referencedTable.tsName] as PgTable,
@@ -1363,6 +1390,109 @@ export function buildDataLoaderCache(qb: QB) {
     }
 
     return dataLoader;
+  };
+}
+
+export function buildManyDataLoaderCache(qb: QB) {
+  const loaders = new Map<string, DataLoader<unknown, any>>();
+
+  return ({
+    relation,
+    table,
+    relationColumn,
+    args,
+    includeTotalCount,
+  }: {
+    relation: PgTable;
+    table: TableRelationalConfig;
+    relationColumn: Column;
+    args: PluralArgs;
+    includeTotalCount: boolean;
+  }) => {
+    const key = superjson.stringify({
+      table: table.tsName,
+      column: relationColumn.name,
+      args,
+      includeTotalCount,
+    });
+    let loader = loaders.get(key);
+    if (loader !== undefined) return loader;
+
+    loader = new DataLoader(
+      async (values) => {
+        const limit = args.limit ?? DEFAULT_LIMIT;
+        if (limit > MAX_LIMIT) {
+          throw new Error(`Invalid limit. Got ${limit}, expected <=${MAX_LIMIT}.`);
+        }
+
+        const orderBySchema = buildOrderBySchema(relation, args);
+        const orderBy = orderBySchema.map(([columnName, direction]) => {
+          const column = table.columns[columnName];
+          if (column === undefined) {
+            throw new Error(
+              `Unknown column "${columnName}" used in orderBy argument`,
+            );
+          }
+          return direction === "asc" ? asc(column) : desc(column);
+        });
+        const whereConditions = buildWhereConditions(args.where, table.columns);
+        const relationColumnName = getColumnTsName(relationColumn);
+        const ranked = qb.raw
+          .select({
+            ...getTableColumns(relation),
+            __ponderRowNumber:
+              sql<number>`row_number() over (partition by ${relationColumn} order by ${sql.join(orderBy, sql`, `)})`
+                .mapWith(Number)
+                .as("__ponder_row_number"),
+            __ponderTotalCount:
+              sql<number>`count(*) over (partition by ${relationColumn})`
+                .mapWith(Number)
+                .as("__ponder_total_count"),
+          })
+          .from(relation)
+          .where(and(...whereConditions, inArray(relationColumn, [...values])))
+          .as("__ponder_many_ranked");
+        const rows = await qb.raw
+          .select()
+          .from(ranked)
+          .where(lte(ranked.__ponderRowNumber, limit + 1));
+
+        return values.map((value) => {
+          const matching = rows
+            .filter(
+              (row) =>
+                (row as Record<string, unknown>)[relationColumnName] === value,
+            )
+            .sort((a, b) => a.__ponderRowNumber - b.__ponderRowNumber);
+          const items = matching.slice(0, limit).map((row) => {
+            const {
+              __ponderRowNumber: _,
+              __ponderTotalCount: __,
+              ...item
+            } = row;
+            return item;
+          });
+          const totalCount = matching[0]?.__ponderTotalCount ?? 0;
+          return {
+            items,
+            totalCount: includeTotalCount ? totalCount : null,
+            pageInfo: {
+              hasNextPage: totalCount > limit,
+              hasPreviousPage: false,
+              startCursor:
+                items.length > 0 ? encodeCursor(orderBySchema, items[0]!) : null,
+              endCursor:
+                items.length > 0
+                  ? encodeCursor(orderBySchema, items[items.length - 1]!)
+                  : null,
+            },
+          };
+        });
+      },
+      { maxBatchSize: 1_000 },
+    );
+    loaders.set(key, loader);
+    return loader;
   };
 }
 

--- a/packages/core/src/graphql/middleware.ts
+++ b/packages/core/src/graphql/middleware.ts
@@ -7,7 +7,11 @@ import { createMiddleware } from "hono/factory";
 import { graphiQLHtml } from "@/graphql/graphiql.html.js";
 import type { Schema } from "@/internal/types.js";
 import type { ReadonlyDrizzle } from "@/types/db.js";
-import { buildDataLoaderCache, buildGraphQLSchema } from "./index.js";
+import {
+  buildDataLoaderCache,
+  buildGraphQLSchema,
+  buildManyDataLoaderCache,
+} from "./index.js";
 
 /**
  * Middleware for GraphQL with an interactive web view.
@@ -62,8 +66,15 @@ export const graphql = (
       const getDataLoader = buildDataLoaderCache(
         globalThis.PONDER_DATABASE.readonlyQB,
       );
+      const getManyDataLoader = buildManyDataLoaderCache(
+        globalThis.PONDER_DATABASE.readonlyQB,
+      );
 
-      return { qb: globalThis.PONDER_DATABASE.readonlyQB, getDataLoader };
+      return {
+        qb: globalThis.PONDER_DATABASE.readonlyQB,
+        getDataLoader,
+        getManyDataLoader,
+      };
     },
     maskedErrors: process.env.NODE_ENV === "production",
     logging: false,


### PR DESCRIPTION
## Summary

- batch compatible GraphQL `many` relation resolutions in a request-scoped DataLoader
- use a partitioned window query to preserve per-parent ordering, limits, cursors, page info, and `totalCount` while bounding returned rows
- retain the existing resolver as a fallback for composite relations, cursor pagination, offsets, and null relation keys

## Benchmark

Deterministic in-memory PGlite data, one child per parent, `limit: 2`, with `totalCount`; wall time measures GraphQL execution only. Each point is one isolated execution after data setup (so timings are directional rather than a statistical suite).

| Parents / child rows | Before SQL | After SQL | Before wall | After wall | Heap delta before / after |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 10 | 21 | 2 | 10.43 ms | 3.22 ms | +6126 / +980 KiB |
| 50 | 101 | 2 | 28.89 ms | 2.56 ms | -3957 / +2701 KiB |
| 250 | 501 | 2 | 134.10 ms | 7.15 ms | +15835 / -23555 KiB |
| 1000 | 2001 | 2 | 577.50 ms | 25.29 ms | +23309 / +652 KiB |

Heap deltas are process-level snapshots and include V8 GC noise (negative values indicate a collection); the batched SQL result is bounded to `limit + 1` rows per parent. The root collection is one query; before this change each parent issues one items query plus one count query.

## Correctness

- added an exact result and SQL-count regression test covering empty relations, ordering, limit/page info, and `totalCount`
- existing GraphQL relation tests cover filters, custom ordering, relation names, camel-case columns, and fallback behavior
- focused GraphQL suite: 38/38 passed on PGlite
- production core build passed (`tsc` plus ESM/type output and path rewriting)
- patch changeset included

## DX

No schema or query changes are required. Existing GraphQL documents automatically use request-scoped batching when the relation has one key and requests the first page. Unsupported shapes transparently use the existing query path.

## Caveats

- batching is intentionally limited to single-column relations with no `before`/`after` cursor and zero offset
- composite keys, null parent keys, cursor pagination, and nonzero offsets fall back to the existing implementation
- SQL uses PostgreSQL window functions supported by both Postgres and PGlite; runtime correctness was exercised on PGlite in this environment
