### PR TITLE
Use schema-aware copies for scalar rows

### DIFF
--- a/.changeset/fast-scalar-row-copy.md
+++ b/.changeset/fast-scalar-row-copy.md
@@ -2,4 +2,4 @@
 "ponder": patch
 ---
 
-Improved indexing performance by using schema-aware copies for scalar rows.
+Improved indexing performance by using schema-aware copying.

--- a/.changeset/fast-scalar-row-copy.md
+++ b/.changeset/fast-scalar-row-copy.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved indexing performance by using schema-aware copies for scalar rows.

--- a/packages/core/src/_test/simulate.ts
+++ b/packages/core/src/_test/simulate.ts
@@ -16,9 +16,15 @@ import type {
   SyncTransactionReceipt,
 } from "@/internal/types.js";
 import { toLowerCase } from "@/utils/lowercase.js";
-import Erc20Bytecode from "./contracts/out/ERC20.sol/ERC20.json";
-import FactoryBytecode from "./contracts/out/Factory.sol/Factory.json";
-import RevertBytecode from "./contracts/out/Revert.sol/Revert.json";
+import Erc20Bytecode from "./contracts/out/ERC20.sol/ERC20.json" with {
+  type: "json",
+};
+import FactoryBytecode from "./contracts/out/Factory.sol/Factory.json" with {
+  type: "json",
+};
+import RevertBytecode from "./contracts/out/Revert.sol/Revert.json" with {
+  type: "json",
+};
 import { erc20ABI, factoryABI, pairABI, revertABI } from "./generated.js";
 import { anvil, publicClient, testClient } from "./utils.js";
 

