### PR TITLE
Release write-only Postgres rows after flush

### DIFF
--- a/.changeset/clean-write-only-rows.md
+++ b/.changeset/clean-write-only-rows.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved Postgres indexing performance by releasing write-only rows after they were flushed.

--- a/packages/core/src/indexing-store/cache.test.ts
+++ b/packages/core/src/indexing-store/cache.test.ts
@@ -84,6 +84,92 @@ test("flush() insert", async () => {
   });
 });
 
+test("flush() releases write-only inserts", async () => {
+  if (context.databaseConfig.kind !== "postgres") return;
+
+  const schema = {
+    account: onchainTable("account", (p) => ({
+      address: p.hex().primaryKey(),
+      balance: p.bigint().notNull(),
+    })),
+  };
+
+  const { database } = await setupDatabaseServices({
+    schemaBuild: { schema },
+  });
+
+  const indexingCache = createIndexingCache({
+    common: context.common,
+    schemaBuild: { schema },
+    crashRecoveryCheckpoint: undefined,
+    eventCount: {},
+  });
+
+  const indexingStore = createIndexingStore({
+    common: context.common,
+    schemaBuild: { schema },
+    indexingCache,
+    indexingErrorHandler,
+  });
+
+  await database.userQB.transaction(async (tx) => {
+    indexingCache.qb = tx;
+    indexingStore.qb = tx;
+
+    await indexingStore.db
+      .insert(schema.account)
+      .values({ address: ALICE, balance: 10n });
+    await indexingStore.db
+      .insert(schema.account)
+      .values({ address: BOB, balance: 10n });
+    await indexingStore.db
+      .insert(schema.account)
+      .values({ address: zeroAddress, balance: 10n });
+
+    await indexingStore.db.find(schema.account, { address: BOB });
+    await indexingCache.flush();
+
+    expect(
+      await indexingStore.db
+        .insert(schema.account)
+        .values({ address: ALICE, balance: 0n })
+        .onConflictDoNothing(),
+    ).toBeNull();
+    expect(
+      await indexingStore.db.find(schema.account, { address: BOB }),
+    ).toMatchObject({ balance: 10n });
+    expect(
+      await indexingStore.db.find(schema.account, { address: zeroAddress }),
+    ).toMatchObject({ address: zeroAddress, balance: 10n });
+
+    const alice = await indexingStore.db
+      .insert(schema.account)
+      .values({ address: ALICE, balance: 0n })
+      .onConflictDoUpdate((row) => ({ balance: row.balance + 1n }));
+
+    expect(alice.balance).toBe(11n);
+
+    await indexingCache.flush();
+    expect(
+      await indexingStore.db.find(schema.account, { address: ALICE }),
+    ).toMatchObject({ balance: 11n });
+
+    const cacheRequests = (
+      await context.common.metrics.ponder_indexing_cache_requests_total.get()
+    ).values;
+    expect(
+      cacheRequests.find(
+        ({ labels }) => labels.table === "account" && labels.type === "miss",
+      )?.value,
+    ).toBe(2);
+    expect(
+      cacheRequests.find(
+        ({ labels }) => labels.table === "account" && labels.type === "hit",
+      )?.value,
+    ).toBe(3);
+  });
+});
+
 test("flush() update", async () => {
   const schema = {
     account: onchainTable("account", (p) => ({

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -60,6 +60,7 @@ export type IndexingCache = {
     key: object;
     row: Row;
     isUpdate: boolean;
+    shouldCache: boolean;
   }) => Row;
   /**
    * Deletes the entry for `table` with `key`.
@@ -185,6 +186,7 @@ type Buffer = Map<
     {
       row: Row;
       metadata: { event: Event | undefined };
+      shouldCache: boolean;
     }
   >
 >;
@@ -435,6 +437,7 @@ export const createIndexingCache = ({
         updateBuffer.get(table)!.get(ck) ?? insertBuffer.get(table)!.get(ck);
 
       if (bufferEntry) {
+        bufferEntry.shouldCache = true;
         common.metrics.ponder_indexing_cache_requests_total.inc({
           table: getTableName(table),
           type: cache.get(table)!.isCacheComplete ? "complete" : "hit",
@@ -501,14 +504,18 @@ export const createIndexingCache = ({
       );
       return result;
     },
-    set({ table, key, row: _row, isUpdate }) {
+    set({ table, key, row: _row, isUpdate, shouldCache }) {
       const row = normalizeRow(table, _row, isUpdate);
       const ck = getCacheKey(table, key, primaryKeyCache);
 
       if (isUpdate) {
-        updateBuffer.get(table)!.set(ck, { row, metadata: { event } });
+        updateBuffer
+          .get(table)!
+          .set(ck, { row, metadata: { event }, shouldCache });
       } else {
-        insertBuffer.get(table)!.set(ck, { row, metadata: { event } });
+        insertBuffer
+          .get(table)!
+          .set(ck, { row, metadata: { event }, shouldCache });
       }
 
       return row;
@@ -586,12 +593,19 @@ export const createIndexingCache = ({
 
           let bytes = 0;
           for (const [key, entry] of insertBuffer.get(table)!) {
-            if (shouldRecordBytes && tableCache.cache.has(key) === false) {
-              bytes += getBytes(entry.row) + getBytes(key);
+            if (qb.$dialect === "postgres" && entry.shouldCache === false) {
+              // An omitted database row makes cache absence inconclusive.
+              tableCache.cache.delete(key);
+              tableCache.isCacheComplete = false;
+              tableCache.bytes = 0;
+            } else {
+              if (shouldRecordBytes && tableCache.cache.has(key) === false) {
+                bytes += getBytes(entry.row) + getBytes(key);
+              }
+              tableCache.cache.set(key, entry.row);
             }
-            tableCache.cache.set(key, entry.row);
           }
-          tableCache.bytes += bytes;
+          if (tableCache.isCacheComplete) tableCache.bytes += bytes;
           insertBuffer.get(table)!.clear();
 
           await new Promise(setImmediate);

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -200,6 +200,7 @@ export const createIndexingStore = ({
                           key: value,
                           row: value,
                           isUpdate: false,
+                          shouldCache: true,
                         }),
                       );
                     }
@@ -224,6 +225,7 @@ export const createIndexingStore = ({
                     key: ponderValues,
                     row: ponderValues,
                     isUpdate: false,
+                    shouldCache: true,
                   });
 
                   const userRow = copyOnWrite(ponderRow);
@@ -287,6 +289,7 @@ export const createIndexingStore = ({
                             key: ponderRowUpdate,
                             row: ponderRowUpdate,
                             isUpdate: true,
+                            shouldCache: true,
                           }),
                         );
                       } else {
@@ -297,6 +300,7 @@ export const createIndexingStore = ({
                             key: ponderValue,
                             row: ponderValue,
                             isUpdate: false,
+                            shouldCache: true,
                           }),
                         );
                       }
@@ -347,6 +351,7 @@ export const createIndexingStore = ({
                         key: ponderRowUpdate,
                         row: ponderRowUpdate,
                         isUpdate: true,
+                        shouldCache: true,
                       });
                       const userRow = copyOnWrite(ponderRow);
                       return userRow;
@@ -359,6 +364,7 @@ export const createIndexingStore = ({
                       key: ponderValues,
                       row: ponderValues,
                       isUpdate: false,
+                      shouldCache: true,
                     });
 
                     const userRow = copyOnWrite(ponderRowInsert);
@@ -398,6 +404,7 @@ export const createIndexingStore = ({
                               key: value,
                               row: value,
                               isUpdate: false,
+                              shouldCache: true,
                             }),
                           );
                         }
@@ -411,6 +418,7 @@ export const createIndexingStore = ({
                             key: value,
                             row: value,
                             isUpdate: false,
+                            shouldCache: false,
                           }),
                         );
                       }
@@ -442,6 +450,7 @@ export const createIndexingStore = ({
                           key: ponderValues,
                           row: ponderValues,
                           isUpdate: false,
+                          shouldCache: true,
                         });
                       }
                     } else {
@@ -453,6 +462,7 @@ export const createIndexingStore = ({
                         key: ponderValues,
                         row: ponderValues,
                         isUpdate: false,
+                        shouldCache: false,
                       });
                     }
                     const userRow = copyOnWrite(ponderRow);
@@ -543,6 +553,7 @@ export const createIndexingStore = ({
               key: ponderRowUpdate,
               row: ponderRowUpdate,
               isUpdate: true,
+              shouldCache: true,
             });
             const userRow = copyOnWrite(ponderRow);
             return userRow;


### PR DESCRIPTION
## Bottleneck

Postgres plain inserts were promoted into the indexing cache after every successful flush, even when no store operation had read the row. Append-only event tables therefore retained hundreds of thousands of complete row objects, paid recursive byte-accounting cost for them, and kept them alive through the full historical run.

This change marks plain Postgres inserts as non-cache candidates. A buffered row becomes a cache candidate if it is read before flush. Conflict-aware inserts, updates, and all PGlite inserts remain cache candidates from the start.

## Correctness

When a committed row is omitted, the table transitions to incomplete-cache mode and any stale positive or negative entry for that key is removed. A later `db.find()`, conflict check, or update therefore queries Postgres instead of treating cache absence as proof that the row does not exist.

The policy is generic and based on store behavior, not table names or schema shape:

- Plain Postgres insert, unread before flush: released.
- Plain Postgres insert, read before flush: retained.
- `onConflictDoNothing()` / `onConflictDoUpdate()` insert: retained.
- Update row: retained.
- PGlite insert: unchanged and retained.

The new Postgres test verifies both released and retained rows in one table, find-after-insert, cross-batch `onConflictDoNothing()`, callback-based `onConflictDoUpdate()`, and cache hit/miss behavior. The existing delayed-error test verifies that a duplicate plain insert in a later batch still raises the Postgres unique-constraint error. Database writes, triggers, transaction rollback, retry, reorg, and crash-recovery data are unchanged.

## Benchmark

Workload: `benchmark/apps/reth/src/index.ts`, Postgres, complete historical cache.

- Base: `cc7ce34693c972b10eb63ff60f7a0f8704c67655`
- Candidate: `b9dffdd55400863065f59a599509361fd89abfd4`
- Harness: identical local-only post-ready metrics/resource/checksum instrumentation in both worktrees; scrape and output validation were outside the measured interval.
- Warmup cache: `cache_rate=100%` for `mainnet`, with no historical RPC fetching.
- Every measured run: `/metrics` reported Postgres through `ponder_settings_info`.
- Every parent and candidate scrape produced the same additive-metrics checksum: `479deb9285f3ff2be96ce09a972ccbb7505b52123d20de8239def15505be1e7e`.

Five alternating measured pairs, in execution order:

| Pair | Parent | Candidate |
|---|---:|---:|
| 1 | 18,698 ms | 17,043 ms |
| 2 | 17,273 ms | 16,842 ms |
| 3 | 17,369 ms | 15,817 ms |
| 4 | 16,489 ms | 19,019 ms |
| 5 | 17,438 ms | 16,899 ms |

| | Parent | Candidate | Delta |
|---|---:|---:|---:|
| Median | 17,369 ms | 16,899 ms | -470 ms (-2.7%) |
| Minimum | 16,489 ms | 15,817 ms | -672 ms |
| Maximum | 18,698 ms | 19,019 ms | +321 ms |

The fourth candidate had a wall-time outlier even though its user CPU remained below every parent run. It is included above.

| Resource | Parent median | Candidate median | Delta |
|---|---:|---:|---:|
| User CPU | 18,502 ms | 17,045 ms | -1,457 ms (-7.9%) |
| System CPU | 774 ms | 677 ms | -97 ms |
| Peak RSS | 1,137 MiB | 590 MiB | -547 MiB (-48.1%) |

Raw parent `(user/system/RSS)`: `19396/798/1132`, `18621/839/1146`, `18347/764/1072`, `18150/774/1177`, `18502/757/1137` (ms/ms/MiB).

Raw candidate `(user/system/RSS)`: `16855/587/590`, `17177/677/584`, `16620/644/606`, `17222/699/582`, `17045/711/599` (ms/ms/MiB).

One tightly paired Bun CPU profile was captured per revision. Profiled user CPU fell from `19,865 ms` to `18,819 ms`. Profiled wall time was `18,101 ms` parent and `20,145 ms` candidate, another candidate wall-time outlier; profile-buffer RSS is excluded from the normal retained-memory comparison.

Host 1-minute load averages ranged from `2.39` to `3.38`; no timing was discarded.

## Output validation

All final warmup, measured, and profiled runs produced the same counts and checksums:

| Table | Rows | Checksum |
|---|---:|---|
| `account` | 51,227 | `8e795521d20a86ea8043fdd12ae1783f` |
| `allowance` | 54,996 | `0875d3c760becd28a1e059a66fa66d70` |
| `transfer_event` | 382,727 | `0a931acc6c99900e1c88bf1c3f0842da` |
| `approval_event` | 207,386 | `7724c3e50867270802b6e4a0126f45fd` |

## Checks

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --filter ponder typecheck`
- `pnpm lint`
- `CI=1 pnpm --filter ponder test src/indexing-store/cache.test.ts src/indexing-store/index.test.ts` with PGlite: 34 passed, 3 skipped
- Same cache suite with Postgres: 9 passed

## Tradeoffs

A later access to a released plain-insert row performs a Postgres read and then caches the result. This trades work only for rows that prove they are not write-only. The table-wide completeness flag means one released row makes absence inconclusive for that table; conflict-aware tables avoid this transition because their inserted rows are retained by default.