### PR TITLE
fix historical log filter batching

### DIFF
--- a/.changeset/bright-logs-batch.md
+++ b/.changeset/bright-logs-batch.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved backfill sync performance by combining compatible JSON-RPC `eth_getLogs` requests.

--- a/packages/core/src/sync-historical/index.test.ts
+++ b/packages/core/src/sync-historical/index.test.ts
@@ -1,7 +1,14 @@
-import { zeroAddress, zeroHash } from "viem";
+import {
+  getAbiItem,
+  type Hex,
+  toEventSelector,
+  zeroAddress,
+  zeroHash,
+} from "viem";
 import { parseEther } from "viem/utils";
 import { beforeEach, expect, test, vi } from "vitest";
 import { ALICE, BOB } from "@/_test/constants.js";
+import { erc20ABI } from "@/_test/generated.js";
 import {
   context,
   setupAnvil,
@@ -61,6 +68,66 @@ test("createHistoricalSync()", async () => {
   });
 
   expect(historicalSync).toBeDefined();
+});
+
+test("sync() batches log filters with wildcard indexed topics", async () => {
+  const { syncStore } = await setupDatabaseServices();
+
+  const chain = {
+    ...getChain(),
+    ethGetLogsBlockRange: 1_000,
+  };
+  const contractAddress = "0x9eb95e4b47aeccb131f20ae7af33a29832499067" as const;
+  const approval = toEventSelector(
+    getAbiItem({ abi: erc20ABI, name: "Approval" }),
+  );
+  const transfer = toEventSelector(
+    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
+  );
+  const rpc = createRpc({ chain, common: context.common });
+  const requestSpy = vi.spyOn(rpc, "request");
+  requestSpy.mockResolvedValue([] as never);
+
+  const historicalSync = createHistoricalSync({
+    common: context.common,
+    chain,
+    rpc,
+    childAddresses: new Map(),
+  });
+
+  const { filter: baseFilter } = getErc20IndexingBuild({
+    address: contractAddress,
+  }).eventCallbacks[0]!;
+  const createLogFilter = (topic0: Hex) => ({ ...baseFilter, topic0 });
+
+  await historicalSync.syncBlockRangeData({
+    interval: [1, 2],
+    requiredIntervals: [
+      {
+        filter: createLogFilter(approval),
+        interval: [1, 2],
+      },
+      {
+        filter: createLogFilter(transfer),
+        interval: [1, 2],
+      },
+    ],
+    requiredFactoryIntervals: [],
+    syncStore,
+  });
+
+  expect(requestSpy).toHaveBeenCalledTimes(1);
+  expect(requestSpy.mock.calls[0]![0]).toMatchObject({
+    method: "eth_getLogs",
+    params: [
+      {
+        address: contractAddress,
+        topics: [[approval, transfer]],
+        fromBlock: "0x1",
+        toBlock: "0x2",
+      },
+    ],
+  });
 });
 
 test("sync() with log filter", async () => {

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -483,9 +483,9 @@ export const createHistoricalSync = (
         if (filter.type !== "log") continue;
 
         const hasAddress = filter.address !== undefined;
-        const hasTopic1 = filter.topic1 !== undefined;
-        const hasTopic2 = filter.topic2 !== undefined;
-        const hasTopic3 = filter.topic3 !== undefined;
+        const hasTopic1 = filter.topic1 !== undefined && filter.topic1 !== null;
+        const hasTopic2 = filter.topic2 !== undefined && filter.topic2 !== null;
+        const hasTopic3 = filter.topic3 !== undefined && filter.topic3 !== null;
 
         if (hasAddress === false || hasTopic1 || hasTopic2 || hasTopic3) {
           if (isAddressFactory(filter.address)) {


### PR DESCRIPTION
Fixes a bug that caused compatible historical log filters not to be batched. Fixing this improves the performance in historical backfill because less RPC requests will be made.