### PR TITLE
Cancel stale simulation workflows

### DIFF
--- a/.github/workflows/simulation-test.yml
+++ b/.github/workflows/simulation-test.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   simulation-test-known-failures:


### PR DESCRIPTION
## Summary

- cancel older simulation workflow runs when a new run starts
- use a stable concurrency group so scheduled runs do not accumulate unique queues

## Verification

- `git diff --check`