### PR TITLE
Skip unused log transaction queries

### DIFF
--- a/.changeset/skip-unused-log-transactions.md
+++ b/.changeset/skip-unused-log-transactions.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved cached log indexing performance by avoiding unused transaction data queries.

--- a/packages/core/src/indexing/index.test.ts
+++ b/packages/core/src/indexing/index.test.ts
@@ -1249,11 +1249,6 @@ test("processEvents() column selection", async () => {
       "log.logIndex",
       "log.removed",
       "log.topics",
-      "transaction.transactionIndex",
-      "transaction.from",
-      "transaction.to",
-      "transaction.hash",
-      "transaction.type",
       "block.timestamp",
       "block.number",
       "block.hash",
@@ -1272,6 +1267,39 @@ test("processEvents() column selection", async () => {
   ).rejects.toThrowError(
     new InvalidEventAccessError("transaction.maxPriorityFeePerGas"),
   );
+
+  eventCallbacks[0]!.fn = async ({ event }: { event: any }) => {
+    event.transaction.from;
+  };
+
+  const skippedTransactionEvent = {
+    ...event,
+    isTransactionDataSkipped: true,
+    event: { ...event.event, transaction: undefined },
+  } as unknown as typeof event;
+
+  await expect(
+    indexing.processHistoricalEvents({
+      events: [skippedTransactionEvent],
+      updateIndexingSeconds: vi.fn(),
+    }),
+  ).rejects.toThrowError(new InvalidEventAccessError("transaction.from"));
+
+  eventCallbacks[0]!.fn = async ({ event }: { event: any }) => {
+    event.transaction?.from;
+  };
+
+  const missingTransactionEvent = {
+    ...event,
+    event: { ...event.event, transaction: undefined },
+  } as unknown as typeof event;
+
+  await expect(
+    indexing.processHistoricalEvents({
+      events: [missingTransactionEvent],
+      updateIndexingSeconds: vi.fn(),
+    }),
+  ).resolves.toBeUndefined();
 });
 
 test("ponderActions getBalance()", async () => {

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -526,10 +526,13 @@ export const createIndexing = ({
             blockProxy.underlying = event.event.block as Block;
             proxyEvent.block = blockProxy.proxy;
 
-            if (event.event.transaction !== undefined) {
+            if (
+              event.event.transaction !== undefined ||
+              event.isTransactionDataSkipped
+            ) {
               transactionProxy.eventName = event.eventCallback.name;
-              transactionProxy.underlying = event.event
-                .transaction as Transaction;
+              transactionProxy.underlying =
+                (event.event.transaction as Transaction) ?? ({} as Transaction);
               // @ts-expect-error
               proxyEvent.transaction = transactionProxy.proxy;
             }

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -497,6 +497,7 @@ export type RawEvent = {
   checkpoint: string;
   chainId: number;
   eventCallbackIndex: number;
+  isTransactionDataSkipped?: true;
   log?: UserLog;
   block: UserBlock;
   transaction?: UserTransaction;
@@ -568,6 +569,7 @@ export type LogEvent = {
   checkpoint: string;
   chain: Chain;
   eventCallback: EventCallback;
+  isTransactionDataSkipped?: true;
 
   event: {
     id: string;

--- a/packages/core/src/runtime/events.test.ts
+++ b/packages/core/src/runtime/events.test.ts
@@ -26,7 +26,7 @@ import type {
   TransferEvent,
 } from "@/internal/types.js";
 import { ZERO_CHECKPOINT_STRING } from "@/utils/checkpoint.js";
-import { decodeEvents, splitEvents } from "./events.js";
+import { buildEvents, decodeEvents, splitEvents } from "./events.js";
 
 beforeEach(setupCommon);
 
@@ -139,6 +139,55 @@ test("decodeEvents() log", async () => {
     to: ALICE.toLowerCase(),
     amount: parseEther("1"),
   });
+});
+
+test("buildEvents() distinguishes skipped and missing log transactions", () => {
+  const { eventCallbacks } = getErc20IndexingBuild({
+    address: zeroAddress,
+  });
+
+  const topics = encodeEventTopics({
+    abi: erc20ABI,
+    eventName: "Transfer",
+    args: {
+      from: zeroAddress,
+      to: ALICE,
+    },
+  });
+  const data = padHex(toHex(parseEther("1")), { size: 32 });
+  const params = {
+    eventCallbacks,
+    blocks: [{ number: 1n, hash: `0x${"0".repeat(64)}`, timestamp: 1n }],
+    logs: [
+      {
+        address: zeroAddress,
+        blockNumber: 1,
+        data,
+        logIndex: 0,
+        removed: false,
+        topics,
+        transactionIndex: 0,
+      },
+    ],
+    transactions: [],
+    transactionReceipts: [],
+    traces: [],
+    childAddresses: new Map(),
+    chainId: 1,
+  } as unknown as Parameters<typeof buildEvents>[0];
+
+  const [skippedTransactionEvent] = buildEvents({
+    ...params,
+    isTransactionDataSkipped: true,
+  });
+  const [missingTransactionEvent] = buildEvents(params);
+
+  expect(skippedTransactionEvent).toMatchObject({
+    isTransactionDataSkipped: true,
+    transaction: undefined,
+  });
+  expect(missingTransactionEvent?.isTransactionDataSkipped).toBeUndefined();
+  expect(missingTransactionEvent?.transaction).toBeUndefined();
 });
 
 test("decodeEvents() log error", async () => {

--- a/packages/core/src/runtime/events.ts
+++ b/packages/core/src/runtime/events.ts
@@ -71,6 +71,7 @@ export const buildEvents = ({
   traces,
   childAddresses,
   chainId,
+  isTransactionDataSkipped = false,
 }: {
   eventCallbacks: EventCallback[];
   blocks: InternalBlock[];
@@ -80,6 +81,7 @@ export const buildEvents = ({
   traces: InternalTrace[];
   childAddresses: Map<FactoryId, Map<Address, number>>;
   chainId: number;
+  isTransactionDataSkipped?: boolean;
 }) => {
   const events: RawEvent[] = [];
 
@@ -480,6 +482,7 @@ export const buildEvents = ({
         events.push({
           chainId: filter.chainId,
           eventCallbackIndex: logEventCallbackIndex,
+          isTransactionDataSkipped: isTransactionDataSkipped || undefined,
           checkpoint: encodeCheckpoint({
             blockTimestamp: block.timestamp,
             chainId: filter.chainId,
@@ -585,6 +588,7 @@ export const decodeEvents = (
         checkpoint: event.checkpoint,
         chain,
         eventCallback,
+        isTransactionDataSkipped: event.isTransactionDataSkipped,
 
         event: {
           id: event.checkpoint,

--- a/packages/core/src/runtime/filter.ts
+++ b/packages/core/src/runtime/filter.ts
@@ -566,7 +566,6 @@ export const defaultLogFilterInclude: LogFilter["include"] = [
 
 export const requiredLogFilterInclude: LogFilter["include"] = [
   ...requiredLogInclude.map((value) => `log.${value}` as const),
-  ...requiredTransactionInclude.map((value) => `transaction.${value}` as const),
   ...requiredBlockInclude.map((value) => `block.${value}` as const),
 ];
 

--- a/packages/core/src/runtime/historical.ts
+++ b/packages/core/src/runtime/historical.ts
@@ -934,6 +934,7 @@ export async function refetchLocalEvents(params: {
       transactions,
       transactionReceipts,
       traces,
+      isTransactionDataSkipped,
       cursor: queryCursor,
     } = await params.syncStore.getEventData({
       filters: params.eventCallbacks.map(({ filter }) => filter),
@@ -951,6 +952,7 @@ export async function refetchLocalEvents(params: {
       transactions,
       transactionReceipts,
       traces,
+      isTransactionDataSkipped,
       childAddresses: params.childAddresses,
       chainId: params.chain.id,
     });
@@ -1030,6 +1032,7 @@ export async function* getLocalEventGenerator(params: {
         transactions,
         transactionReceipts,
         traces,
+        isTransactionDataSkipped,
         cursor: queryCursor,
       } = await syncStore.getEventData({
         filters: params.eventCallbacks.map(({ filter }) => filter),
@@ -1047,6 +1050,7 @@ export async function* getLocalEventGenerator(params: {
         transactions,
         transactionReceipts,
         traces,
+        isTransactionDataSkipped,
         childAddresses: params.childAddresses,
         chainId: params.chain.id,
       });

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -1074,6 +1074,49 @@ test("getEventData() applies one block range to logs and traces queries", async 
   expect(tracesQuery!.values).toEqual(expect.arrayContaining([30n, 70n]));
 });
 
+test("getEventData() skips unused log transaction data", async () => {
+  const { database, syncStore } = await setupDatabaseServices();
+  const querySpy = vi.spyOn(database.syncQB.$client, "query");
+
+  const result = await syncStore.getEventData({
+    filters: [EMPTY_LOG_FILTER],
+    fromBlock: 0,
+    toBlock: 100,
+    chainId: 1,
+    limit: 10,
+  });
+
+  expect(result.isTransactionDataSkipped).toBe(true);
+  expect(
+    querySpy.mock.calls.some(([query]) =>
+      (typeof query === "string"
+        ? query
+        : (query as { text: string }).text
+      ).includes('from "ponder_sync"."transactions"'),
+    ),
+  ).toBe(false);
+
+  querySpy.mockClear();
+
+  const resultWithTransaction = await syncStore.getEventData({
+    filters: [{ ...EMPTY_LOG_FILTER, include: ["transaction.hash"] }],
+    fromBlock: 0,
+    toBlock: 100,
+    chainId: 1,
+    limit: 10,
+  });
+
+  expect(resultWithTransaction.isTransactionDataSkipped).toBe(false);
+  expect(
+    querySpy.mock.calls.some(([query]) =>
+      (typeof query === "string"
+        ? query
+        : (query as { text: string }).text
+      ).includes('from "ponder_sync"."transactions"'),
+    ),
+  ).toBe(true);
+});
+
 test("getEventBlockData() pagination", async () => {
   const { syncStore } = await setupDatabaseServices();
 

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -1077,9 +1077,10 @@ test("getEventData() applies one block range to logs and traces queries", async 
 test("getEventData() skips unused log transaction data", async () => {
   const { database, syncStore } = await setupDatabaseServices();
   const querySpy = vi.spyOn(database.syncQB.$client, "query");
+  querySpy.mockClear();
 
   const result = await syncStore.getEventData({
-    filters: [EMPTY_LOG_FILTER],
+    filters: [{ ...EMPTY_LOG_FILTER, include: [] }],
     fromBlock: 0,
     toBlock: 100,
     chainId: 1,

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -166,6 +166,7 @@ export type SyncStore = {
     transactions: InternalTransaction[];
     transactionReceipts: InternalTransactionReceipt[];
     traces: InternalTrace[];
+    isTransactionDataSkipped: boolean;
     cursor: number;
   }>;
   insertRpcRequestResults(
@@ -746,6 +747,7 @@ export const createSyncStore = ({
       transactions: InternalTransaction[];
       transactionReceipts: InternalTransactionReceipt[];
       traces: InternalTrace[];
+      isTransactionDataSkipped: boolean;
       cursor: number;
     }> => {
       const activeFilters = filters.filter((filter) =>
@@ -779,8 +781,11 @@ export const createSyncStore = ({
       const shouldQueryLogs = logFilters.length > 0;
       const shouldQueryTraces =
         traceFilters.length > 0 || transferFilters.length > 0;
+      const transactionInclude = unionFilterIncludeTransaction(filters);
       const shouldQueryTransactions =
-        transactionFilters.length > 0 || shouldQueryLogs || shouldQueryTraces;
+        transactionFilters.length > 0 ||
+        shouldQueryTraces ||
+        (shouldQueryLogs && transactionInclude.length > 0);
       const shouldQueryTransactionReceipts = activeFilters.some(
         (filter) => filter.hasTransactionReceipt,
       );
@@ -852,7 +857,7 @@ export const createSyncStore = ({
         type: PONDER_SYNC.transactions.type,
       };
 
-      for (const column of unionFilterIncludeTransaction(filters)) {
+      for (const column of transactionInclude) {
         // @ts-expect-error
         transactionSelect[column] = PONDER_SYNC.transactions[column];
       }
@@ -1240,6 +1245,7 @@ export const createSyncStore = ({
         transactionReceipts:
           transactionReceiptsRows as InternalTransactionReceipt[],
         traces: tracesRows as InternalTrace[],
+        isTransactionDataSkipped: shouldQueryLogs && !shouldQueryTransactions,
         cursor,
       };
     },


### PR DESCRIPTION
## Bottleneck

Historical log extraction queried and decoded every transaction in each block range even after event-property profiling established that no log callback used `event.transaction`. On the cached rETH workload, that repeated a large Postgres query and transaction-formatting pass throughout backfill indexing.

This change lets resolved log filters omit transaction columns when none were observed. `getEventData()` skips the transaction query for those log-only ranges while transaction, trace, and transfer filters retain their existing transaction requirements.

## Correctness

Unresolved log filters still request every transaction column during profiling. If a callback accesses any transaction property, that property remains in the resolved filter and transaction hydration continues.

Skipped transaction data is marked separately from a transaction that is genuinely absent on chains such as zkSync. A late property access receives the existing event proxy over an empty internal value, raises `InvalidEventAccessError`, resets the filter to full selection, and follows the existing refetch/retry path. A genuinely absent transaction remains `undefined`.

Tests cover query omission and retention, skipped-versus-missing event assembly, late-access retry, genuine missing-transaction behavior, and the updated resolved include set.

## Benchmark

Workload: `benchmark/apps/reth/src/index.ts`, Postgres, complete historical cache.

- Base: `cc7ce34693c972b10eb63ff60f7a0f8704c67655`
- Candidate: `218171e2fb4e6808ec661e0b04bc67ea3ac27be3`
- Harness: identical local-only post-ready metrics/resource/checksum instrumentation in both worktrees; scrape and output validation were outside the measured interval.
- Warmup cache: `cache_rate=100%` for `mainnet`, with no historical RPC fetching.
- Every measured run: `/metrics` reported Postgres through `ponder_settings_info`.
- Every parent and candidate scrape produced the same additive-metrics checksum: `479deb9285f3ff2be96ce09a972ccbb7505b52123d20de8239def15505be1e7e`.

Five alternating measured pairs, in execution order:

| Pair | Parent | Candidate |
|---|---:|---:|
| 1 | 17,500 ms | 17,632 ms |
| 2 | 18,299 ms | 16,986 ms |
| 3 | 17,367 ms | 17,738 ms |
| 4 | 17,658 ms | 17,193 ms |
| 5 | 17,246 ms | 15,870 ms |

| | Parent | Candidate | Delta |
|---|---:|---:|---:|
| Median | 17,500 ms | 17,193 ms | -307 ms (-1.8%) |
| Minimum | 17,246 ms | 15,870 ms | -1,376 ms |
| Maximum | 18,299 ms | 17,738 ms | -561 ms |

Pairs 1 and 3 favored the parent by `132 ms` and `371 ms`; the other three pairs favored the candidate. No completed timing was discarded. One pre-series attempt did not reach readiness and produced no timing, so it was excluded before the measured series.

| Resource | Parent median | Candidate median | Delta |
|---|---:|---:|---:|
| User CPU | 19,014 ms | 18,026 ms | -988 ms (-5.2%) |
| System CPU | 792 ms | 736 ms | -56 ms (-7.1%) |
| Peak RSS | 1,127 MiB | 1,107 MiB | -20 MiB (-1.8%) |

Raw parent `(user/system/RSS)`: `18882/795/1127`, `19494/920/1175`, `19014/792/1148`, `19249/746/1031`, `18838/717/1123` (ms/ms/MiB).

Raw candidate `(user/system/RSS)`: `18026/766/1125`, `18227/671/1107`, `18388/733/1098`, `17891/741/1086`, `17329/736/1131` (ms/ms/MiB).

One tightly paired Bun CPU profile was captured per revision. Profiled wall/user CPU was `17,581/18,878 ms` on the parent and `16,854/18,107 ms` on the candidate. Profile-buffer RSS is excluded from the normal RSS comparison.

Measured host 1-minute load averages ranged from `1.73` to `2.83`.

## Output validation

All warmup, measured, and profiled runs produced the same counts and checksums:

| Table | Rows | Checksum |
|---|---:|---|
| `account` | 51,227 | `8e795521d20a86ea8043fdd12ae1783f` |
| `allowance` | 54,996 | `0875d3c760becd28a1e059a66fa66d70` |
| `transfer_event` | 382,727 | `0a931acc6c99900e1c88bf1c3f0842da` |
| `approval_event` | 207,386 | `7724c3e50867270802b6e4a0126f45fd` |

## Checks

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --filter ponder typecheck`
- `pnpm lint`
- `CI=1 pnpm --filter ponder test src/sync-store/index.test.ts src/indexing/index.test.ts`
- `CI=1 pnpm --filter ponder test src/runtime/events.test.ts`
- `CI=1 pnpm --filter ponder test src/runtime/historical.test.ts src/runtime/filter.test.ts`

Result: 86 focused tests passed.

## Tradeoffs

The optimization starts only after the existing 100-event access profile resolves, so short workloads are unchanged. If transaction access begins after resolution, the current block range is retried with full transaction selection; this preserves behavior at the cost of one retry for changing access patterns.