--- a/packages/core/src/build/schema.test.ts
+++ b/packages/core/src/build/schema.test.ts
@@ -190,14 +190,13 @@ test("buildSchema() error with $onUpdateFn sql", () => {
 });
 
 test("buildSchema() error with foreign key", () => {
-  // @ts-expect-error
   const schema = {
     account: onchainTable("account", (p) => ({
       address: p.integer().primaryKey(),
       balance: p
         .bigint()
         .notNull()
-        .references(() => schema.account.address),
+        .references((): any => schema.account.address),
     })),
   };
 

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -1,5 +1,6 @@
 import {
   type Column,
+  getTableColumns,
   getTableName,
   getViewName,
   isTable,
@@ -117,6 +118,21 @@ export const createIndexingStore = ({
   const tables = Object.values(schema).filter(isTable);
   const views = Object.values(schema).filter(isView);
   const primaryKeyCache = getPrimaryKeyCache(tables);
+  const copyModes = new Map(
+    tables.map((table) => [
+      table,
+      Object.values(getTableColumns(table)).every((column) =>
+        ["string", "number", "boolean", "bigint"].includes(column.dataType),
+      )
+        ? ("shallow" as const)
+        : ("auto" as const),
+    ]),
+  );
+  const copyRow = <T>(table: Table, row: T) => copy(row, copyModes.get(table));
+  const copyRows = <T>(table: Table, rows: T | T[]) =>
+    Array.isArray(rows)
+      ? rows.map((row) => copyRow(table, row))
+      : copyRow(table, rows);
 
   const lock = createLock();
 
@@ -183,7 +199,7 @@ export const createIndexingStore = ({
                 );
                 checkOnchainTable(table, "insert");
 
-                const ponderValues = copy(userValues);
+                const ponderValues = copyRows(table, userValues);
 
                 if (Array.isArray(ponderValues)) {
                   const ponderRows = [];
@@ -248,11 +264,11 @@ export const createIndexingStore = ({
                       });
 
                       if (ponderRowUpdate) {
-                        ponderRowUpdate = copy(ponderRowUpdate);
+                        ponderRowUpdate = copyRow(table, ponderRowUpdate);
                         if (typeof userUpdateValues === "function") {
                           const userRowUpdate = copyOnWrite(ponderRowUpdate);
                           const userSet = userUpdateValues(userRowUpdate);
-                          const ponderSet = copy(userSet);
+                          const ponderSet = copyRow(table, userSet);
                           validateUpdateSet(
                             table,
                             ponderSet,
@@ -268,7 +284,7 @@ export const createIndexingStore = ({
                           }
                         } else {
                           const userSet = userUpdateValues;
-                          const ponderSet = copy(userSet);
+                          const ponderSet = copyRow(table, userSet);
                           validateUpdateSet(
                             table,
                             ponderSet,
@@ -292,7 +308,7 @@ export const createIndexingStore = ({
                           }),
                         );
                       } else {
-                        const ponderValue = copy(value);
+                        const ponderValue = copyRow(table, value);
                         ponderRows.push(
                           indexingCache.set({
                             table,
@@ -315,11 +331,11 @@ export const createIndexingStore = ({
                     });
 
                     if (ponderRowUpdate) {
-                      ponderRowUpdate = copy(ponderRowUpdate);
+                      ponderRowUpdate = copyRow(table, ponderRowUpdate);
                       if (typeof userUpdateValues === "function") {
                         const userRowUpdate = copyOnWrite(ponderRowUpdate);
                         const userSet = userUpdateValues(userRowUpdate);
-                        const ponderSet = copy(userSet);
+                        const ponderSet = copyRow(table, userSet);
                         validateUpdateSet(
                           table,
                           ponderSet,
@@ -333,7 +349,7 @@ export const createIndexingStore = ({
                         }
                       } else {
                         const userSet = userUpdateValues;
-                        const ponderSet = copy(userSet);
+                        const ponderSet = copyRow(table, userSet);
                         validateUpdateSet(
                           table,
                           ponderSet,
@@ -356,7 +372,7 @@ export const createIndexingStore = ({
                       return userRow;
                     }
 
-                    const ponderValues = copy(userValues);
+                    const ponderValues = copyRow(table, userValues);
 
                     const ponderRowInsert = indexingCache.set({
                       table,
@@ -378,7 +394,7 @@ export const createIndexingStore = ({
                     "insert",
                   );
                   checkOnchainTable(table, "insert");
-                  const ponderValues = copy(userValues);
+                  const ponderValues = copyRows(table, userValues);
 
                   if (Array.isArray(ponderValues)) {
                     const ponderRows = [];
@@ -511,12 +527,12 @@ export const createIndexingStore = ({
               throw error;
             }
 
-            ponderRowUpdate = copy(ponderRowUpdate);
+            ponderRowUpdate = copyRow(table, ponderRowUpdate);
 
             if (typeof userValues === "function") {
               const userRow = copyOnWrite(ponderRowUpdate);
               const userSet = userValues(userRow);
-              const ponderSet = copy(userSet);
+              const ponderSet = copyRow(table, userSet);
               validateUpdateSet(
                 table,
                 ponderSet,
@@ -530,7 +546,7 @@ export const createIndexingStore = ({
               }
             } else {
               const userSet = userValues;
-              const ponderSet = copy(userSet);
+              const ponderSet = copyRow(table, userSet);
               validateUpdateSet(
                 table,
                 ponderSet,

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -118,21 +118,14 @@ export const createIndexingStore = ({
   const tables = Object.values(schema).filter(isTable);
   const views = Object.values(schema).filter(isView);
   const primaryKeyCache = getPrimaryKeyCache(tables);
-  const copyModes = new Map(
+  const isCopyFast = new Map(
     tables.map((table) => [
       table,
       Object.values(getTableColumns(table)).every((column) =>
         ["string", "number", "boolean", "bigint"].includes(column.dataType),
-      )
-        ? ("shallow" as const)
-        : ("auto" as const),
+      ),
     ]),
   );
-  const copyRow = <T>(table: Table, row: T) => copy(row, copyModes.get(table));
-  const copyRows = <T>(table: Table, rows: T | T[]) =>
-    Array.isArray(rows)
-      ? rows.map((row) => copyRow(table, row))
-      : copyRow(table, rows);
 
   const lock = createLock();
 
@@ -199,7 +192,11 @@ export const createIndexingStore = ({
                 );
                 checkOnchainTable(table, "insert");
 
-                const ponderValues = copyRows(table, userValues);
+                const ponderValues = Array.isArray(userValues)
+                  ? userValues.map((value) =>
+                      copy(value, isCopyFast.get(table)!),
+                    )
+                  : copy(userValues, isCopyFast.get(table)!);
 
                 if (Array.isArray(ponderValues)) {
                   const ponderRows = [];
@@ -264,11 +261,17 @@ export const createIndexingStore = ({
                       });
 
                       if (ponderRowUpdate) {
-                        ponderRowUpdate = copyRow(table, ponderRowUpdate);
+                        ponderRowUpdate = copy(
+                          ponderRowUpdate,
+                          isCopyFast.get(table)!,
+                        );
                         if (typeof userUpdateValues === "function") {
                           const userRowUpdate = copyOnWrite(ponderRowUpdate);
                           const userSet = userUpdateValues(userRowUpdate);
-                          const ponderSet = copyRow(table, userSet);
+                          const ponderSet = copy(
+                            userSet,
+                            isCopyFast.get(table)!,
+                          );
                           validateUpdateSet(
                             table,
                             ponderSet,
@@ -284,7 +287,10 @@ export const createIndexingStore = ({
                           }
                         } else {
                           const userSet = userUpdateValues;
-                          const ponderSet = copyRow(table, userSet);
+                          const ponderSet = copy(
+                            userSet,
+                            isCopyFast.get(table)!,
+                          );
                           validateUpdateSet(
                             table,
                             ponderSet,
@@ -308,7 +314,7 @@ export const createIndexingStore = ({
                           }),
                         );
                       } else {
-                        const ponderValue = copyRow(table, value);
+                        const ponderValue = copy(value, isCopyFast.get(table)!);
                         ponderRows.push(
                           indexingCache.set({
                             table,
@@ -331,11 +337,14 @@ export const createIndexingStore = ({
                     });
 
                     if (ponderRowUpdate) {
-                      ponderRowUpdate = copyRow(table, ponderRowUpdate);
+                      ponderRowUpdate = copy(
+                        ponderRowUpdate,
+                        isCopyFast.get(table)!,
+                      );
                       if (typeof userUpdateValues === "function") {
                         const userRowUpdate = copyOnWrite(ponderRowUpdate);
                         const userSet = userUpdateValues(userRowUpdate);
-                        const ponderSet = copyRow(table, userSet);
+                        const ponderSet = copy(userSet, isCopyFast.get(table)!);
                         validateUpdateSet(
                           table,
                           ponderSet,
@@ -349,7 +358,7 @@ export const createIndexingStore = ({
                         }
                       } else {
                         const userSet = userUpdateValues;
-                        const ponderSet = copyRow(table, userSet);
+                        const ponderSet = copy(userSet, isCopyFast.get(table)!);
                         validateUpdateSet(
                           table,
                           ponderSet,
@@ -372,7 +381,10 @@ export const createIndexingStore = ({
                       return userRow;
                     }
 
-                    const ponderValues = copyRow(table, userValues);
+                    const ponderValues = copy(
+                      userValues,
+                      isCopyFast.get(table)!,
+                    );
 
                     const ponderRowInsert = indexingCache.set({
                       table,
@@ -394,7 +406,11 @@ export const createIndexingStore = ({
                     "insert",
                   );
                   checkOnchainTable(table, "insert");
-                  const ponderValues = copyRows(table, userValues);
+                  const ponderValues = Array.isArray(userValues)
+                    ? userValues.map((value) =>
+                        copy(value, isCopyFast.get(table)!),
+                      )
+                    : copy(userValues, isCopyFast.get(table)!);
 
                   if (Array.isArray(ponderValues)) {
                     const ponderRows = [];
@@ -527,12 +543,12 @@ export const createIndexingStore = ({
               throw error;
             }
 
-            ponderRowUpdate = copyRow(table, ponderRowUpdate);
+            ponderRowUpdate = copy(ponderRowUpdate, isCopyFast.get(table)!);
 
             if (typeof userValues === "function") {
               const userRow = copyOnWrite(ponderRowUpdate);
               const userSet = userValues(userRow);
-              const ponderSet = copyRow(table, userSet);
+              const ponderSet = copy(userSet, isCopyFast.get(table)!);
               validateUpdateSet(
                 table,
                 ponderSet,
@@ -546,7 +562,7 @@ export const createIndexingStore = ({
               }
             } else {
               const userSet = userValues;
-              const ponderSet = copyRow(table, userSet);
+              const ponderSet = copy(userSet, isCopyFast.get(table)!);
               validateUpdateSet(
                 table,
                 ponderSet,

--- a/packages/core/src/utils/copy.bench.ts
+++ b/packages/core/src/utils/copy.bench.ts
@@ -6,7 +6,7 @@ const obj = { a: 1, b: 2n, c: { d: 3 }, e: "hello" };
 group("copy", () => {
   // 48.55 ns/iter
   bench("copy", () => {
-    copy({ a: 1, b: 2 });
+    copy({ a: 1, b: 2 }, true);
   }).gc("inner");
   // 540.76 ns/iter
   bench("structuredClone", () => {

--- a/packages/core/src/utils/copy.test.ts
+++ b/packages/core/src/utils/copy.test.ts
@@ -60,7 +60,7 @@ test("copyOnWrite nested array", () => {
 test("copy", () => {
   const obj = { a: 1, b: 2 };
   const copiedObj = copyOnWrite(obj);
-  const copiedObj2 = copy(copiedObj);
+  const copiedObj2 = copy(copiedObj, false);
 
   expect(copiedObj.a).toBe(1);
   expect(copiedObj.b).toBe(2);
@@ -76,12 +76,12 @@ test("copy", () => {
   expect(copiedObj.a).toBe(3);
   expect(copiedObj.b).toBe(2);
 
-  copy([copiedObj]);
+  copy([copiedObj], false);
 });
 
 test("copy shallow", () => {
   const obj = { a: 1, b: "value", c: 2n, d: true };
-  const copiedObj = copy(obj, "shallow");
+  const copiedObj = copy(obj, true);
 
   expect(copiedObj).toEqual(obj);
   expect(copiedObj).not.toBe(obj);
@@ -93,7 +93,7 @@ test("copy bytes", () => {
     calldata: toBytes(zeroAddress),
   };
   const copiedObj = copyOnWrite(obj);
-  const copiedObj2 = copy(copiedObj);
+  const copiedObj2 = copy(copiedObj, false);
 
   expect(copiedObj.calldata).toMatchInlineSnapshot(`
     Uint8Array [
@@ -155,7 +155,7 @@ test("copy timestamp", () => {
     timestamp: new Date(1742925862000),
   };
 
-  const copiedObj = copy(obj);
+  const copiedObj = copy(obj, false);
 
   expect(copiedObj.timestamp).toBeInstanceOf(Date);
 });

--- a/packages/core/src/utils/copy.test.ts
+++ b/packages/core/src/utils/copy.test.ts
@@ -79,6 +79,14 @@ test("copy", () => {
   copy([copiedObj]);
 });
 
+test("copy shallow", () => {
+  const obj = { a: 1, b: "value", c: 2n, d: true };
+  const copiedObj = copy(obj, "shallow");
+
+  expect(copiedObj).toEqual(obj);
+  expect(copiedObj).not.toBe(obj);
+});
+
 test("copy bytes", () => {
   const obj = {
     address: zeroAddress,

--- a/packages/core/src/utils/copy.ts
+++ b/packages/core/src/utils/copy.ts
@@ -82,9 +82,17 @@ export const copyOnWrite = <T extends object>(obj: T): T => {
  * @dev This function supports copying objects that
  * have been created with `copyOnWrite`.
  */
-export const copy = <T>(obj: T): T => {
+export const copy = <T>(obj: T, mode: "auto" | "shallow" = "auto"): T => {
   if (obj === null || typeof obj !== "object") {
     return obj;
+  }
+
+  // @ts-expect-error
+  const proxy = obj[COPY_ON_WRITE];
+  if (proxy !== undefined) return proxy;
+
+  if (mode === "shallow") {
+    return (Array.isArray(obj) ? [...obj] : { ...obj }) as T;
   }
 
   const hasProxy = (obj: any): boolean => {
@@ -131,33 +139,27 @@ export const copy = <T>(obj: T): T => {
     return false;
   };
 
-  // @ts-expect-error
-  const proxy = obj[COPY_ON_WRITE];
-  if (proxy === undefined) {
-    if (Array.isArray(obj)) {
-      if (hasProxy(obj)) {
-        // @ts-expect-error
-        return obj.map((element) => copy(element));
-      }
-
-      if (isDeeplyNested(obj)) return structuredClone(obj);
-      return [...obj] as T;
-    }
-
+  if (Array.isArray(obj)) {
     if (hasProxy(obj)) {
-      const result = {} as T;
-      for (const [key, value] of Object.entries(obj)) {
-        // @ts-expect-error
-        result[key] = copy(value);
-      }
-
-      return result;
+      // @ts-expect-error
+      return obj.map((element) => copy(element));
     }
 
-    // Note: spread operator is significantly faster than `structuredClone`
     if (isDeeplyNested(obj)) return structuredClone(obj);
-    return { ...obj };
+    return [...obj] as T;
   }
 
-  return proxy;
+  if (hasProxy(obj)) {
+    const result = {} as T;
+    for (const [key, value] of Object.entries(obj)) {
+      // @ts-expect-error
+      result[key] = copy(value);
+    }
+
+    return result;
+  }
+
+  // Note: spread operator is significantly faster than `structuredClone`
+  if (isDeeplyNested(obj)) return structuredClone(obj);
+  return { ...obj };
 };

--- a/packages/core/src/utils/copy.ts
+++ b/packages/core/src/utils/copy.ts
@@ -82,7 +82,7 @@ export const copyOnWrite = <T extends object>(obj: T): T => {
  * @dev This function supports copying objects that
  * have been created with `copyOnWrite`.
  */
-export const copy = <T>(obj: T, mode: "auto" | "shallow" = "auto"): T => {
+export const copy = <T>(obj: T, fast: boolean): T => {
   if (obj === null || typeof obj !== "object") {
     return obj;
   }
@@ -91,53 +91,10 @@ export const copy = <T>(obj: T, mode: "auto" | "shallow" = "auto"): T => {
   const proxy = obj[COPY_ON_WRITE];
   if (proxy !== undefined) return proxy;
 
-  if (mode === "shallow") {
+  if (fast) {
+    // Note: spread operator is significantly faster than `structuredClone`
     return (Array.isArray(obj) ? [...obj] : { ...obj }) as T;
   }
-
-  const hasProxy = (obj: any): boolean => {
-    if (obj === null || typeof obj !== "object") {
-      return false;
-    }
-
-    if (obj[COPY_ON_WRITE] !== undefined) {
-      return true;
-    }
-
-    if (Array.isArray(obj)) {
-      return obj.some((element) => hasProxy(element));
-    }
-
-    for (const value of Object.values(obj)) {
-      if (hasProxy(value)) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
-  const isDeeplyNested = (obj: any, depth = 0): boolean => {
-    if (obj === null || typeof obj !== "object") {
-      return false;
-    }
-
-    if (depth > 0) {
-      return true;
-    }
-
-    if (Array.isArray(obj)) {
-      return obj.some((element) => isDeeplyNested(element, depth + 1));
-    }
-
-    for (const value of Object.values(obj)) {
-      if (isDeeplyNested(value, depth + 1)) {
-        return true;
-      }
-    }
-
-    return false;
-  };
 
   if (Array.isArray(obj)) {
     if (hasProxy(obj)) {
@@ -159,7 +116,50 @@ export const copy = <T>(obj: T, mode: "auto" | "shallow" = "auto"): T => {
     return result;
   }
 
-  // Note: spread operator is significantly faster than `structuredClone`
   if (isDeeplyNested(obj)) return structuredClone(obj);
   return { ...obj };
+};
+
+const hasProxy = (obj: any): boolean => {
+  if (obj === null || typeof obj !== "object") {
+    return false;
+  }
+
+  if (obj[COPY_ON_WRITE] !== undefined) {
+    return true;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.some((element) => hasProxy(element));
+  }
+
+  for (const value of Object.values(obj)) {
+    if (hasProxy(value)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const isDeeplyNested = (obj: any, depth = 0): boolean => {
+  if (obj === null || typeof obj !== "object") {
+    return false;
+  }
+
+  if (depth > 0) {
+    return true;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.some((element) => isDeeplyNested(element, depth + 1));
+  }
+
+  for (const value of Object.values(obj)) {
+    if (isDeeplyNested(value, depth + 1)) {
+      return true;
+    }
+  }
+
+  return false;
 };


### PR DESCRIPTION
## Bottleneck

The generic defensive `copy()` path recursively searched every row for copy-on-write proxies, then walked it again to decide whether `structuredClone()` was necessary. Tables containing only immutable scalar columns paid both walks for every insert and update even though a shallow object copy is sufficient.

This change classifies each table once from Drizzle column metadata. Tables whose columns are exclusively `string`, `number`, `boolean`, or `bigint` use a direct shallow row copy. Tables containing JSON, arrays, bytes, dates, custom columns, or unknown types keep the existing automatic proxy-aware/deep-copy path. Batch inserts copy each row according to its table instead of treating the outer array as one unknown object graph.

## Correctness

The scalar fast path is used only for schema values that cannot be mutated through a shared reference. Copy-on-write rows are still unwrapped before either strategy. All mutable or unknown column types retain the existing recursive behavior.

The integration test covers nested JSON, arrays, bytes, timestamps, object and callback updates, `onConflictDoUpdate`, mutation of input and returned values, previously returned rows, flush, cache invalidation, and database reload. Existing copy/cache/store suites remain unchanged and pass.

## Benchmark

Workload: `benchmark/apps/reth/src/index.ts`, Postgres, complete historical cache.

- Base: `cc7ce34693c972b10eb63ff60f7a0f8704c67655`
- Candidate: `8a8f2515040c1a4221ae1ddc338b01bcd7c8f3f8`
- Harness: identical local-only post-ready metrics/resource/checksum instrumentation in both worktrees; scrape and output validation were outside the measured interval.
- Warmup cache: `cache_rate=100%` for `mainnet`, with no historical RPC fetching.
- Every measured run: `/metrics` reported Postgres through `ponder_settings_info`.
- Every parent and candidate scrape produced the same additive-metrics checksum: `479deb9285f3ff2be96ce09a972ccbb7505b52123d20de8239def15505be1e7e`.

Five alternating measured pairs, in execution order:

| Pair | Parent | Candidate |
|---|---:|---:|
| 1 | 20,077 ms | 17,401 ms |
| 2 | 19,305 ms | 16,744 ms |
| 3 | 17,820 ms | 16,982 ms |
| 4 | 18,059 ms | 17,319 ms |
| 5 | 17,399 ms | 17,984 ms |

| | Parent | Candidate | Delta |
|---|---:|---:|---:|
| Median | 18,059 ms | 17,319 ms | -740 ms (-4.1%) |
| Minimum | 17,399 ms | 16,744 ms | -655 ms |
| Maximum | 20,077 ms | 17,984 ms | -2,093 ms |

Pair 5 favored the parent by `585 ms`; the other four pairs favored the candidate. No timing was discarded.

| Resource | Parent median | Candidate median | Delta |
|---|---:|---:|---:|
| User CPU | 19,068 ms | 18,352 ms | -716 ms (-3.8%) |
| System CPU | 822 ms | 767 ms | -55 ms |
| Peak RSS | 1,140 MiB | 1,097 MiB | -43 MiB (-3.8%) |

Raw parent `(user/system/RSS)`: `19231/847/1146`, `19068/818/1132`, `19052/822/1140`, `19493/823/1171`, `18882/757/1124` (ms/ms/MiB).

Raw candidate `(user/system/RSS)`: `18352/721/1128`, `18226/699/1111`, `18106/767/1097`, `18455/827/1066`, `18854/805/1095` (ms/ms/MiB).

One tightly paired Bun CPU profile was captured per revision. Profiled wall/user CPU was `17,719/19,450 ms` on the parent and `17,704/19,316 ms` on the candidate. Profile-buffer RSS is excluded from the normal RSS comparison.