### PR TITLE
fix: batch eth_getLogs address filters

### DIFF
--- a/.changeset/quiet-logs-batch.md
+++ b/.changeset/quiet-logs-batch.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed `eth_getLogs` requests with large address arrays and empty address arrays, and sanitized trailing `null` log topics for RPC providers that reject them.

--- a/.changeset/quiet-logs-batch.md
+++ b/.changeset/quiet-logs-batch.md
@@ -2,4 +2,4 @@
 "ponder": patch
 ---
 
-Fixed `eth_getLogs` requests with large address arrays and empty address arrays, and sanitized trailing `null` log topics for RPC providers that reject them.
+Added validation for `address: []` in `ponder.config.ts`.

--- a/packages/core/src/build/config.test.ts
+++ b/packages/core/src/build/config.test.ts
@@ -535,6 +535,93 @@ test("buildIndexingFunctions() validates address empty string", async () => {
   );
 });
 
+test("buildIndexingFunctions() validates empty contract address array", async () => {
+  const config = createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}` },
+    },
+    contracts: {
+      a: {
+        chain: "mainnet",
+        abi: [event0],
+        address: [],
+      },
+    },
+  });
+
+  const configBuild = buildConfig({ common: context.common, config });
+  const result = await safeBuildIndexingFunctions({
+    common: context.common,
+    config,
+    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+    configBuild,
+  });
+
+  expect(result.status).toBe("error");
+  expect(result.error?.message).toBe(
+    "Validation failed: Invalid address for 'a'. Got an empty array, expected at least one address.",
+  );
+});
+
+test("buildIndexingFunctions() validates empty account address array", async () => {
+  const config = createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}` },
+    },
+    accounts: {
+      a: {
+        chain: "mainnet",
+        address: [],
+      },
+    },
+  });
+
+  const configBuild = buildConfig({ common: context.common, config });
+  const result = await safeBuildIndexingFunctions({
+    common: context.common,
+    config,
+    indexingFunctions: [{ name: "a:transaction:to", fn: () => {} }],
+    configBuild,
+  });
+
+  expect(result.status).toBe("error");
+  expect(result.error?.message).toBe(
+    "Validation failed: Invalid address for 'a'. Got an empty array, expected at least one address.",
+  );
+});
+
+test("buildIndexingFunctions() validates empty factory address array", async () => {
+  const config = createConfig({
+    chains: {
+      mainnet: { id: 1, rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}` },
+    },
+    contracts: {
+      a: {
+        chain: "mainnet",
+        abi: [event0],
+        address: factory({
+          address: [],
+          event: eventFactory,
+          parameter: "child",
+        }),
+      },
+    },
+  });
+
+  const configBuild = buildConfig({ common: context.common, config });
+  const result = await safeBuildIndexingFunctions({
+    common: context.common,
+    config,
+    indexingFunctions: [{ name: "a:Event0", fn: () => {} }],
+    configBuild,
+  });
+
+  expect(result.status).toBe("error");
+  expect(result.error?.message).toBe(
+    "Validation failed: Invalid address for 'a'. Got an empty array, expected at least one address.",
+  );
+});
+
 test("buildIndexingFunctions() validates address prefix", async () => {
   const config = createConfig({
     chains: {

--- a/packages/core/src/build/config.ts
+++ b/packages/core/src/build/config.ts
@@ -77,6 +77,34 @@ const flattenSources = <
   );
 };
 
+const validateAddresses = ({
+  sourceName,
+  addresses,
+}: {
+  sourceName: string;
+  addresses: Address | readonly Address[];
+}) => {
+  if (Array.isArray(addresses) && addresses.length === 0) {
+    throw new Error(
+      `Validation failed: Invalid address for '${sourceName}'. Got an empty array, expected at least one address.`,
+    );
+  }
+
+  for (const address of Array.isArray(addresses) ? addresses : [addresses]) {
+    if (!address.startsWith("0x"))
+      throw new Error(
+        `Validation failed: Invalid prefix for address '${address}'. Got '${address.slice(
+          0,
+          2,
+        )}', expected '0x'.`,
+      );
+    if (address.length !== 42)
+      throw new Error(
+        `Validation failed: Invalid length for address '${address}'. Got ${address.length}, expected 42 characters.`,
+      );
+  }
+};
+
 export async function buildIndexingFunctions({
   common,
   config,
@@ -407,6 +435,12 @@ export async function buildIndexingFunctions({
       Array.isArray(resolvedAddress) === false
     ) {
       const factoryAddress = resolvedAddress as Factory;
+      if (factoryAddress.address !== undefined) {
+        validateAddresses({
+          sourceName: source.name,
+          addresses: factoryAddress.address,
+        });
+      }
       const factoryFromBlock =
         (await resolveBlockNumber(factoryAddress.startBlock, chain)) ??
         fromBlock;
@@ -433,21 +467,10 @@ export async function buildIndexingFunctions({
       address = logFactory;
     } else {
       if (resolvedAddress !== undefined) {
-        for (const address of Array.isArray(resolvedAddress)
-          ? resolvedAddress
-          : [resolvedAddress as Address]) {
-          if (!address!.startsWith("0x"))
-            throw new Error(
-              `Validation failed: Invalid prefix for address '${address}'. Got '${address!.slice(
-                0,
-                2,
-              )}', expected '0x'.`,
-            );
-          if (address!.length !== 42)
-            throw new Error(
-              `Validation failed: Invalid length for address '${address}'. Got ${address!.length}, expected 42 characters.`,
-            );
-        }
+        validateAddresses({
+          sourceName: source.name,
+          addresses: resolvedAddress as Address | readonly Address[],
+        });
       }
 
       const validatedAddress = Array.isArray(resolvedAddress)
@@ -708,6 +731,12 @@ export async function buildIndexingFunctions({
       typeof resolvedAddress === "object" &&
       !Array.isArray(resolvedAddress)
     ) {
+      if (resolvedAddress.address !== undefined) {
+        validateAddresses({
+          sourceName: source.name,
+          addresses: resolvedAddress.address,
+        });
+      }
       const factoryFromBlock =
         (await resolveBlockNumber(resolvedAddress.startBlock, chain)) ??
         fromBlock;
@@ -726,21 +755,10 @@ export async function buildIndexingFunctions({
 
       address = logFactory;
     } else {
-      for (const address of Array.isArray(resolvedAddress)
-        ? resolvedAddress
-        : [resolvedAddress]) {
-        if (!address!.startsWith("0x"))
-          throw new Error(
-            `Validation failed: Invalid prefix for address '${address}'. Got '${address!.slice(
-              0,
-              2,
-            )}', expected '0x'.`,
-          );
-        if (address!.length !== 42)
-          throw new Error(
-            `Validation failed: Invalid length for address '${address}'. Got ${address!.length}, expected 42 characters.`,
-          );
-      }
+      validateAddresses({
+        sourceName: source.name,
+        addresses: resolvedAddress as Address | readonly Address[],
+      });
 
       const validatedAddress = Array.isArray(resolvedAddress)
         ? dedupe(resolvedAddress).map((r) => toLowerCase(r))

--- a/packages/core/src/rpc/actions.test.ts
+++ b/packages/core/src/rpc/actions.test.ts
@@ -1,0 +1,85 @@
+import type { Address, Hex } from "viem";
+import { expect, test, vi } from "vitest";
+import type { RequestParameters, Rpc } from "@/rpc/index.js";
+import { eth_getLogs } from "./actions.js";
+
+const hash =
+  "0x1111111111111111111111111111111111111111111111111111111111111111" as const;
+const address = "0x2222222222222222222222222222222222222222" as const;
+
+const createLog = ({
+  address: logAddress = address,
+  blockNumber = "0x1",
+  logIndex = "0x0",
+}: {
+  address?: Address;
+  blockNumber?: Hex;
+  logIndex?: Hex;
+} = {}) => ({
+  blockNumber,
+  logIndex,
+  blockHash: hash,
+  address: logAddress,
+  topics: [],
+  data: "0x",
+  transactionHash: hash,
+  transactionIndex: "0x0",
+});
+
+test("eth_getLogs chunks address arrays and merges responses", async () => {
+  const addresses = Array.from(
+    { length: 51 },
+    (_, index) => `0x${index.toString(16).padStart(40, "0")}` as Address,
+  );
+  const firstLog = createLog({
+    address: addresses[0],
+    blockNumber: "0x2",
+  });
+  const secondLog = createLog({
+    address: addresses[50],
+    blockNumber: "0x1",
+    logIndex: "0x1",
+  });
+  const requests: Extract<RequestParameters, { method: "eth_getLogs" }>[] = [];
+  const rpcRequest = vi.fn(
+    async (request: Extract<RequestParameters, { method: "eth_getLogs" }>) => {
+      requests.push(request);
+      const requestAddress = request.params[0].address;
+      if (
+        Array.isArray(requestAddress) &&
+        requestAddress[0] === addresses[50]
+      ) {
+        return [secondLog];
+      }
+      return [firstLog];
+    },
+  );
+  const rpc = { request: rpcRequest } as unknown as Rpc;
+  const params: Extract<
+    RequestParameters,
+    { method: "eth_getLogs" }
+  >["params"] = [{ address: addresses }];
+
+  await expect(eth_getLogs(rpc, params)).resolves.toStrictEqual([
+    firstLog,
+    secondLog,
+  ]);
+  expect(requests).toHaveLength(2);
+  expect(requests.map((request) => request.params[0].address)).toStrictEqual([
+    addresses.slice(0, 50),
+    [addresses[50]],
+  ]);
+  expect(params[0].address).toStrictEqual(addresses);
+});
+
+test("eth_getLogs skips empty address arrays", async () => {
+  const rpcRequest = vi.fn();
+  const rpc = { request: rpcRequest } as unknown as Rpc;
+  const params: Extract<
+    RequestParameters,
+    { method: "eth_getLogs" }
+  >["params"] = [{ address: [] }];
+
+  await expect(eth_getLogs(rpc, params)).resolves.toStrictEqual([]);
+  expect(rpcRequest).not.toHaveBeenCalled();
+});

--- a/packages/core/src/rpc/actions.ts
+++ b/packages/core/src/rpc/actions.ts
@@ -20,7 +20,10 @@ import type {
 } from "@/internal/types.js";
 import type { RequestParameters, Rpc } from "@/rpc/index.js";
 import { zeroLogsBloom } from "@/sync-realtime/bloom.js";
+import { chunk } from "@/utils/chunk.js";
 import { PG_BIGINT_MAX, PG_INTEGER_MAX } from "@/utils/pg.js";
+
+const ADDRESS_CHUNK_SIZE = 50;
 
 /**
  * Helper function for "eth_getBlockByNumber" request.
@@ -93,13 +96,29 @@ export const eth_getLogs = async (
     params,
   };
 
-  return rpc.request(request, context).then((logs) => {
-    if (logs === null || logs === undefined) {
-      throw new Error("Received invalid empty eth_getLogs response.");
-    }
+  const requests: Extract<RequestParameters, { method: "eth_getLogs" }>[] =
+    Array.isArray(params[0].address)
+      ? chunk(params[0].address, ADDRESS_CHUNK_SIZE).map(
+          (address) =>
+            ({
+              method: "eth_getLogs",
+              params: [{ ...params[0], address }],
+            }) as Extract<RequestParameters, { method: "eth_getLogs" }>,
+        )
+      : [request];
 
-    return standardizeLogs(logs as SyncLog[], request);
-  });
+  const responses = await Promise.all(
+    requests.map(async (request) => {
+      const logs = await rpc.request(request, context);
+      if (logs === null || logs === undefined) {
+        throw new Error("Received invalid empty eth_getLogs response.");
+      }
+
+      return logs as SyncLog[];
+    }),
+  );
+
+  return standardizeLogs(responses.flat(), request);
 };
 
 /**

--- a/packages/core/src/rpc/index.test.ts
+++ b/packages/core/src/rpc/index.test.ts
@@ -3,7 +3,7 @@ import { context, setupAnvil, setupCommon } from "@/_test/setup.js";
 import { simulateBlock } from "@/_test/simulate.js";
 import { getChain } from "@/_test/utils.js";
 import { wait } from "@/utils/wait.js";
-import { createRpc } from "./index.js";
+import { createRpc, sanitizeLogTopics } from "./index.js";
 
 beforeEach(setupCommon);
 beforeEach(setupAnvil);
@@ -83,3 +83,35 @@ test("https://github.com/ponder-sh/ponder/pull/2143", async () => {
 
   await rpc.request({ method: "eth_blockNumber" });
 }, 15_000);
+
+const topic0 =
+  "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
+const topic1 =
+  "0x1111111111111111111111111111111111111111111111111111111111111111" as const;
+
+test("sanitizeLogTopics removes trailing null values", () => {
+  expect(sanitizeLogTopics([topic0, topic1, null, null])).toStrictEqual([
+    topic0,
+    topic1,
+  ]);
+});
+
+test("sanitizeLogTopics preserves null wildcards before a topic", () => {
+  expect(sanitizeLogTopics([topic0, null, topic1, null])).toStrictEqual([
+    topic0,
+    null,
+    topic1,
+  ]);
+});
+
+test("sanitizeLogTopics does not mutate the input", () => {
+  const topics = [topic0, null, null] as const;
+
+  expect(sanitizeLogTopics(topics)).toStrictEqual([topic0]);
+  expect(topics).toStrictEqual([topic0, null, null]);
+});
+
+test("sanitizeLogTopics preserves omitted and empty topics", () => {
+  expect(sanitizeLogTopics([])).toStrictEqual([]);
+  expect(sanitizeLogTopics([null, null])).toStrictEqual([]);
+});

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -14,6 +14,7 @@ import {
   hexToNumber,
   isHex,
   JsonRpcVersionUnsupportedError,
+  type LogTopic,
   MethodNotFoundRpcError,
   MethodNotSupportedRpcError,
   ParseRpcError,
@@ -56,6 +57,17 @@ export type RequestParameters = EIP1193Parameters<RpcSchema>;
 export type RequestReturnType<
   method extends EIP1193Parameters<RpcSchema>["method"],
 > = Extract<RpcSchema[number], { Method: method }>["ReturnType"];
+
+export const sanitizeLogTopics = <
+  topics extends readonly LogTopic[] | LogTopic[],
+>(
+  topics: topics,
+) => {
+  const sanitizedTopics = [...topics];
+  while (sanitizedTopics.at(-1) === null) sanitizedTopics.pop();
+
+  return sanitizedTopics as topics;
+};
 
 export type Rpc = {
   hostnames: string[];

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -37,7 +37,7 @@ import {
   validateTracesAndBlock,
   validateTransactionsAndBlock,
 } from "@/rpc/actions.js";
-import type { Rpc } from "@/rpc/index.js";
+import { type Rpc, sanitizeLogTopics } from "@/rpc/index.js";
 import {
   getChildAddress,
   isAddressFactory,
@@ -145,120 +145,72 @@ export const createHistoricalSync = (
         logsRequestMetadata.estimatedRange,
     });
 
-    const topics = [
+    const topics = sanitizeLogTopics([
       topic0 ?? null,
       topic1 ?? null,
       topic2 ?? null,
       topic3 ?? null,
-    ];
-
-    // Note: the `topics` field is very fragile for many rpc providers, and
-    // cannot handle extra "null" topics
-
-    if (topics[3] === null) {
-      topics.pop();
-      if (topics[2] === null) {
-        topics.pop();
-        if (topics[1] === null) {
-          topics.pop();
-          if (topics[0] === null) {
-            topics.pop();
-          }
-        }
-      }
-    }
-
-    // Batch large arrays of addresses, handling arrays that are empty
-
-    let addressBatches: (Address | Address[] | undefined)[];
-
-    if (address === undefined) {
-      // no address (match all)
-      addressBatches = [undefined];
-    } else if (typeof address === "string") {
-      // single address
-      addressBatches = [address];
-    } else if (address.length === 0) {
-      // no address (factory with no children)
-      return [];
-    } else {
-      // many addresses
-      // Note: it is assumed that `address` is deduplicated
-      addressBatches = [];
-      for (let i = 0; i < address.length; i += 50) {
-        addressBatches.push(address.slice(i, i + 50));
-      }
-    }
+    ])!;
 
     const logs = await Promise.all(
-      intervals.flatMap((interval) =>
-        addressBatches.map((address) =>
-          eth_getLogs(
-            args.rpc,
-            [
+      intervals.map((interval) =>
+        eth_getLogs(
+          args.rpc,
+          [
+            {
+              address,
+              topics,
+              fromBlock: numberToHex(interval[0]),
+              toBlock: numberToHex(interval[1]),
+            },
+          ],
+          context,
+        ).catch((error) => {
+          // Note: skip eth_getLogs range retry logic if the chain
+          // has a custom block range.
+          if (args.chain.ethGetLogsBlockRange !== undefined) {
+            throw error;
+          }
+
+          const getLogsErrorResponse = getLogsRetryHelper({
+            params: [
               {
                 address,
                 topics,
-                fromBlock: numberToHex(interval[0]),
-                toBlock: numberToHex(interval[1]),
+                fromBlock: toHex(interval[0]),
+                toBlock: toHex(interval[1]),
               },
             ],
+            error: error as RpcError,
+          });
+
+          if (getLogsErrorResponse.shouldRetry === false) throw error;
+
+          const range =
+            hexToNumber(getLogsErrorResponse.ranges[0]!.toBlock) -
+            hexToNumber(getLogsErrorResponse.ranges[0]!.fromBlock);
+
+          args.common.logger.debug({
+            msg: "Updated eth_getLogs range",
+            chain: args.chain.name,
+            chain_id: args.chain.id,
+            range,
+          });
+
+          logsRequestMetadata = {
+            estimatedRange: range,
+            confirmedRange: getLogsErrorResponse.isSuggestedRange
+              ? range
+              : undefined,
+          };
+
+          return syncLogsDynamic(
+            { address, topic0, topic1, topic2, topic3, interval },
             context,
-          ).catch((error) => {
-            // Note: skip eth_getLogs range retry logic if the chain
-            // has a custom block range.
-            if (args.chain.ethGetLogsBlockRange !== undefined) {
-              throw error;
-            }
-
-            const getLogsErrorResponse = getLogsRetryHelper({
-              params: [
-                {
-                  address,
-                  topics,
-                  fromBlock: toHex(interval[0]),
-                  toBlock: toHex(interval[1]),
-                },
-              ],
-              error: error as RpcError,
-            });
-
-            if (getLogsErrorResponse.shouldRetry === false) throw error;
-
-            const range =
-              hexToNumber(getLogsErrorResponse.ranges[0]!.toBlock) -
-              hexToNumber(getLogsErrorResponse.ranges[0]!.fromBlock);
-
-            args.common.logger.debug({
-              msg: "Updated eth_getLogs range",
-              chain: args.chain.name,
-              chain_id: args.chain.id,
-              range,
-            });
-
-            logsRequestMetadata = {
-              estimatedRange: range,
-              confirmedRange: getLogsErrorResponse.isSuggestedRange
-                ? range
-                : undefined,
-            };
-
-            return syncLogsDynamic(
-              { address, topic0, topic1, topic2, topic3, interval },
-              context,
-            );
-          }),
-        ),
+          );
+        }),
       ),
-    ).then((logs) => {
-      const result: SyncLog[] = [];
-      for (const _logs of logs) {
-        for (const log of _logs) {
-          result.push(log);
-        }
-      }
-      return result;
-    });
+    ).then((logs) => logs.flat());
 
     /**
      * Dynamically increase the range used in "eth_getLogs" if an
@@ -490,6 +442,11 @@ export const createHistoricalSync = (
         if (hasAddress === false || hasTopic1 || hasTopic2 || hasTopic3) {
           if (isAddressFactory(filter.address)) {
             const childAddresses = args.childAddresses.get(filter.address.id)!;
+
+            if (childAddresses.size === 0) {
+              continue;
+            }
+
             singleEthGetLogsParams.push({
               address:
                 childAddresses.size >=
@@ -528,6 +485,11 @@ export const createHistoricalSync = (
         if (mergedEthGetLogsParams.has(addressKey) === false) {
           if (isAddressFactory(filter.address)) {
             const childAddresses = args.childAddresses.get(filter.address.id)!;
+
+            if (childAddresses.size === 0) {
+              continue;
+            }
+
             mergedEthGetLogsParams.set(addressKey, {
               address:
                 childAddresses.size >=


### PR DESCRIPTION
Adds validation for `address: []` in `ponder.config.ts` and cleanups internal `eth_getLogs` request sanitation for `topics` and `address` arrays