### PR TITLE
Normalize only changed row fields

### DIFF
--- a/.changeset/quick-update-normalization.md
+++ b/.changeset/quick-update-normalization.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved indexing performance by normalizing only changed row fields during updates.

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -502,7 +502,7 @@ export const createIndexingCache = ({
       return result;
     },
     set({ table, key, row: _row, isUpdate }) {
-      const row = normalizeRow(table, _row, isUpdate);
+      const row = isUpdate ? _row : normalizeRow(table, _row, false);
       const ck = getCacheKey(table, key, primaryKeyCache);
 
       if (isUpdate) {

--- a/packages/core/src/indexing-store/index.test.ts
+++ b/packages/core/src/indexing-store/index.test.ts
@@ -132,6 +132,122 @@ test("find", async () => {
   });
 });
 
+test("update mutable values", async () => {
+  const schema = {
+    account: onchainTable("account", (p) => ({
+      address: p.hex().primaryKey(),
+      metadata: p
+        .json()
+        .$type<{ count: number; nested: { value: string } }>()
+        .notNull(),
+      values: p.integer().array().notNull(),
+      calldata: p.bytes().notNull(),
+      timestamp: p.timestamp().notNull(),
+    })),
+  };
+
+  const { database } = await setupDatabaseServices({
+    schemaBuild: { schema },
+  });
+  const indexingCache = createIndexingCache({
+    common: context.common,
+    schemaBuild: { schema },
+    crashRecoveryCheckpoint: undefined,
+    eventCount: {},
+  });
+  const indexingStore = createIndexingStore({
+    common: context.common,
+    schemaBuild: { schema },
+    indexingCache,
+    indexingErrorHandler,
+  });
+
+  await database.userQB.transaction(async (tx) => {
+    indexingCache.qb = tx;
+    indexingStore.qb = tx;
+
+    await indexingStore.db.insert(schema.account).values({
+      address: zeroAddress,
+      metadata: { count: 1, nested: { value: "one" } },
+      values: [1],
+      calldata: new Uint8Array([1]),
+      timestamp: new Date(1_000),
+    });
+
+    const previous = await indexingStore.db.find(schema.account, {
+      address: zeroAddress,
+    });
+    const metadata = { count: 2, nested: { value: "two" } };
+    const values = [2];
+    const calldata = new Uint8Array([2]);
+    const timestamp = new Date(2_000);
+    const upserted = await indexingStore.db
+      .insert(schema.account)
+      .values({
+        address: zeroAddress,
+        metadata,
+        values,
+        calldata,
+        timestamp,
+      })
+      .onConflictDoUpdate({ metadata, values, calldata, timestamp });
+
+    metadata.nested.value = "mutated input";
+    values.push(9);
+    calldata[0] = 9;
+    timestamp.setTime(9_000);
+    upserted.metadata.nested.value = "mutated result";
+    upserted.values.push(9);
+    upserted.calldata[0] = 9;
+    upserted.timestamp.setTime(9_000);
+
+    expect(previous).toMatchObject({
+      metadata: { count: 1, nested: { value: "one" } },
+      values: [1],
+      calldata: new Uint8Array([1]),
+      timestamp: new Date(1_000),
+    });
+    expect(
+      await indexingStore.db.find(schema.account, { address: zeroAddress }),
+    ).toMatchObject({
+      metadata: { count: 2, nested: { value: "two" } },
+      values: [2],
+      calldata: new Uint8Array([2]),
+      timestamp: new Date(2_000),
+    });
+
+    const updated = await indexingStore.db
+      .update(schema.account, { address: zeroAddress })
+      .set((row) => ({
+        metadata: {
+          count: row.metadata.count + 1,
+          nested: { value: "three" },
+        },
+        values: [...row.values, 3],
+        calldata: new Uint8Array([3]),
+        timestamp: new Date(3_000),
+      }));
+
+    updated.metadata.nested.value = "mutated update result";
+    updated.values.push(9);
+    updated.calldata[0] = 9;
+    updated.timestamp.setTime(9_000);
+
+    await indexingCache.flush();
+    indexingCache.clear();
+    indexingCache.invalidate();
+
+    expect(
+      await indexingStore.db.find(schema.account, { address: zeroAddress }),
+    ).toMatchObject({
+      metadata: { count: 3, nested: { value: "three" } },
+      values: [2, 3],
+      calldata: new Uint8Array([3]),
+      timestamp: new Date(3_000),
+    });
+  });
+});
+
 test("insert", async () => {
   const { database } = await setupDatabaseServices();
 

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -35,7 +35,7 @@ import { prettyPrint } from "@/utils/print.js";
 import { getSQLQueryRelations, isReadonlySQLQuery } from "@/utils/sql-parse.js";
 import { startClock } from "@/utils/timer.js";
 import type { IndexingCache, Row } from "./cache.js";
-import { getPrimaryKeyCache } from "./utils.js";
+import { getPrimaryKeyCache, normalizeUpdateSet } from "./utils.js";
 
 export type IndexingStore = {
   db: Db<Schema>;
@@ -259,6 +259,7 @@ export const createIndexingStore = ({
                             ponderRowUpdate,
                             primaryKeyCache,
                           );
+                          normalizeUpdateSet(table, ponderSet);
                           for (const [key, value] of Object.entries(
                             ponderSet,
                           )) {
@@ -274,6 +275,7 @@ export const createIndexingStore = ({
                             ponderRowUpdate,
                             primaryKeyCache,
                           );
+                          normalizeUpdateSet(table, ponderSet);
                           for (const [key, value] of Object.entries(
                             ponderSet,
                           )) {
@@ -324,6 +326,7 @@ export const createIndexingStore = ({
                           ponderRowUpdate,
                           primaryKeyCache,
                         );
+                        normalizeUpdateSet(table, ponderSet);
                         for (const [key, value] of Object.entries(ponderSet)) {
                           if (value === undefined) continue;
                           ponderRowUpdate[key] = value;
@@ -337,6 +340,7 @@ export const createIndexingStore = ({
                           ponderRowUpdate,
                           primaryKeyCache,
                         );
+                        normalizeUpdateSet(table, ponderSet);
                         for (const [key, value] of Object.entries(ponderSet)) {
                           if (value === undefined) continue;
                           ponderRowUpdate[key] = value;
@@ -519,6 +523,7 @@ export const createIndexingStore = ({
                 ponderRowUpdate,
                 primaryKeyCache,
               );
+              normalizeUpdateSet(table, ponderSet);
               for (const [key, value] of Object.entries(ponderSet)) {
                 if (value === undefined) continue;
                 ponderRowUpdate[key] = value;
@@ -532,6 +537,7 @@ export const createIndexingStore = ({
                 ponderRowUpdate,
                 primaryKeyCache,
               );
+              normalizeUpdateSet(table, ponderSet);
               for (const [key, value] of Object.entries(ponderSet)) {
                 if (value === undefined) continue;
                 ponderRowUpdate[key] = value;

--- a/packages/core/src/indexing-store/utils.test.ts
+++ b/packages/core/src/indexing-store/utils.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { onchainTable } from "@/drizzle/onchain.js";
-import { normalizeColumn } from "./utils.js";
+import { normalizeColumn, normalizeUpdateSet } from "./utils.js";
 
 test("normalize smallint", () => {
   const column = onchainTable("account", (t) => ({
@@ -11,4 +11,41 @@ test("normalize smallint", () => {
   const value = 123;
   const result = normalizeColumn(column.balance, value, false);
   expect(result).toBe(value);
+});
+
+test("normalizeUpdateSet", () => {
+  const table = onchainTable("account", (t) => ({
+    address: t.hex().primaryKey(),
+    balance: t.bigint(),
+    metadata: t.json(),
+    values: t.integer().array(),
+    bytes: t.bytes(),
+    timestamp: t.timestamp(),
+  }));
+  const addressMapper = vi.spyOn(table.address, "mapToDriverValue");
+  const metadata = { nested: [1, 2] };
+  const values = [1, 2];
+  const bytes = new Uint8Array([1, 2]);
+  const timestamp = new Date(1742925862000);
+
+  const result = normalizeUpdateSet(table, {
+    metadata,
+    values,
+    bytes,
+    timestamp,
+    balance: undefined,
+  });
+
+  expect(addressMapper).not.toHaveBeenCalled();
+  expect(result).toMatchObject({
+    metadata,
+    values,
+    bytes,
+    timestamp,
+    balance: undefined,
+  });
+  expect(result.metadata).not.toBe(metadata);
+  expect(result.values).not.toBe(values);
+  expect(result.bytes).toBeInstanceOf(Uint8Array);
+  expect(result.timestamp).toBeInstanceOf(Date);
 });

--- a/packages/core/src/indexing-store/utils.ts
+++ b/packages/core/src/indexing-store/utils.ts
@@ -16,6 +16,21 @@ import {
 } from "@/internal/errors.js";
 import { prettyPrint } from "@/utils/print.js";
 
+const tableColumnCache = new WeakMap<
+  Table,
+  { columns: Record<string, Column>; entries: [string, Column][] }
+>();
+
+const getCachedTableColumns = (table: Table) => {
+  let cached = tableColumnCache.get(table);
+  if (cached === undefined) {
+    const columns = getTableColumns(table);
+    cached = { columns, entries: Object.entries(columns) };
+    tableColumnCache.set(table, cached);
+  }
+  return cached;
+};
+
 /**
  * Returns true if the column has a "default" value that is used when no value is passed.
  * Handles `.default`, `.$defaultFn()`, `.$onUpdateFn()`.
@@ -102,7 +117,7 @@ export const normalizeRow = (
   row: { [key: string]: unknown },
   isUpdate: boolean,
 ) => {
-  for (const [columnName, column] of Object.entries(getTableColumns(table))) {
+  for (const [columnName, column] of getCachedTableColumns(table).entries) {
     // not-null constraint
     if (
       isUpdate === false &&
@@ -124,6 +139,19 @@ export const normalizeRow = (
     row[columnName] = normalizeColumn(column, row[columnName], isUpdate);
   }
 
+  return row;
+};
+
+export const normalizeUpdateSet = (
+  table: Table,
+  row: { [key: string]: unknown },
+) => {
+  const { columns } = getCachedTableColumns(table);
+  for (const [columnName, value] of Object.entries(row)) {
+    const column = columns[columnName];
+    if (value === undefined || column === undefined) continue;
+    row[columnName] = normalizeColumn(column, value, true);
+  }
   return row;
 };
 


### PR DESCRIPTION
## Bottleneck

Every update started from an already-normalized cached row, changed a small update set, and then passed the complete row through every column driver mapper again. The rETH account/allowance updates therefore repeatedly normalized unchanged primary keys, booleans, and other fields.

This change caches table column metadata, normalizes only defined fields in the copied update set, merges those fields into the copied cached row, and buffers that already-normalized full row. Full insert normalization remains unchanged.

## Correctness

Ownership isolation is preserved in the same order:

1. Copy the cached row.
2. Run the update callback, if present, against a copy-on-write view.
3. Defensively copy the returned/provided update set.
4. Validate primary-key changes against the copied set.
5. Normalize only defined schema fields in that set.
6. Merge into the copied full row.

Unknown runtime keys and `undefined` fields retain their previous merge behavior. Existing normalized fields are not remapped. The integration test covers object and callback updates, `onConflictDoUpdate`, nested JSON, arrays, bytes, timestamps, input/result mutation, previously returned rows, flush, cache invalidation, and database reload. A focused mapper test verifies that an unchanged primary-key mapper is not called.

## Benchmark

Workload: `benchmark/apps/reth/src/index.ts`, Postgres, complete historical cache.

- Base: `cc7ce34693c972b10eb63ff60f7a0f8704c67655`
- Candidate: `755235b9fa9ce9099b1bd88cac923a80d212b302`
- Harness: identical local-only post-ready metrics/resource/checksum instrumentation in both worktrees; scrape and output validation were outside the measured interval.
- Warmup cache: `cache_rate=100%` for `mainnet`, with no historical RPC fetching.
- Every measured run: `/metrics` reported Postgres through `ponder_settings_info`.
- Every parent and candidate scrape produced the same additive-metrics checksum: `479deb9285f3ff2be96ce09a972ccbb7505b52123d20de8239def15505be1e7e`.

Five alternating measured pairs, in execution order:

| Pair | Parent | Candidate |
|---|---:|---:|
| 1 | 21,202 ms | 17,126 ms |
| 2 | 17,699 ms | 17,879 ms |
| 3 | 17,705 ms | 17,468 ms |
| 4 | 17,991 ms | 17,176 ms |
| 5 | 17,975 ms | 16,963 ms |

| | Parent | Candidate | Delta |
|---|---:|---:|---:|
| Median | 17,975 ms | 17,176 ms | -799 ms (-4.4%) |
| Minimum | 17,699 ms | 16,963 ms | -736 ms |
| Maximum | 21,202 ms | 17,879 ms | -3,323 ms |

The first parent run coincided with the highest 1-minute host load (`3.90`) and is retained above. Pair 2 favored the parent by `180 ms`; the other four pairs favored the candidate.

| Resource | Parent median | Candidate median | Delta |
|---|---:|---:|---:|
| User CPU | 19,178 ms | 18,588 ms | -590 ms (-3.1%) |
| System CPU | 827 ms | 766 ms | -61 ms |
| Peak RSS | 1,102 MiB | 1,122 MiB | +20 MiB (+1.8%) |

Raw parent `(user/system/RSS)`: `20056/866/1102`, `19065/851/1078`, `18777/827/1121`, `19272/810/1064`, `19178/800/1150` (ms/ms/MiB).

Raw candidate `(user/system/RSS)`: `18426/721/1122`, `19071/812/1075`, `18588/736/1122`, `18844/766/1128`, `18420/792/1066` (ms/ms/MiB).

One tightly paired Bun CPU profile was captured per revision. Profiled wall/user CPU was `18,477/19,866 ms` on the parent and `17,906/19,423 ms` on the candidate. Profile-buffer RSS is excluded from the normal RSS comparison.