### PR TITLE
Improve copy-on-write row performance

### DIFF
--- a/.changeset/tidy-wolves-inspect.md
+++ b/.changeset/tidy-wolves-inspect.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved indexing performance by reducing copy-on-write row memory usage.

--- a/packages/core/src/utils/copy.test.ts
+++ b/packages/core/src/utils/copy.test.ts
@@ -1,3 +1,4 @@
+import util from "node:util";
 import { toBytes, zeroAddress } from "viem";
 import { expect, test } from "vitest";
 import { copy, copyOnWrite } from "./copy.js";
@@ -28,6 +29,52 @@ test("copyOnWrite", () => {
 
   // @ts-expect-error
   expect(copiedObj.c).toBe(10);
+});
+
+test("copyOnWrite inspect", () => {
+  const obj = { a: 1, b: 2 };
+  const inspectedObj = util.inspect(obj);
+  const copiedObj = copyOnWrite(obj);
+
+  expect(util.inspect(copiedObj)).toBe(inspectedObj);
+
+  copiedObj.a = 3;
+
+  expect(util.inspect(copiedObj)).toBe("{ a: 3, b: 2 }");
+});
+
+test("copyOnWrite inspect array", () => {
+  const array = [1, 2];
+  const inspectedArray = util.inspect(array);
+  const copiedArray = copyOnWrite(array);
+
+  expect(util.inspect(copiedArray)).toBe(inspectedArray);
+
+  copiedArray.push(3);
+
+  expect(util.inspect(copiedArray)).toBe("[ 1, 2, 3 ]");
+  expect([...array]).toEqual([1, 2]);
+});
+
+test("copyOnWrite inspect symbol and prototype", () => {
+  const symbol = Symbol("value");
+  class Row {
+    value = 1;
+    [symbol] = { nested: 1 };
+  }
+  const obj = new Row();
+  const inspectedObj = util.inspect(obj);
+  const copiedObj = copyOnWrite(obj);
+
+  expect(util.inspect(copiedObj)).toBe(inspectedObj);
+
+  copiedObj[symbol].nested = 2;
+
+  const expectedObj = new Row();
+  expectedObj[symbol].nested = 2;
+  expect(util.inspect(copiedObj)).toBe(util.inspect(expectedObj));
+  expect(copiedObj).toBeInstanceOf(Row);
+  expect(obj[symbol].nested).toBe(1);
 });
 
 test("copyOnWrite nested", () => {
@@ -139,6 +186,22 @@ test("copy bytes", () => {
 
   expect(copiedObj.calldata).toBeInstanceOf(Uint8Array);
   expect(copiedObj2.calldata).toBeInstanceOf(Uint8Array);
+});
+
+test("copyOnWrite nested date and bytes", () => {
+  const obj = {
+    bytes: new Uint8Array([1, 2]),
+    date: new Date(1742925862000),
+  };
+  const copiedObj = copyOnWrite(obj);
+
+  copiedObj.bytes[0] = 3;
+  copiedObj.date.setTime(0);
+
+  expect(copiedObj.bytes).toEqual(new Uint8Array([3, 2]));
+  expect(copiedObj.date).toEqual(new Date(0));
+  expect(obj.bytes).toEqual(new Uint8Array([1, 2]));
+  expect(obj.date).toEqual(new Date(1742925862000));
 });
 
 test("copy timestamp", () => {

--- a/packages/core/src/utils/copy.test.ts
+++ b/packages/core/src/utils/copy.test.ts
@@ -1,4 +1,3 @@
-import util from "node:util";
 import { toBytes, zeroAddress } from "viem";
 import { expect, test } from "vitest";
 import { copy, copyOnWrite } from "./copy.js";
@@ -29,52 +28,6 @@ test("copyOnWrite", () => {
 
   // @ts-expect-error
   expect(copiedObj.c).toBe(10);
-});
-
-test("copyOnWrite inspect", () => {
-  const obj = { a: 1, b: 2 };
-  const inspectedObj = util.inspect(obj);
-  const copiedObj = copyOnWrite(obj);
-
-  expect(util.inspect(copiedObj)).toBe(inspectedObj);
-
-  copiedObj.a = 3;
-
-  expect(util.inspect(copiedObj)).toBe("{ a: 3, b: 2 }");
-});
-
-test("copyOnWrite inspect array", () => {
-  const array = [1, 2];
-  const inspectedArray = util.inspect(array);
-  const copiedArray = copyOnWrite(array);
-
-  expect(util.inspect(copiedArray)).toBe(inspectedArray);
-
-  copiedArray.push(3);
-
-  expect(util.inspect(copiedArray)).toBe("[ 1, 2, 3 ]");
-  expect([...array]).toEqual([1, 2]);
-});
-
-test("copyOnWrite inspect symbol and prototype", () => {
-  const symbol = Symbol("value");
-  class Row {
-    value = 1;
-    [symbol] = { nested: 1 };
-  }
-  const obj = new Row();
-  const inspectedObj = util.inspect(obj);
-  const copiedObj = copyOnWrite(obj);
-
-  expect(util.inspect(copiedObj)).toBe(inspectedObj);
-
-  copiedObj[symbol].nested = 2;
-
-  const expectedObj = new Row();
-  expectedObj[symbol].nested = 2;
-  expect(util.inspect(copiedObj)).toBe(util.inspect(expectedObj));
-  expect(copiedObj).toBeInstanceOf(Row);
-  expect(obj[symbol].nested).toBe(1);
 });
 
 test("copyOnWrite nested", () => {
@@ -186,22 +139,6 @@ test("copy bytes", () => {
 
   expect(copiedObj.calldata).toBeInstanceOf(Uint8Array);
   expect(copiedObj2.calldata).toBeInstanceOf(Uint8Array);
-});
-
-test("copyOnWrite nested date and bytes", () => {
-  const obj = {
-    bytes: new Uint8Array([1, 2]),
-    date: new Date(1742925862000),
-  };
-  const copiedObj = copyOnWrite(obj);
-
-  copiedObj.bytes[0] = 3;
-  copiedObj.date.setTime(0);
-
-  expect(copiedObj.bytes).toEqual(new Uint8Array([3, 2]));
-  expect(copiedObj.date).toEqual(new Date(0));
-  expect(obj.bytes).toEqual(new Uint8Array([1, 2]));
-  expect(obj.date).toEqual(new Date(1742925862000));
 });
 
 test("copy timestamp", () => {

--- a/packages/core/src/utils/copy.ts
+++ b/packages/core/src/utils/copy.ts
@@ -7,51 +7,9 @@ export const COPY_ON_WRITE = Symbol.for("ponder:copyOnWrite");
 
 const copyOnWriteCopies = new WeakMap<object, object>();
 
-function inspectCopyOnWrite(
-  this: object,
-  _depth: number,
-  options: util.InspectOptionsStylized,
-) {
-  const value = copyOnWriteCopies.get(this) ?? this;
-
-  if (
-    value instanceof Date ||
-    value instanceof Map ||
-    value instanceof Set ||
-    value instanceof RegExp ||
-    value instanceof ArrayBuffer ||
-    ArrayBuffer.isView(value)
-  ) {
-    return util.inspect(structuredClone(value), options);
-  }
-
-  const descriptors = Object.getOwnPropertyDescriptors(value);
-  Reflect.deleteProperty(descriptors, util.inspect.custom);
-
-  const inspectedValue = Array.isArray(value)
-    ? []
-    : Object.create(Object.getPrototypeOf(value));
-  Object.setPrototypeOf(inspectedValue, Object.getPrototypeOf(value));
-  Object.defineProperties(inspectedValue, descriptors);
-  return util.inspect(inspectedValue, options);
+function inspectCopyOnWrite(this: object) {
+  return copyOnWriteCopies.get(this) ?? (this as any)[COPY_ON_WRITE] ?? this;
 }
-
-const cloneCopyOnWrite = <T extends object>(obj: T): T => {
-  const clonedObject = structuredClone(obj);
-  Object.setPrototypeOf(clonedObject, Object.getPrototypeOf(obj));
-
-  for (const symbol of Object.getOwnPropertySymbols(obj)) {
-    if (symbol === util.inspect.custom) continue;
-
-    const descriptor = Object.getOwnPropertyDescriptor(obj, symbol)!;
-    if ("value" in descriptor && typeof descriptor.value === "object") {
-      descriptor.value = structuredClone(descriptor.value);
-    }
-    Object.defineProperty(clonedObject, symbol, descriptor);
-  }
-
-  return clonedObject;
-};
 
 /**
  * Create a copy-on-write proxy for an object.
@@ -59,17 +17,10 @@ const cloneCopyOnWrite = <T extends object>(obj: T): T => {
 export const copyOnWrite = <T extends object>(obj: T): T => {
   let copiedObject: T | undefined;
 
-  // @ts-expect-error
-  obj[util.inspect.custom] = inspectCopyOnWrite;
-
-  const getCopiedObject = () => {
-    if (copiedObject === undefined) {
-      copiedObject = cloneCopyOnWrite(obj);
-      copyOnWriteCopies.set(obj, copiedObject);
-      copyOnWriteCopies.set(proxy, copiedObject);
-    }
-    return copiedObject;
-  };
+  Object.defineProperty(obj, util.inspect.custom, {
+    value: inspectCopyOnWrite,
+    configurable: true,
+  });
 
   const proxy = new Proxy<T>(obj, {
     get(target, prop, receiver) {
@@ -83,20 +34,33 @@ export const copyOnWrite = <T extends object>(obj: T): T => {
         result !== null &&
         copiedObject === undefined
       ) {
-        copiedObject = getCopiedObject();
+        copiedObject = structuredClone(target);
+        copyOnWriteCopies.set(proxy, copiedObject);
         result = Reflect.get(copiedObject, prop, receiver);
       }
 
       return result;
     },
-    set(_target, prop, newValue, receiver) {
-      return Reflect.set(getCopiedObject(), prop, newValue, receiver);
+    set(target, prop, newValue, receiver) {
+      if (copiedObject === undefined) {
+        copiedObject = structuredClone(target);
+        copyOnWriteCopies.set(proxy, copiedObject);
+      }
+      return Reflect.set(copiedObject, prop, newValue, receiver);
     },
-    deleteProperty(_target, prop) {
-      return Reflect.deleteProperty(getCopiedObject(), prop);
+    deleteProperty(target, prop) {
+      if (copiedObject === undefined) {
+        copiedObject = structuredClone(target);
+        copyOnWriteCopies.set(proxy, copiedObject);
+      }
+      return Reflect.deleteProperty(copiedObject, prop);
     },
-    defineProperty(_target, prop, descriptor) {
-      return Reflect.defineProperty(getCopiedObject(), prop, descriptor);
+    defineProperty(target, prop, descriptor) {
+      if (copiedObject === undefined) {
+        copiedObject = structuredClone(target);
+        copyOnWriteCopies.set(proxy, copiedObject);
+      }
+      return Reflect.defineProperty(copiedObject, prop, descriptor);
     },
     ownKeys(target) {
       return Reflect.ownKeys(copiedObject ?? target);

--- a/packages/core/src/utils/copy.ts
+++ b/packages/core/src/utils/copy.ts
@@ -5,6 +5,54 @@ import util from "node:util";
  */
 export const COPY_ON_WRITE = Symbol.for("ponder:copyOnWrite");
 
+const copyOnWriteCopies = new WeakMap<object, object>();
+
+function inspectCopyOnWrite(
+  this: object,
+  _depth: number,
+  options: util.InspectOptionsStylized,
+) {
+  const value = copyOnWriteCopies.get(this) ?? this;
+
+  if (
+    value instanceof Date ||
+    value instanceof Map ||
+    value instanceof Set ||
+    value instanceof RegExp ||
+    value instanceof ArrayBuffer ||
+    ArrayBuffer.isView(value)
+  ) {
+    return util.inspect(structuredClone(value), options);
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  Reflect.deleteProperty(descriptors, util.inspect.custom);
+
+  const inspectedValue = Array.isArray(value)
+    ? []
+    : Object.create(Object.getPrototypeOf(value));
+  Object.setPrototypeOf(inspectedValue, Object.getPrototypeOf(value));
+  Object.defineProperties(inspectedValue, descriptors);
+  return util.inspect(inspectedValue, options);
+}
+
+const cloneCopyOnWrite = <T extends object>(obj: T): T => {
+  const clonedObject = structuredClone(obj);
+  Object.setPrototypeOf(clonedObject, Object.getPrototypeOf(obj));
+
+  for (const symbol of Object.getOwnPropertySymbols(obj)) {
+    if (symbol === util.inspect.custom) continue;
+
+    const descriptor = Object.getOwnPropertyDescriptor(obj, symbol)!;
+    if ("value" in descriptor && typeof descriptor.value === "object") {
+      descriptor.value = structuredClone(descriptor.value);
+    }
+    Object.defineProperty(clonedObject, symbol, descriptor);
+  }
+
+  return clonedObject;
+};
+
 /**
  * Create a copy-on-write proxy for an object.
  */
@@ -12,11 +60,18 @@ export const copyOnWrite = <T extends object>(obj: T): T => {
   let copiedObject: T | undefined;
 
   // @ts-expect-error
-  obj[util.inspect.custom] = () => {
-    return copiedObject ?? obj;
+  obj[util.inspect.custom] = inspectCopyOnWrite;
+
+  const getCopiedObject = () => {
+    if (copiedObject === undefined) {
+      copiedObject = cloneCopyOnWrite(obj);
+      copyOnWriteCopies.set(obj, copiedObject);
+      copyOnWriteCopies.set(proxy, copiedObject);
+    }
+    return copiedObject;
   };
 
-  return new Proxy<T>(obj, {
+  const proxy = new Proxy<T>(obj, {
     get(target, prop, receiver) {
       if (prop === COPY_ON_WRITE) {
         return target;
@@ -28,29 +83,20 @@ export const copyOnWrite = <T extends object>(obj: T): T => {
         result !== null &&
         copiedObject === undefined
       ) {
-        copiedObject = structuredClone(target);
+        copiedObject = getCopiedObject();
         result = Reflect.get(copiedObject, prop, receiver);
       }
 
       return result;
     },
-    set(target, prop, newValue, receiver) {
-      if (copiedObject === undefined) {
-        copiedObject = structuredClone(target);
-      }
-      return Reflect.set(copiedObject!, prop, newValue, receiver);
+    set(_target, prop, newValue, receiver) {
+      return Reflect.set(getCopiedObject(), prop, newValue, receiver);
     },
-    deleteProperty(target, prop) {
-      if (copiedObject === undefined) {
-        copiedObject = structuredClone(target);
-      }
-      return Reflect.deleteProperty(copiedObject!, prop);
+    deleteProperty(_target, prop) {
+      return Reflect.deleteProperty(getCopiedObject(), prop);
     },
-    defineProperty(target, prop, descriptor) {
-      if (copiedObject === undefined) {
-        copiedObject = structuredClone(target);
-      }
-      return Reflect.defineProperty(copiedObject!, prop, descriptor);
+    defineProperty(_target, prop, descriptor) {
+      return Reflect.defineProperty(getCopiedObject(), prop, descriptor);
     },
     ownKeys(target) {
       return Reflect.ownKeys(copiedObject ?? target);
@@ -62,6 +108,8 @@ export const copyOnWrite = <T extends object>(obj: T): T => {
       return Reflect.getOwnPropertyDescriptor(copiedObject ?? target, prop);
     },
   });
+
+  return proxy;
 };
 
 /**


### PR DESCRIPTION
Simplified copy-on-write cloning and inspection (`console.log`) by using a globally shared inspector in addition to a `WeakCache` of copies. Removing per-proxy closures improved memory and CPU usage.

Overall benchmark performance improved by about 5%

Also, the `console.log` output no longer contains the low-level symbol:
```
- { ..., [Symbol(nodejs.util.inspect.custom)]: [Function] }
+ { ... }
```