### PR TITLE
Batch high-frequency indexing metrics

### DIFF
--- a/.changeset/calm-metrics-batch.md
+++ b/.changeset/calm-metrics-batch.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved indexing performance by batching internal metrics updates.

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -435,10 +435,10 @@ export const createIndexingCache = ({
         updateBuffer.get(table)!.get(ck) ?? insertBuffer.get(table)!.get(ck);
 
       if (bufferEntry) {
-        common.metrics.ponder_indexing_cache_requests_total.inc({
-          table: getTableName(table),
-          type: cache.get(table)!.isCacheComplete ? "complete" : "hit",
-        });
+        common.metrics.incrementIndexingCacheRequests(
+          getTableName(table),
+          cache.get(table)!.isCacheComplete ? "complete" : "hit",
+        );
         return bufferEntry.row;
       }
 
@@ -452,29 +452,29 @@ export const createIndexingCache = ({
           cache.get(table)!.spillover.add(ck);
         }
 
-        common.metrics.ponder_indexing_cache_requests_total.inc({
-          table: getTableName(table),
-          type: cache.get(table)!.isCacheComplete ? "complete" : "hit",
-        });
+        common.metrics.incrementIndexingCacheRequests(
+          getTableName(table),
+          cache.get(table)!.isCacheComplete ? "complete" : "hit",
+        );
         return entry;
       }
 
       cache.get(table)!.diskReads++;
 
       if (cache.get(table)!.isCacheComplete) {
-        common.metrics.ponder_indexing_cache_requests_total.inc({
-          table: getTableName(table),
-          type: "complete",
-        });
+        common.metrics.incrementIndexingCacheRequests(
+          getTableName(table),
+          "complete",
+        );
         return null;
       }
 
       cache.get(table)!.spillover.add(ck);
 
-      common.metrics.ponder_indexing_cache_requests_total.inc({
-        table: getTableName(table),
-        type: "miss",
-      });
+      common.metrics.incrementIndexingCacheRequests(
+        getTableName(table),
+        "miss",
+      );
 
       const endClock = startClock();
 
@@ -964,11 +964,9 @@ export const createIndexingCache = ({
       }
 
       for (const [table, tablePredictions] of prediction) {
-        common.metrics.ponder_indexing_cache_requests_total.inc(
-          {
-            table: getTableName(table),
-            type: "prefetch",
-          },
+        common.metrics.incrementIndexingCacheRequests(
+          getTableName(table),
+          "prefetch",
           tablePredictions.size,
         );
       }

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -161,10 +161,10 @@ export const createIndexingStore = ({
   return {
     db: {
       find: storeMethodWrapper(async (table: Table, key) => {
-        common.metrics.ponder_indexing_store_queries_total.inc({
-          table: getTableName(table),
-          method: "find",
-        });
+        common.metrics.incrementIndexingStoreQueries(
+          getTableName(table),
+          "find",
+        );
         checkOnchainTable(table, "find");
         checkTableAccess(table, "find", key, chainId);
         const ponderRow = await indexingCache.get({ table, key });
@@ -177,10 +177,10 @@ export const createIndexingStore = ({
           values: (userValues: any) => {
             const inner = {
               onConflictDoNothing: storeMethodWrapper(async () => {
-                common.metrics.ponder_indexing_store_queries_total.inc({
-                  table: getTableName(table),
-                  method: "insert",
-                });
+                common.metrics.incrementIndexingStoreQueries(
+                  getTableName(table),
+                  "insert",
+                );
                 checkOnchainTable(table, "insert");
 
                 const ponderValues = copy(userValues);
@@ -232,10 +232,10 @@ export const createIndexingStore = ({
               }),
               onConflictDoUpdate: storeMethodWrapper(
                 async (userUpdateValues: any) => {
-                  common.metrics.ponder_indexing_store_queries_total.inc({
-                    table: getTableName(table),
-                    method: "insert",
-                  });
+                  common.metrics.incrementIndexingStoreQueries(
+                    getTableName(table),
+                    "insert",
+                  );
                   checkOnchainTable(table, "insert");
 
                   if (Array.isArray(userValues)) {
@@ -369,10 +369,10 @@ export const createIndexingStore = ({
               // biome-ignore lint/suspicious/noThenProperty: The returned object is intentionally thenable for the query API.
               then: (onFulfilled, onRejected) =>
                 storeMethodWrapper(async () => {
-                  common.metrics.ponder_indexing_store_queries_total.inc({
-                    table: getTableName(table),
-                    method: "insert",
-                  });
+                  common.metrics.incrementIndexingStoreQueries(
+                    getTableName(table),
+                    "insert",
+                  );
                   checkOnchainTable(table, "insert");
                   const ponderValues = copy(userValues);
 
@@ -488,10 +488,10 @@ export const createIndexingStore = ({
       update(table: Table, key) {
         return {
           set: storeMethodWrapper(async (userValues: any) => {
-            common.metrics.ponder_indexing_store_queries_total.inc({
-              table: getTableName(table),
-              method: "update",
-            });
+            common.metrics.incrementIndexingStoreQueries(
+              getTableName(table),
+              "update",
+            );
             checkOnchainTable(table, "update");
             checkTableAccess(table, "update", key, chainId);
 
@@ -550,10 +550,10 @@ export const createIndexingStore = ({
         };
       },
       delete: storeMethodWrapper(async (table: Table, key) => {
-        common.metrics.ponder_indexing_store_queries_total.inc({
-          table: getTableName(table),
-          method: "delete",
-        });
+        common.metrics.incrementIndexingStoreQueries(
+          getTableName(table),
+          "delete",
+        );
         checkOnchainTable(table, "delete");
         checkTableAccess(table, "delete", key, chainId);
         return indexingCache.delete({ table, key });

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -549,9 +549,8 @@ export const createIndexing = ({
         // @ts-expect-error
         await executeEvent({ ...event, event: proxyEvent });
 
-        common.metrics.ponder_indexing_completed_events.inc(
-          { event: event.eventCallback.name },
-          1,
+        common.metrics.incrementIndexingCompletedEvents(
+          event.eventCallback.name,
         );
         columnAccessPattern.get(event.eventCallback.name)!.count++;
         eventCount[event.eventCallback.name] =
@@ -716,9 +715,8 @@ export const createIndexing = ({
 
         await executeEvent(event);
 
-        common.metrics.ponder_indexing_completed_events.inc(
-          { event: event.eventCallback.name },
-          1,
+        common.metrics.incrementIndexingCompletedEvents(
+          event.eventCallback.name,
         );
         eventCount[event.eventCallback.name] =
           eventCount[event.eventCallback.name]! + 1;

--- a/packages/core/src/internal/metrics.test.ts
+++ b/packages/core/src/internal/metrics.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "vitest";
+import { MetricsService } from "./metrics.js";
+
+test("batches indexing metrics until collection", async () => {
+  const metrics = new MetricsService();
+
+  metrics.incrementIndexingCompletedEvents("Token:Transfer");
+  metrics.incrementIndexingCompletedEvents("Token:Transfer", 2);
+  metrics.incrementIndexingCacheRequests("account", "hit");
+  metrics.incrementIndexingCacheRequests("account", "hit", 2);
+  metrics.incrementIndexingCacheRequests("account", "prefetch", 0);
+  metrics.incrementIndexingStoreQueries("account", "insert");
+  metrics.incrementIndexingStoreQueries("account", "insert", 2);
+
+  expect(await metrics.ponder_indexing_completed_events.get()).toMatchObject({
+    values: [{ labels: { event: "Token:Transfer" }, value: 3 }],
+  });
+  expect(
+    await metrics.ponder_indexing_cache_requests_total.get(),
+  ).toMatchObject({
+    values: [
+      { labels: { table: "account", type: "hit" }, value: 3 },
+      { labels: { table: "account", type: "prefetch" }, value: 0 },
+    ],
+  });
+  expect(await metrics.ponder_indexing_store_queries_total.get()).toMatchObject(
+    {
+      values: [{ labels: { table: "account", method: "insert" }, value: 3 }],
+    },
+  );
+
+  await metrics.getMetrics();
+
+  expect(await metrics.ponder_indexing_completed_events.get()).toMatchObject({
+    values: [{ labels: { event: "Token:Transfer" }, value: 3 }],
+  });
+});
+
+test("flushes pending indexing metrics before reset", async () => {
+  const metrics = new MetricsService();
+
+  metrics.incrementIndexingCompletedEvents("Token:Transfer", 2);
+  metrics.incrementIndexingCacheRequests("account", "hit", 3);
+  metrics.incrementIndexingStoreQueries("account", "insert", 4);
+
+  metrics.resetIndexingMetrics();
+
+  expect(await metrics.ponder_indexing_completed_events.get()).toMatchObject({
+    values: [],
+  });
+  expect(
+    await metrics.ponder_indexing_cache_requests_total.get(),
+  ).toMatchObject({
+    values: [{ labels: { table: "account", type: "hit" }, value: 3 }],
+  });
+  expect(await metrics.ponder_indexing_store_queries_total.get()).toMatchObject(
+    {
+      values: [{ labels: { table: "account", method: "insert" }, value: 4 }],
+    },
+  );
+});
+
+test("does not replay flushed completed event metrics", async () => {
+  const metrics = new MetricsService();
+
+  metrics.incrementIndexingCompletedEvents("Token:Transfer", 2);
+  metrics.flushIndexingMetrics();
+  metrics.ponder_indexing_completed_events.set({ event: "Token:Transfer" }, 1);
+
+  expect(await metrics.ponder_indexing_completed_events.get()).toMatchObject({
+    values: [{ labels: { event: "Token:Transfer" }, value: 1 }],
+  });
+});

--- a/packages/core/src/internal/metrics.ts
+++ b/packages/core/src/internal/metrics.ts
@@ -25,6 +25,9 @@ const httpRequestSizeBytes = [
 const GET_METRICS_REQ = "prom-client:getMetricsReq";
 const GET_METRICS_RES = "prom-client:getMetricsRes";
 
+type IndexingCacheRequestType = "complete" | "hit" | "miss" | "prefetch";
+type IndexingStoreMethod = "find" | "insert" | "update" | "delete";
+
 export class MetricsService {
   registry: prometheus.Registry;
   start_timestamp: number;
@@ -111,6 +114,16 @@ export class MetricsService {
   ponder_postgres_query_total: prometheus.Counter<"pool">;
   ponder_postgres_query_queue_size: prometheus.Gauge<"pool"> = null!;
   ponder_postgres_pool_connections: prometheus.Gauge<"pool" | "kind"> = null!;
+
+  private indexingCompletedEvents = new Map<string, number>();
+  private indexingCacheRequests = new Map<
+    string,
+    Map<IndexingCacheRequestType, number>
+  >();
+  private indexingStoreQueries = new Map<
+    string,
+    Map<IndexingStoreMethod, number>
+  >();
 
   constructor() {
     this.registry = new prometheus.Registry();
@@ -206,6 +219,7 @@ export class MetricsService {
       labelNames: ["chain", "event"] as const,
       registers: [this.registry],
       aggregator: "sum",
+      collect: () => this.flushIndexingCompletedEvents(),
     });
     this.ponder_indexing_timestamp = new prometheus.Gauge({
       name: "ponder_indexing_timestamp",
@@ -258,6 +272,7 @@ export class MetricsService {
       labelNames: ["table", "type"] as const,
       registers: [this.registry],
       aggregator: "sum",
+      collect: () => this.flushIndexingCacheRequests(),
     });
     this.ponder_indexing_store_queries_total = new prometheus.Counter({
       name: "ponder_indexing_store_queries_total",
@@ -265,6 +280,7 @@ export class MetricsService {
       labelNames: ["table", "method"] as const,
       registers: [this.registry],
       aggregator: "sum",
+      collect: () => this.flushIndexingStoreQueries(),
     });
     this.ponder_indexing_store_raw_sql_duration = new prometheus.Histogram({
       name: "ponder_indexing_store_raw_sql_duration",
@@ -449,6 +465,70 @@ export class MetricsService {
     return this.registry;
   }
 
+  incrementIndexingCompletedEvents(event: string, value = 1) {
+    this.indexingCompletedEvents.set(
+      event,
+      (this.indexingCompletedEvents.get(event) ?? 0) + value,
+    );
+  }
+
+  incrementIndexingCacheRequests(
+    table: string,
+    type: IndexingCacheRequestType,
+    value = 1,
+  ) {
+    let requests = this.indexingCacheRequests.get(table);
+    if (requests === undefined) {
+      requests = new Map();
+      this.indexingCacheRequests.set(table, requests);
+    }
+    requests.set(type, (requests.get(type) ?? 0) + value);
+  }
+
+  incrementIndexingStoreQueries(
+    table: string,
+    method: IndexingStoreMethod,
+    value = 1,
+  ) {
+    let queries = this.indexingStoreQueries.get(table);
+    if (queries === undefined) {
+      queries = new Map();
+      this.indexingStoreQueries.set(table, queries);
+    }
+    queries.set(method, (queries.get(method) ?? 0) + value);
+  }
+
+  flushIndexingMetrics() {
+    this.flushIndexingCompletedEvents();
+    this.flushIndexingCacheRequests();
+    this.flushIndexingStoreQueries();
+  }
+
+  private flushIndexingCompletedEvents() {
+    for (const [event, value] of this.indexingCompletedEvents) {
+      this.ponder_indexing_completed_events.inc({ event }, value);
+    }
+    this.indexingCompletedEvents.clear();
+  }
+
+  private flushIndexingCacheRequests() {
+    for (const [table, requests] of this.indexingCacheRequests) {
+      for (const [type, value] of requests) {
+        this.ponder_indexing_cache_requests_total.inc({ table, type }, value);
+      }
+    }
+    this.indexingCacheRequests.clear();
+  }
+
+  private flushIndexingStoreQueries() {
+    for (const [table, queries] of this.indexingStoreQueries) {
+      for (const [method, value] of queries) {
+        this.ponder_indexing_store_queries_total.inc({ table, method }, value);
+      }
+    }
+    this.indexingStoreQueries.clear();
+  }
+
   initializeIndexingMetrics({
     indexingBuild,
     schemaBuild,
@@ -480,6 +560,7 @@ export class MetricsService {
   }
 
   resetIndexingMetrics() {
+    this.flushIndexingMetrics();
     this.start_timestamp = Date.now();
     this.rps = {};
     this.progressMetadata = {

--- a/packages/core/src/runtime/isolated.ts
+++ b/packages/core/src/runtime/isolated.ts
@@ -398,6 +398,7 @@ export async function runIsolated({
         } catch (error) {
           // Note: This can cause a bug with "dev" command, because there are multiple instances
           // updating the same metric.
+          common.metrics.flushIndexingMetrics();
           for (const value of initialCompletedEvents.values) {
             common.metrics.ponder_indexing_completed_events.set(
               value.labels,

--- a/packages/core/src/runtime/multichain.ts
+++ b/packages/core/src/runtime/multichain.ts
@@ -451,6 +451,7 @@ export async function runMultichain({
           );
           endClock = startClock();
         } catch (error) {
+          common.metrics.flushIndexingMetrics();
           for (const value of initialCompletedEvents.values) {
             common.metrics.ponder_indexing_completed_events.set(
               value.labels,

--- a/packages/core/src/runtime/omnichain.ts
+++ b/packages/core/src/runtime/omnichain.ts
@@ -470,6 +470,7 @@ export async function runOmnichain({
           );
           endClock = startClock();
         } catch (error) {
+          common.metrics.flushIndexingMetrics();
           for (const value of initialCompletedEvents.values) {
             common.metrics.ponder_indexing_completed_events.set(
               value.labels,


### PR DESCRIPTION
## Bottleneck

Historical indexing performed millions of synchronous `prom-client` counter/gauge updates. Each update validated labels, hashed the label object, and mutated metric state even though the label cardinality is small and bounded.

This change accumulates exact deltas in primitive `Map` counters for:

- `ponder_indexing_completed_events`
- `ponder_indexing_cache_requests_total`
- `ponder_indexing_store_queries_total`

Each metric flushes its pending deltas through the documented `collect()` hook before `.get()`, registry JSON aggregation, or `/metrics` exposition. Histograms are unchanged because `prom-client` has no documented weighted observation API.

## Correctness

Metric names, types, labels, counts, and aggregation modes are unchanged. Zero-valued series are preserved. Collection drains synchronously, so overlapping scrapes cannot interleave a drain. Reset flushes pending values first, preserving the existing lifetime behavior of cache/store counters, and historical rollback paths flush before restoring the completed-event snapshot so failed batches are not replayed later.

Focused tests cover weighted updates, zero values, repeated collection without replay, reset behavior, and rollback-style flush/set behavior. Existing indexing, cache, and store suites verify the call sites.

## Benchmark

Workload: `benchmark/apps/reth/src/index.ts`, Postgres, complete historical cache.

- Base: `cc7ce34693c972b10eb63ff60f7a0f8704c67655`
- Candidate: `101f23ac0f31b3e683434bd8505a11e2a15f6f35`
- Harness: identical local-only post-ready metrics/resource/checksum instrumentation in both worktrees; scrape and output validation were outside the measured interval.
- Warmup cache: `cache_rate=100%` for `mainnet`, with no historical RPC fetching.
- Every measured run: `/metrics` reported Postgres through `ponder_settings_info`.
- Every parent and candidate scrape produced the same exact additive-metrics checksum: `479deb9285f3ff2be96ce09a972ccbb7505b52123d20de8239def15505be1e7e`.

Five alternating measured pairs, in execution order:

| Pair | Parent | Candidate |
|---|---:|---:|
| 1 | 17,648 ms | 16,813 ms |
| 2 | 17,391 ms | 17,199 ms |
| 3 | 17,087 ms | 16,416 ms |
| 4 | 17,738 ms | 16,892 ms |
| 5 | 17,787 ms | 16,524 ms |

| | Parent | Candidate | Delta |
|---|---:|---:|---:|
| Median | 17,648 ms | 16,813 ms | -835 ms (-4.7%) |
| Minimum | 17,087 ms | 16,416 ms | -671 ms |
| Maximum | 17,787 ms | 17,199 ms | -588 ms |

| Resource | Parent median | Candidate median | Delta |
|---|---:|---:|---:|
| User CPU | 18,871 ms | 18,226 ms | -645 ms (-3.4%) |
| System CPU | 764 ms | 701 ms | -63 ms |
| Peak RSS | 1,141 MiB | 1,115 MiB | -26 MiB (-2.3%) |

Raw parent `(user/system/RSS)`: `18821/799/1141`, `19135/764/1146`, `18751/691/1177`, `18871/791/1134`, `18967/746/1120` (ms/ms/MiB).

Raw candidate `(user/system/RSS)`: `18226/701/1115`, `18319/745/1115`, `17945/698/1122`, `18363/700/1139`, `18093/717/1114` (ms/ms/MiB).

One tightly paired Bun CPU profile was captured per revision. Profiled wall/user CPU was `17,714/19,696 ms` on the parent and `16,604/18,035 ms` on the candidate. Parent self time included about `273 ms` in counter `setValue`, `227 ms` in `fastHashObject`, and `103 ms` in label validation; candidate `fastHashObject` and label-validation self time fell to about `40 ms` and `28 ms` respectively. Profile-buffer RSS is excluded from the normal RSS comparison.
