### PR TITLE
perf: consolidate sync interval retrieval

### DIFF
--- a/.changeset/fast-interval-queries.md
+++ b/.changeset/fast-interval-queries.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved sync interval retrieval performance for configurations with many filter fragments.

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -424,6 +424,40 @@ test("getIntervals() returns factory intervals when factory_log rows exist", asy
   expect(intervals.get(factory)![0]!.intervals).toEqual([[10, 20]]);
 });
 
+test("getIntervals() retrieves many fragments in one statement", async () => {
+  const { database, syncStore } = await setupDatabaseServices();
+  const filter = {
+    ...EMPTY_LOG_FILTER,
+    address: Array.from(
+      { length: 100 },
+      (_, index) => `0x${index.toString(16).padStart(40, "0")}` as const,
+    ),
+  } satisfies LogFilter;
+
+  await syncStore.insertIntervals({
+    intervals: [{ filter, interval: [0, 10] }],
+    factoryIntervals: [],
+    chainId: 1,
+  });
+
+  const wrap = vi.spyOn(database.syncQB, "wrap");
+  const intervals = await syncStore.getIntervals({ filters: [filter] });
+
+  expect(
+    wrap.mock.calls.filter(
+      ([options]) =>
+        typeof options === "object" &&
+        options !== null &&
+        "label" in options &&
+        options.label === "select_intervals",
+    ),
+  ).toHaveLength(1);
+  expect(intervals.get(filter)).toHaveLength(100);
+  expect(intervals.get(filter)!.map(({ intervals }) => intervals)).toEqual(
+    Array.from({ length: 100 }, () => [[0, 10]]),
+  );
+});
+
 test("insertIntervals() merges duplicates", async () => {
   const { syncStore } = await setupDatabaseServices();
 

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -13,11 +13,7 @@ import {
   type SQL,
   sql,
 } from "drizzle-orm";
-import {
-  type PgColumn,
-  type PgSelectBase,
-  unionAll,
-} from "drizzle-orm/pg-core";
+import type { PgColumn } from "drizzle-orm/pg-core";
 import { type Address, hexToNumber, isHex } from "viem";
 import type { QB } from "@/database/queryBuilder.js";
 import { extractBlockNumberParam } from "@/indexing/client.js";
@@ -280,97 +276,90 @@ export const createSyncStore = ({
       }
     },
     getIntervals: async ({ filters }, context) => {
-      const queries: PgSelectBase<
-        "unnested",
-        {
-          mergedBlocks: SQL.Aliased<string>;
-          fragment: SQL.Aliased<unknown>;
-        },
-        "partial"
-      >[] = [];
-      let index = 0;
+      const requests: {
+        fragmentIds: FragmentId[];
+        fragment: Fragment;
+      }[] = [];
 
       for (const filter of filters) {
-        const fragments = getFragments(filter);
-
-        for (const fragment of fragments) {
-          queries.push(
-            qb.raw
-              .select({
-                mergedBlocks: sql<string>`range_agg(unnested.blocks)`.as(
-                  "merged_blocks",
-                ),
-                fragment: sql.raw(`'${index++}'`).as("fragment"),
-              })
-              .from(
-                qb.raw
-                  .select({ blocks: sql.raw("unnest(blocks)").as("blocks") })
-                  .from(PONDER_SYNC.intervals)
-                  .where(
-                    sql.raw(
-                      `fragment_id IN (${fragment.adjacentIds.map((id) => `'${id}'`).join(", ")})`,
-                    ),
-                  )
-                  .as("unnested"),
-              ),
-          );
+        for (const fragment of getFragments(filter)) {
+          requests.push({
+            fragmentIds: fragment.adjacentIds,
+            fragment: fragment.fragment,
+          });
         }
 
         for (const factory of getFilterFactories(filter)) {
           for (const fragment of getFactoryFragments(factory)) {
-            queries.push(
-              qb.raw
-                .select({
-                  mergedBlocks: sql<string>`range_agg(unnested.blocks)`.as(
-                    "merged_blocks",
-                  ),
-                  fragment: sql.raw(`'${index++}'`).as("fragment"),
-                })
-                .from(
-                  qb.raw
-                    .select({
-                      blocks: sql.raw("unnest(blocks)").as("blocks"),
-                    })
-                    .from(PONDER_SYNC.intervals)
-                    .where(
-                      sql.raw(`fragment_id = '${encodeFragment(fragment)}'`),
-                    )
-                    .as("unnested"),
-                ),
-            );
+            requests.push({
+              fragmentIds: [encodeFragment(fragment)],
+              fragment,
+            });
           }
         }
       }
 
-      let rows: Awaited<(typeof queries)[number]> = [];
+      const intervalsByRequest: Interval[][] = Array.from(
+        { length: requests.length },
+        () => [],
+      );
+      const maxMappings = Math.floor(
+        common.options.databaseMaxQueryParameters / 2,
+      );
 
-      if (queries.length > 1) {
-        // Note: This query has no parameters, but there is a bug with
-        // drizzle causing a "maximum call stack size exceeded" error.
-        // Related: https://github.com/drizzle-team/drizzle-orm/issues/1740
-        const batchSize = 200;
+      for (let start = 0; start < requests.length; ) {
+        let end = start;
+        let mappingCount = 0;
 
-        for (let i = 0; i < queries.length; i += batchSize) {
-          const _rows = await qb.wrap(
-            { label: "select_intervals" },
-            () =>
-              // @ts-expect-error
-              unionAll(...queries.slice(i, i + batchSize)),
-            context,
-          );
-
-          if (i === 0) {
-            rows = _rows;
-          } else {
-            rows.push(..._rows);
-          }
+        while (end < requests.length) {
+          const nextCount = requests[end]!.fragmentIds.length;
+          if (end > start && mappingCount + nextCount > maxMappings) break;
+          mappingCount += nextCount;
+          end++;
         }
-      } else {
-        rows = await qb.wrap(
+
+        const mappings = requests
+          .slice(start, end)
+          .flatMap((request, offset) =>
+            request.fragmentIds.map(
+              (fragmentId) => sql`(${start + offset}, ${fragmentId})`,
+            ),
+          );
+        const query = sql<{
+          requestId: number;
+          mergedBlocks: string | null;
+        }>`
+          WITH requests(request_id, fragment_id) AS (
+            VALUES ${sql.join(mappings, sql`, `)}
+          )
+          SELECT
+            requests.request_id AS "requestId",
+            range_agg(unnested.block) AS "mergedBlocks"
+          FROM requests
+          LEFT JOIN ${PONDER_SYNC.intervals}
+            ON ${PONDER_SYNC.intervals.fragmentId} = requests.fragment_id
+          LEFT JOIN LATERAL unnest(${PONDER_SYNC.intervals.blocks}) AS unnested(block)
+            ON true
+          GROUP BY requests.request_id
+          ORDER BY requests.request_id
+        `;
+        const { rows } = (await qb.wrap(
           { label: "select_intervals" },
-          () => queries[0]!.execute(),
+          (db) => db.execute(query),
           context,
-        );
+        )) as {
+          rows: { requestId: number; mergedBlocks: string | null }[];
+        };
+
+        for (const row of rows) {
+          intervalsByRequest[row.requestId] = row.mergedBlocks
+            ? (
+                JSON.parse(`[${row.mergedBlocks.slice(1, -1)}]`) as Interval[]
+              ).map((interval) => [interval[0], interval[1] - 1] as Interval)
+            : [];
+        }
+
+        start = end;
       }
 
       const result = new Map<
@@ -381,46 +370,27 @@ export const createSyncStore = ({
       // NOTE: `interval[1]` must be rounded down in order to offset the previous
       // rounding.
 
-      index = 0;
-
+      let index = 0;
       for (const filter of filters) {
-        const fragments = getFragments(filter);
         result.set(filter, []);
-
-        for (const fragment of fragments) {
-          const intervals = rows
-            .filter((row) => row.fragment === `${index}`)
-            .map((row) =>
-              (row.mergedBlocks
-                ? (JSON.parse(
-                    `[${row.mergedBlocks.slice(1, -1)}]`,
-                  ) as Interval[])
-                : []
-              ).map((interval) => [interval[0], interval[1] - 1] as Interval),
-            )[0]!;
-
-          index += 1;
-
-          result.get(filter)!.push({ fragment: fragment.fragment, intervals });
+        for (let i = 0; i < getFragments(filter).length; i++) {
+          const { fragment } = requests[index]!;
+          result.get(filter)!.push({
+            fragment,
+            intervals: intervalsByRequest[index]!,
+          });
+          index++;
         }
 
         for (const factory of getFilterFactories(filter)) {
           result.set(factory, []);
-          for (const fragment of getFactoryFragments(factory)) {
-            const intervals = rows
-              .filter((row) => row.fragment === `${index}`)
-              .map((row) =>
-                (row.mergedBlocks
-                  ? (JSON.parse(
-                      `[${row.mergedBlocks.slice(1, -1)}]`,
-                    ) as Interval[])
-                  : []
-                ).map((interval) => [interval[0], interval[1] - 1] as Interval),
-              )[0]!;
-
-            index += 1;
-
-            result.get(factory)!.push({ fragment, intervals });
+          for (let i = 0; i < getFactoryFragments(factory).length; i++) {
+            const { fragment } = requests[index]!;
+            result.get(factory)!.push({
+              fragment,
+              intervals: intervalsByRequest[index]!,
+            });
+            index++;
           }
         }
       }


### PR DESCRIPTION
## Summary

- replace one `range_agg` subquery per sync fragment with a relational `(request_id, fragment_id)` request map joined once to `ponder_sync.intervals`
- map result rows by request id in linear time instead of rescanning all rows for every fragment
- retain parameter-limit batching and the existing fragment/factory output identity and ordering
- add a query-count/equivalence test and a patch changeset

## Benchmark

Postgres 17 (Docker, local), Node 26.5, two adjacent interval rows per requested fragment (`[0,10]` and overlapping `[5,15]`). SQL numbers are sums across all batches from `EXPLAIN (ANALYZE, FORMAT JSON, TIMING OFF)`. JS formatting uses equivalent returned multirange rows; memory is heap growth after forced GC. One measured run after setup (directional, not a statistically rigorous suite).

| Fragments | Statements old → new | SQL bytes old → new | Planning ms old → new | Execution ms old → new | JS format ms old → new | Heap MB old → new |
|---:|---:|---:|---:|---:|---:|---:|
| 100 | 1 → 1 | 15,359 → 2,439 | 1.323 → 0.456 | 2.283 → 0.380 | 0.205 → 0.059 | 0.094 → 0.046 |
| 1,000 | 5 → 1 | 156,615 → 25,839 | 12.939 → 0.543 | 69.842 → 1.787 | 6.175 → 0.196 | 0.800 → 0.414 |
| 5,000 | 25 → 1 | 796,395 → 145,839 | 65.023 → 2.715 | 346.702 → 25.054 | 132.742 → 0.895 | 3.984 → 2.016 |
| 20,000 | 100 → 3 | 3,225,570 → 636,397 | 239.424 → 10.632 | 2,355.402 → 59.218 | 2,158.177 → 2.734 | 15.776 → 7.963 |

The old/new JS outputs were byte-equivalent at every size. The new statement count at 20k reflects the existing 16k parameter limit (two parameters per request mapping).

## Compatibility & DX

- Adjacent fragment ids remain separate request-map rows grouped by the original request id, so overlapping and adjacent ranges still aggregate together.
- Factory fragment requests use the same map but remain separate from filter fragments.
- `LEFT JOIN` preserves fragments with no stored intervals as `[]`.
- Existing result assembly order and object-key identity are unchanged.
- The query was exercised directly on both Postgres 17 and PGlite, including an absent fragment and overlapping adjacent ids.
- Large configs now generate compact, conventional relational SQL instead of deeply repeated `UNION ALL` aggregation subqueries, which also makes traces/query logs easier to inspect.

## Validation

- `CI=1 pnpm --filter ponder test src/sync-store/index.test.ts` — 35 passed
- `pnpm --filter ponder typecheck` — passed
- `pnpm build` — passed (all publishable packages)
- `pnpm --filter ponder build` — passed after final source edits
- Biome check/write on changed TypeScript files — passed
- focused PGlite SQL compatibility smoke test — passed
