### PR TITLE
fix: persist realtime factory child addresses

### DIFF
--- a/.changeset/fuzzy-factories-persist.md
+++ b/.changeset/fuzzy-factories-persist.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug that caused realtime-discovered factory child addresses to be omitted from `ponder_sync.factory_addresses` when a factory was shared across multiple event handlers.

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -1,9 +1,11 @@
-import { type Hex, parseEther } from "viem";
+import { getAbiItem, type Hex, parseEther } from "viem";
 import { beforeEach, expect, test, vi } from "vitest";
 import { ALICE, BOB } from "@/_test/constants.js";
+import { erc20ABI } from "@/_test/generated.js";
 import {
   context,
   setupAnvil,
+  setupChildAddresses,
   setupCleanup,
   setupCommon,
   setupDatabaseServices,
@@ -26,7 +28,8 @@ import {
   getErc20IndexingBuild,
   getPairWithFactoryIndexingBuild,
 } from "@/_test/utils.js";
-import type { LogFactory, LogFilter } from "@/internal/types.js";
+import { buildLogFactory } from "@/build/factory.js";
+import type { EventCallback, LogFactory, LogFilter } from "@/internal/types.js";
 import { eth_getBlockByNumber } from "@/rpc/actions.js";
 import { createRpc } from "@/rpc/index.js";
 import { drainAsyncGenerator } from "@/utils/generators.js";
@@ -461,6 +464,86 @@ test("handleBlock() block event with log factory", async () => {
 
   expect(data[0]?.transactions).toHaveLength(0);
   expect(data[1]?.transactions).toHaveLength(1);
+});
+
+test("handleBlock() block event with factories shared by callbacks", async () => {
+  const { common } = context;
+  await setupDatabaseServices();
+
+  const chain = getChain({ finalityBlockCount: 2 });
+  const rpc = createRpc({ common, chain });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  const { block: finalizedBlock } = await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+  const { block } = await transferErc20({
+    erc20: address,
+    to: BOB,
+    amount: 1n,
+    sender: ALICE,
+  });
+
+  const event = getAbiItem({ abi: erc20ABI, name: "Transfer" });
+  const fromFactory = buildLogFactory({
+    address,
+    event,
+    parameter: "from",
+    chainId: chain.id,
+    sourceId: "From",
+    fromBlock: undefined,
+    toBlock: undefined,
+  });
+  const toFactory = buildLogFactory({
+    address,
+    event,
+    parameter: "to",
+    chainId: chain.id,
+    sourceId: "To",
+    fromBlock: undefined,
+    toBlock: undefined,
+  });
+
+  const { eventCallbacks: templateCallbacks } = getErc20IndexingBuild({
+    address,
+  });
+  const templateCallback = templateCallbacks[0];
+  const templateFilter = templateCallback.filter as LogFilter;
+  const fromCallback = {
+    ...templateCallback,
+    filter: { ...templateFilter, address: fromFactory },
+  } satisfies EventCallback;
+  const eventCallbacks = [
+    fromCallback,
+    { ...fromCallback, name: `${fromCallback.name}:duplicate` },
+    {
+      ...templateCallback,
+      filter: { ...templateFilter, address: toFactory },
+    },
+  ] satisfies EventCallback[];
+
+  const realtimeSync = createRealtimeSync({
+    common,
+    chain,
+    rpc,
+    eventCallbacks,
+    syncProgress: { finalized: finalizedBlock },
+    childAddresses: setupChildAddresses(eventCallbacks),
+  });
+
+  const [blockEvent] = (await drainAsyncGenerator(
+    realtimeSync.sync(block),
+  )) as Extract<RealtimeSyncEvent, { type: "block" }>[];
+
+  expect(blockEvent?.childAddresses.get(fromFactory)).toEqual(
+    new Set([ALICE.toLowerCase()]),
+  );
+  expect(blockEvent?.childAddresses.get(toFactory)).toEqual(
+    new Set([BOB.toLowerCase()]),
+  );
 });
 
 test("handleBlock() block event with log factory and no address", async () => {

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -128,6 +128,7 @@ export const createRealtimeSync = (
   const realtimeSyncLock = createLock();
 
   const factories: Factory[] = [];
+  const factoryIds = new Set<FactoryId>();
   const logFilters: LogFilter[] = [];
   const traceFilters: TraceFilter[] = [];
   const transactionFilters: TransactionFilter[] = [];
@@ -163,6 +164,8 @@ export const createRealtimeSync = (
         continue;
       }
 
+      if (factoryIds.has(factory.id)) continue;
+      factoryIds.add(factory.id);
       factories.push(factory);
     }
   }
@@ -706,14 +709,14 @@ export const createRealtimeSync = (
   } => {
     // Update `childAddresses`
     for (const factory of factories) {
-      const factoryId = factory.id;
-      for (const address of blockChildAddresses.get(factory)!) {
-        if (childAddresses.get(factoryId)!.has(address) === false) {
-          childAddresses
-            .get(factoryId)!
-            .set(address, hexToNumber(block.number));
+      const knownAddresses = childAddresses.get(factory.id)!;
+      const blockAddresses = blockChildAddresses.get(factory)!;
+      for (const address of blockAddresses) {
+        // Retain only addresses first discovered in this block in the persistence and reorg delta.
+        if (knownAddresses.has(address)) {
+          blockAddresses.delete(address);
         } else {
-          blockChildAddresses.get(factory)!.delete(address);
+          knownAddresses.set(address, hexToNumber(block.number));
         }
       }
     }


### PR DESCRIPTION
## Summary

- Deduplicated realtime factories by stable factory ID so repeated event callbacks cannot remove newly discovered children from the block-local persistence delta.
- Preserved realtime-discovered child addresses through finalization, restart replay, and reorg bookkeeping.
- Added a regression test covering factories that share an event with different child address parameters, including a factory referenced by multiple callbacks.

## Testing

- `CI=1 pnpm exec vitest run src/sync-realtime/index.test.ts` (19 tests)
- `pnpm --filter ponder typecheck`
- `pnpm exec biome check packages/core/src/sync-realtime/index.ts packages/core/src/sync-realtime/index.test.ts`

Closes #2345