### PR TITLE
Fix historical zero-hash transaction receipts

### DIFF
--- a/.changeset/fix-historical-zero-hash-receipts.md
+++ b/.changeset/fix-historical-zero-hash-receipts.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug that caused historical sync to request transaction receipts for logs with a zero transaction hash when `includeTransactionReceipts` was enabled.

--- a/packages/core/src/sync-historical/index.test.ts
+++ b/packages/core/src/sync-historical/index.test.ts
@@ -1,4 +1,4 @@
-import { zeroAddress } from "viem";
+import { zeroAddress, zeroHash } from "viem";
 import { parseEther } from "viem/utils";
 import { beforeEach, expect, test, vi } from "vitest";
 import { ALICE, BOB } from "@/_test/constants.js";
@@ -196,6 +196,80 @@ test.skipIf(process.env.USER === "jaymiller")(
     expect(intervals).toHaveLength(1);
   },
 );
+
+test("sync() skips transaction receipts for zero-hash logs", async () => {
+  const { syncStore } = await setupDatabaseServices();
+
+  const chain = getChain();
+  const rpc = createRpc({
+    chain,
+    common: context.common,
+  });
+
+  const { address } = await deployErc20({ sender: ALICE });
+  await mintErc20({
+    erc20: address,
+    to: ALICE,
+    amount: parseEther("1"),
+    sender: ALICE,
+  });
+
+  const { eventCallbacks } = getErc20IndexingBuild({
+    address,
+    includeTransactionReceipts: true,
+  });
+
+  const requestSpy = vi.spyOn(rpc, "request");
+  const request = async (request: any) => {
+    const result = await rpc.request(request);
+    if (request.method === "eth_getLogs") {
+      return (result as { transactionHash: string }[]).map((log) => ({
+        ...log,
+        transactionHash: zeroHash,
+      }));
+    }
+    return result;
+  };
+
+  const historicalSync = createHistoricalSync({
+    common: context.common,
+    chain,
+    rpc: {
+      ...rpc,
+      // @ts-expect-error
+      request,
+    },
+    childAddresses: setupChildAddresses(eventCallbacks),
+  });
+
+  const requiredIntervals = getRequiredIntervalsWithFilters({
+    interval: [1, 2],
+    filters: eventCallbacks.map(({ filter }) => filter),
+    cachedIntervals: setupCachedIntervals(eventCallbacks),
+  });
+  const logs = await historicalSync.syncBlockRangeData({
+    interval: [1, 2],
+    requiredIntervals: requiredIntervals.intervals,
+    requiredFactoryIntervals: requiredIntervals.factoryIntervals,
+    syncStore,
+  });
+  await historicalSync.syncBlockData({
+    interval: [1, 2],
+    requiredIntervals: requiredIntervals.intervals,
+    logs,
+    syncStore,
+  });
+
+  expect(logs).toHaveLength(1);
+  expect(logs[0]?.transactionHash).toBe(zeroHash);
+
+  const receiptRequests = requestSpy.mock.calls.filter(
+    ([request]) =>
+      request.method === "eth_getBlockReceipts" ||
+      request.method === "eth_getTransactionReceipt",
+  );
+  expect(receiptRequests).toHaveLength(0);
+});
 
 test("sync() with block filter", async () => {
   const { syncStore, database } = await setupDatabaseServices();

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -734,12 +734,14 @@ export const createHistoricalSync = (
               ) {
                 isMatched = true;
 
-                requiredTransactions.add(log.transactionHash);
-                if (filter.hasTransactionReceipt) {
-                  requiredTransactionReceipts.add(log.transactionHash);
+                if (log.transactionHash !== zeroHash) {
+                  requiredTransactions.add(log.transactionHash);
+                  if (filter.hasTransactionReceipt) {
+                    requiredTransactionReceipts.add(log.transactionHash);
 
-                  // skip to next log
-                  break;
+                    // skip to next log
+                    break;
+                  }
                 }
               }
             }


### PR DESCRIPTION
Fixes a bug for logs with `transactionHash: "0x0000..."` and `includeTransactionReceipts: true` in the historical backfill.
