### PR TITLE
fix: generalize historical eth_getLogs request merging

### DIFF
--- a/.changeset/silly-lions-batch.md
+++ b/.changeset/silly-lions-batch.md
@@ -2,4 +2,4 @@
 "ponder": patch
 ---
 
-Improved backfill sync performance by merging more compatible JSON-RPC `eth_getLogs` requests, including requests that only differ by `address` or an indexed topic.
+Improved backfill sync performance by merging more compatible JSON-RPC `eth_getLogs` requests.

--- a/.changeset/silly-lions-batch.md
+++ b/.changeset/silly-lions-batch.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Improved backfill sync performance by merging more compatible JSON-RPC `eth_getLogs` requests, including requests that only differ by `address` or an indexed topic.

--- a/packages/core/src/runtime/filter.test.ts
+++ b/packages/core/src/runtime/filter.test.ts
@@ -1,6 +1,16 @@
-import { type Address, parseEther, zeroAddress, zeroHash } from "viem";
+import {
+  type Address,
+  getAbiItem,
+  type Hex,
+  numberToHex,
+  parseEther,
+  toEventSelector,
+  zeroAddress,
+  zeroHash,
+} from "viem";
 import { beforeEach, expect, test } from "vitest";
 import { ALICE, BOB } from "@/_test/constants.js";
+import { erc20ABI } from "@/_test/generated.js";
 import { context, setupAnvil, setupCommon } from "@/_test/setup.js";
 import {
   createPair,
@@ -29,6 +39,7 @@ import type {
 } from "@/internal/types.js";
 import { eth_getBlockByNumber } from "@/rpc/actions.js";
 import { createRpc } from "@/rpc/index.js";
+import type { IntervalWithFilter } from "@/runtime/index.js";
 import {
   getChildAddress,
   isBlockFilterMatched,
@@ -37,6 +48,7 @@ import {
   isTraceFilterMatched,
   isTransactionFilterMatched,
   isTransferFilterMatched,
+  mergeLogFiltersToRequests,
 } from "./filter.js";
 
 beforeEach(setupCommon);
@@ -321,4 +333,165 @@ test("isTraceFilterMatched()", async () => {
     trace: blockData.trace.trace,
   });
   expect(isMatched).toBe(false);
+});
+
+const ADDRESS_A: Address = "0x1111111111111111111111111111111111111111";
+const ADDRESS_B: Address = "0x2222222222222222222222222222222222222222";
+
+const TOPIC1_ALICE: Hex = `0x${"0".repeat(24)}${ALICE.slice(2)}`;
+const TOPIC1_BOB: Hex = `0x${"0".repeat(24)}${BOB.slice(2)}`;
+
+const baseLogFilter = {
+  type: "log",
+  chainId: 1,
+  sourceId: "Erc20",
+  fromBlock: undefined,
+  toBlock: undefined,
+  hasTransactionReceipt: false,
+  include: [] as LogFilter["include"],
+};
+
+test("mergeLogFiltersToRequests merges filters with different topic1 values into one request", () => {
+  const transfer = toEventSelector(
+    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
+  );
+
+  const requiredIntervals: IntervalWithFilter[] = [
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: TOPIC1_ALICE,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: TOPIC1_BOB,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+  ];
+
+  // Only `topic1` differs between the two filters, so they're merged into a
+  // single request with `topic1` unioned into an array.
+  const mergedRequests = mergeLogFiltersToRequests(
+    requiredIntervals,
+    new Map(),
+    1000,
+  );
+
+  expect(mergedRequests).toHaveLength(1);
+  expect(mergedRequests[0]!.params[0]).toMatchObject({
+    address: ADDRESS_A,
+    topics: [transfer, [TOPIC1_ALICE, TOPIC1_BOB]],
+  });
+});
+
+test("mergeLogFiltersToRequests merges filters with different addresses into one request", () => {
+  const transfer = toEventSelector(
+    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
+  );
+
+  const requiredIntervals: IntervalWithFilter[] = [
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: null,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_B,
+        topic0: transfer,
+        topic1: null,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+  ];
+
+  // Only `address` differs between the two filters, so they're merged into a
+  // single request with `address` unioned into an array.
+  const mergedRequests = mergeLogFiltersToRequests(
+    requiredIntervals,
+    new Map(),
+    1000,
+  );
+
+  expect(mergedRequests).toHaveLength(1);
+  expect(mergedRequests[0]!.params[0]).toMatchObject({
+    address: [ADDRESS_A, ADDRESS_B],
+    topics: [transfer],
+  });
+});
+
+test("mergeLogFiltersToRequests does not merge disjoint intervals into an overly wide request", () => {
+  const transfer = toEventSelector(
+    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
+  );
+
+  const requiredIntervals: IntervalWithFilter[] = [
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: null,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: null,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [100_000, 100_100],
+    },
+  ];
+
+  // The two filters are otherwise identical, but their intervals are
+  // disjoint (0% overlap), so merging them would force an unnecessarily wide
+  // request that refetches ~100,000 unrelated blocks. Instead, two
+  // tightly-bounded requests are kept.
+  const mergedRequests = mergeLogFiltersToRequests(
+    requiredIntervals,
+    new Map(),
+    1000,
+  );
+
+  expect(mergedRequests).toHaveLength(2);
+  expect(mergedRequests.map((request) => request.params[0])).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        fromBlock: numberToHex(1),
+        toBlock: numberToHex(100),
+      }),
+      expect.objectContaining({
+        fromBlock: numberToHex(100_000),
+        toBlock: numberToHex(100_100),
+      }),
+    ]),
+  );
 });

--- a/packages/core/src/runtime/filter.ts
+++ b/packages/core/src/runtime/filter.ts
@@ -1,4 +1,4 @@
-import { type Address, hexToNumber } from "viem";
+import { type Address, type Hex, hexToNumber, numberToHex } from "viem";
 import type {
   BlockFilter,
   Factory,
@@ -23,6 +23,8 @@ import type {
   TransactionFilter,
   TransferFilter,
 } from "@/internal/types.js";
+import { type RequestParameters, sanitizeLogTopics } from "@/rpc/index.js";
+import type { ChildAddresses, IntervalWithFilter } from "@/runtime/index.js";
 import type {
   Block,
   Log,
@@ -30,6 +32,7 @@ import type {
   Transaction,
   TransactionReceipt,
 } from "@/types/eth.js";
+import type { Interval } from "@/utils/interval.js";
 import { toLowerCase } from "@/utils/lowercase.js";
 
 /** Returns true if `address` is an address filter. */
@@ -44,6 +47,179 @@ export const isAddressFactory = (
     return false;
   }
   return Array.isArray(address) ? isAddressFactory(address[0]) : true;
+};
+
+type EthGetLogsRequest = Extract<
+  RequestParameters,
+  { method: "eth_getLogs" }
+> & {
+  params: [
+    Extract<
+      Extract<RequestParameters, { method: "eth_getLogs" }>["params"][0],
+      { blockHash?: undefined }
+    > & { fromBlock: Hex; toBlock: Hex },
+  ];
+};
+
+const logRequestKeys = [
+  "address",
+  "topic0",
+  "topic1",
+  "topic2",
+  "topic3",
+] as const;
+
+const getLogRequestValue = (
+  request: EthGetLogsRequest,
+  key: (typeof logRequestKeys)[number],
+): Hex | Hex[] | undefined => {
+  if (key === "address") return request.params[0].address;
+
+  const topic = request.params[0].topics?.[Number(key.slice(-1))];
+  return topic === null ? undefined : topic;
+};
+
+/** Returns `true` if `left` and `right` overlap by at least 80% of the smaller interval's length. */
+const hasSufficientLogIntervalOverlap = (
+  left: Interval,
+  right: Interval,
+): boolean => {
+  const overlapStart = Math.max(left[0], right[0]);
+  const overlapEnd = Math.min(left[1], right[1]);
+  if (overlapStart > overlapEnd) return false;
+
+  const overlapLength = overlapEnd - overlapStart + 1;
+  const smallerIntervalLength = Math.min(
+    left[1] - left[0] + 1,
+    right[1] - right[0] + 1,
+  );
+
+  return overlapLength / smallerIntervalLength >= 0.8;
+};
+
+const mergeLogFilterValue = <value extends Hex>(
+  left: value | value[] | undefined,
+  right: value | value[] | undefined,
+): value[] | undefined =>
+  left === undefined || right === undefined
+    ? undefined
+    : [
+        ...new Set([
+          ...(Array.isArray(left) ? left : [left]),
+          ...(Array.isArray(right) ? right : [right]),
+        ]),
+      ];
+
+/**
+ * Merge `LogFilter`s into the smallest possible set of "eth_getLogs" requests.
+ *
+ * @dev Two filters are merged into a single request when:
+ *   1. their required intervals overlap by at least 80% (of the smaller
+ *      interval's length), and
+ *   2. at most one of `address`, `topic0`, `topic1`, `topic2`, or `topic3`
+ *      differs between them.
+ * The one differing dimension (if any) is unioned into an array.
+ *
+ * @dev Factory addresses are resolved into concrete child addresses (or
+ * `undefined`, above `factoryAddressCountThreshold`) before merging, so
+ * requests originating from different factories can still be merged.
+ */
+export const mergeLogFiltersToRequests = (
+  filters: IntervalWithFilter[],
+  childAddresses: ChildAddresses,
+  factoryAddressCountThreshold: number,
+): EthGetLogsRequest[] => {
+  const requests: EthGetLogsRequest[] = [];
+
+  for (const { filter, interval } of filters) {
+    if (filter.type !== "log") continue;
+
+    let address: Hex | Hex[] | undefined;
+    if (isAddressFactory(filter.address)) {
+      const addresses = childAddresses.get(filter.address.id)!;
+      if (addresses.size === 0) continue;
+
+      address =
+        addresses.size >= factoryAddressCountThreshold
+          ? undefined
+          : Array.from(addresses.keys());
+    } else {
+      address = filter.address;
+    }
+
+    const candidate: EthGetLogsRequest = {
+      method: "eth_getLogs",
+      params: [
+        {
+          address,
+          topics: sanitizeLogTopics([
+            filter.topic0,
+            filter.topic1 ?? null,
+            filter.topic2 ?? null,
+            filter.topic3 ?? null,
+          ]),
+          fromBlock: numberToHex(interval[0]),
+          toBlock: numberToHex(interval[1]),
+        },
+      ],
+    };
+
+    let isMerged = false;
+
+    for (const request of requests) {
+      if (
+        hasSufficientLogIntervalOverlap(
+          [
+            hexToNumber(request.params[0].fromBlock),
+            hexToNumber(request.params[0].toBlock),
+          ],
+          interval,
+        ) === false
+      ) {
+        continue;
+      }
+
+      const numberOfDifferences = logRequestKeys.filter(
+        (key) =>
+          JSON.stringify(getLogRequestValue(request, key)) !==
+          JSON.stringify(getLogRequestValue(candidate, key)),
+      ).length;
+      if (numberOfDifferences > 1) continue;
+
+      const requestParams = request.params[0];
+      for (const key of logRequestKeys) {
+        const requestValue = getLogRequestValue(request, key);
+        const candidateValue = getLogRequestValue(candidate, key);
+        if (JSON.stringify(requestValue) === JSON.stringify(candidateValue)) {
+          continue;
+        }
+
+        const mergedValue = mergeLogFilterValue(requestValue, candidateValue);
+        if (key === "address") {
+          requestParams.address = mergedValue;
+        } else {
+          const topics = [...(requestParams.topics ?? [])];
+          topics[Number(key.slice(-1))] = mergedValue ?? null;
+          requestParams.topics = sanitizeLogTopics(topics);
+        }
+      }
+
+      requestParams.fromBlock = numberToHex(
+        Math.min(hexToNumber(requestParams.fromBlock), interval[0]),
+      );
+      requestParams.toBlock = numberToHex(
+        Math.max(hexToNumber(requestParams.toBlock), interval[1]),
+      );
+      isMerged = true;
+      break;
+    }
+
+    if (isMerged === false) {
+      requests.push(candidate);
+    }
+  }
+
+  return requests;
 };
 
 export const getChildAddress = ({

--- a/packages/core/src/sync-historical/index.test.ts
+++ b/packages/core/src/sync-historical/index.test.ts
@@ -1,6 +1,8 @@
 import {
+  type Address,
   getAbiItem,
   type Hex,
+  numberToHex,
   toEventSelector,
   zeroAddress,
   zeroHash,
@@ -36,13 +38,15 @@ import {
   getErc20IndexingBuild,
   getPairWithFactoryIndexingBuild,
 } from "@/_test/utils.js";
+import type { LogFilter } from "@/internal/types.js";
 import { createRpc } from "@/rpc/index.js";
 import {
   getCachedIntervals,
   getRequiredIntervalsWithFilters,
+  type IntervalWithFilter,
 } from "@/runtime/index.js";
 import * as ponderSyncSchema from "@/sync-store/schema.js";
-import { createHistoricalSync } from "./index.js";
+import { createHistoricalSync, mergeLogFiltersToRequests } from "./index.js";
 
 beforeEach(setupCommon);
 beforeEach(setupAnvil);
@@ -1282,4 +1286,169 @@ test("syncAddress() handles many addresses", async () => {
   );
   expect(dbLogs).toHaveLength(1);
   expect(factories).toHaveLength(11);
+});
+
+// The following tests exercise `mergeLogFiltersToRequests` directly. Neither
+// function makes RPC requests, so these tests don't require anvil or a
+// database.
+
+const ADDRESS_A: Address = "0x1111111111111111111111111111111111111111";
+const ADDRESS_B: Address = "0x2222222222222222222222222222222222222222";
+
+const TOPIC1_ALICE: Hex = `0x${"0".repeat(24)}${ALICE.slice(2)}`;
+const TOPIC1_BOB: Hex = `0x${"0".repeat(24)}${BOB.slice(2)}`;
+
+const baseLogFilter = {
+  type: "log",
+  chainId: 1,
+  sourceId: "Erc20",
+  fromBlock: undefined,
+  toBlock: undefined,
+  hasTransactionReceipt: false,
+  include: [] as LogFilter["include"],
+};
+
+test("mergeLogFiltersToRequests merges filters with different topic1 values into one request", () => {
+  const transfer = toEventSelector(
+    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
+  );
+
+  const requiredIntervals: IntervalWithFilter[] = [
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: TOPIC1_ALICE,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: TOPIC1_BOB,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+  ];
+
+  // Only `topic1` differs between the two filters, so they're merged into a
+  // single request with `topic1` unioned into an array.
+  const mergedRequests = mergeLogFiltersToRequests(
+    requiredIntervals,
+    new Map(),
+    1000,
+  );
+
+  expect(mergedRequests).toHaveLength(1);
+  expect(mergedRequests[0]!.params[0]).toMatchObject({
+    address: ADDRESS_A,
+    topics: [transfer, [TOPIC1_ALICE, TOPIC1_BOB]],
+  });
+});
+
+test("mergeLogFiltersToRequests merges filters with different addresses into one request", () => {
+  const transfer = toEventSelector(
+    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
+  );
+
+  const requiredIntervals: IntervalWithFilter[] = [
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: null,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_B,
+        topic0: transfer,
+        topic1: null,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+  ];
+
+  // Only `address` differs between the two filters, so they're merged into a
+  // single request with `address` unioned into an array.
+  const mergedRequests = mergeLogFiltersToRequests(
+    requiredIntervals,
+    new Map(),
+    1000,
+  );
+
+  expect(mergedRequests).toHaveLength(1);
+  expect(mergedRequests[0]!.params[0]).toMatchObject({
+    address: [ADDRESS_A, ADDRESS_B],
+    topics: [transfer],
+  });
+});
+
+test("mergeLogFiltersToRequests does not merge disjoint intervals into an overly wide request", () => {
+  const transfer = toEventSelector(
+    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
+  );
+
+  const requiredIntervals: IntervalWithFilter[] = [
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: null,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [1, 100],
+    },
+    {
+      filter: {
+        ...baseLogFilter,
+        address: ADDRESS_A,
+        topic0: transfer,
+        topic1: null,
+        topic2: null,
+        topic3: null,
+      } as LogFilter,
+      interval: [100_000, 100_100],
+    },
+  ];
+
+  // The two filters are otherwise identical, but their intervals are
+  // disjoint (0% overlap), so merging them would force an unnecessarily wide
+  // request that refetches ~100,000 unrelated blocks. Instead, two
+  // tightly-bounded requests are kept.
+  const mergedRequests = mergeLogFiltersToRequests(
+    requiredIntervals,
+    new Map(),
+    1000,
+  );
+
+  expect(mergedRequests).toHaveLength(2);
+  expect(mergedRequests.map((request) => request.params[0])).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        fromBlock: numberToHex(1),
+        toBlock: numberToHex(100),
+      }),
+      expect.objectContaining({
+        fromBlock: numberToHex(100_000),
+        toBlock: numberToHex(100_100),
+      }),
+    ]),
+  );
 });

--- a/packages/core/src/sync-historical/index.test.ts
+++ b/packages/core/src/sync-historical/index.test.ts
@@ -1,8 +1,6 @@
 import {
-  type Address,
   getAbiItem,
   type Hex,
-  numberToHex,
   toEventSelector,
   zeroAddress,
   zeroHash,
@@ -38,15 +36,13 @@ import {
   getErc20IndexingBuild,
   getPairWithFactoryIndexingBuild,
 } from "@/_test/utils.js";
-import type { LogFilter } from "@/internal/types.js";
 import { createRpc } from "@/rpc/index.js";
 import {
   getCachedIntervals,
   getRequiredIntervalsWithFilters,
-  type IntervalWithFilter,
 } from "@/runtime/index.js";
 import * as ponderSyncSchema from "@/sync-store/schema.js";
-import { createHistoricalSync, mergeLogFiltersToRequests } from "./index.js";
+import { createHistoricalSync } from "./index.js";
 
 beforeEach(setupCommon);
 beforeEach(setupAnvil);
@@ -1286,169 +1282,4 @@ test("syncAddress() handles many addresses", async () => {
   );
   expect(dbLogs).toHaveLength(1);
   expect(factories).toHaveLength(11);
-});
-
-// The following tests exercise `mergeLogFiltersToRequests` directly. Neither
-// function makes RPC requests, so these tests don't require anvil or a
-// database.
-
-const ADDRESS_A: Address = "0x1111111111111111111111111111111111111111";
-const ADDRESS_B: Address = "0x2222222222222222222222222222222222222222";
-
-const TOPIC1_ALICE: Hex = `0x${"0".repeat(24)}${ALICE.slice(2)}`;
-const TOPIC1_BOB: Hex = `0x${"0".repeat(24)}${BOB.slice(2)}`;
-
-const baseLogFilter = {
-  type: "log",
-  chainId: 1,
-  sourceId: "Erc20",
-  fromBlock: undefined,
-  toBlock: undefined,
-  hasTransactionReceipt: false,
-  include: [] as LogFilter["include"],
-};
-
-test("mergeLogFiltersToRequests merges filters with different topic1 values into one request", () => {
-  const transfer = toEventSelector(
-    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
-  );
-
-  const requiredIntervals: IntervalWithFilter[] = [
-    {
-      filter: {
-        ...baseLogFilter,
-        address: ADDRESS_A,
-        topic0: transfer,
-        topic1: TOPIC1_ALICE,
-        topic2: null,
-        topic3: null,
-      } as LogFilter,
-      interval: [1, 100],
-    },
-    {
-      filter: {
-        ...baseLogFilter,
-        address: ADDRESS_A,
-        topic0: transfer,
-        topic1: TOPIC1_BOB,
-        topic2: null,
-        topic3: null,
-      } as LogFilter,
-      interval: [1, 100],
-    },
-  ];
-
-  // Only `topic1` differs between the two filters, so they're merged into a
-  // single request with `topic1` unioned into an array.
-  const mergedRequests = mergeLogFiltersToRequests(
-    requiredIntervals,
-    new Map(),
-    1000,
-  );
-
-  expect(mergedRequests).toHaveLength(1);
-  expect(mergedRequests[0]!.params[0]).toMatchObject({
-    address: ADDRESS_A,
-    topics: [transfer, [TOPIC1_ALICE, TOPIC1_BOB]],
-  });
-});
-
-test("mergeLogFiltersToRequests merges filters with different addresses into one request", () => {
-  const transfer = toEventSelector(
-    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
-  );
-
-  const requiredIntervals: IntervalWithFilter[] = [
-    {
-      filter: {
-        ...baseLogFilter,
-        address: ADDRESS_A,
-        topic0: transfer,
-        topic1: null,
-        topic2: null,
-        topic3: null,
-      } as LogFilter,
-      interval: [1, 100],
-    },
-    {
-      filter: {
-        ...baseLogFilter,
-        address: ADDRESS_B,
-        topic0: transfer,
-        topic1: null,
-        topic2: null,
-        topic3: null,
-      } as LogFilter,
-      interval: [1, 100],
-    },
-  ];
-
-  // Only `address` differs between the two filters, so they're merged into a
-  // single request with `address` unioned into an array.
-  const mergedRequests = mergeLogFiltersToRequests(
-    requiredIntervals,
-    new Map(),
-    1000,
-  );
-
-  expect(mergedRequests).toHaveLength(1);
-  expect(mergedRequests[0]!.params[0]).toMatchObject({
-    address: [ADDRESS_A, ADDRESS_B],
-    topics: [transfer],
-  });
-});
-
-test("mergeLogFiltersToRequests does not merge disjoint intervals into an overly wide request", () => {
-  const transfer = toEventSelector(
-    getAbiItem({ abi: erc20ABI, name: "Transfer" }),
-  );
-
-  const requiredIntervals: IntervalWithFilter[] = [
-    {
-      filter: {
-        ...baseLogFilter,
-        address: ADDRESS_A,
-        topic0: transfer,
-        topic1: null,
-        topic2: null,
-        topic3: null,
-      } as LogFilter,
-      interval: [1, 100],
-    },
-    {
-      filter: {
-        ...baseLogFilter,
-        address: ADDRESS_A,
-        topic0: transfer,
-        topic1: null,
-        topic2: null,
-        topic3: null,
-      } as LogFilter,
-      interval: [100_000, 100_100],
-    },
-  ];
-
-  // The two filters are otherwise identical, but their intervals are
-  // disjoint (0% overlap), so merging them would force an unnecessarily wide
-  // request that refetches ~100,000 unrelated blocks. Instead, two
-  // tightly-bounded requests are kept.
-  const mergedRequests = mergeLogFiltersToRequests(
-    requiredIntervals,
-    new Map(),
-    1000,
-  );
-
-  expect(mergedRequests).toHaveLength(2);
-  expect(mergedRequests.map((request) => request.params[0])).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        fromBlock: numberToHex(1),
-        toBlock: numberToHex(100),
-      }),
-      expect.objectContaining({
-        fromBlock: numberToHex(100_000),
-        toBlock: numberToHex(100_100),
-      }),
-    ]),
-  );
 });

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -4,7 +4,6 @@ import {
   type Hash,
   type Hex,
   hexToNumber,
-  type LogTopic,
   numberToHex,
   type RpcError,
   toHex,
@@ -37,7 +36,11 @@ import {
   validateTracesAndBlock,
   validateTransactionsAndBlock,
 } from "@/rpc/actions.js";
-import { type Rpc, sanitizeLogTopics } from "@/rpc/index.js";
+import {
+  type RequestParameters,
+  type Rpc,
+  sanitizeLogTopics,
+} from "@/rpc/index.js";
 import {
   getChildAddress,
   isAddressFactory,
@@ -67,6 +70,164 @@ import { promiseAllSettledWithThrow } from "@/utils/promiseAllSettledWithThrow.j
 import { createQueue } from "@/utils/queue.js";
 import { startClock } from "@/utils/timer.js";
 
+type LogRequestParams = {
+  fromBlock: number;
+  toBlock: number;
+  address: Hex | Hex[] | undefined;
+  topic0: Hex | Hex[] | undefined;
+  topic1: Hex | Hex[] | undefined;
+  topic2: Hex | Hex[] | undefined;
+  topic3: Hex | Hex[] | undefined;
+  filters: LogFilter[];
+};
+
+const logRequestKeys = [
+  "address",
+  "topic0",
+  "topic1",
+  "topic2",
+  "topic3",
+] as const;
+
+/** Returns `true` if `left` and `right` overlap by at least 80% of the smaller interval's length. */
+const hasSufficientLogIntervalOverlap = (
+  left: Interval,
+  right: Interval,
+): boolean => {
+  const overlapStart = Math.max(left[0], right[0]);
+  const overlapEnd = Math.min(left[1], right[1]);
+  if (overlapStart > overlapEnd) return false;
+
+  const overlapLength = overlapEnd - overlapStart + 1;
+  const smallerIntervalLength = Math.min(
+    left[1] - left[0] + 1,
+    right[1] - right[0] + 1,
+  );
+
+  return overlapLength / smallerIntervalLength >= 0.8;
+};
+
+const mergeLogFilterValue = <value extends Hex>(
+  left: value | value[] | undefined,
+  right: value | value[] | undefined,
+): value[] | undefined =>
+  left === undefined || right === undefined
+    ? undefined
+    : [
+        ...new Set([
+          ...(Array.isArray(left) ? left : [left]),
+          ...(Array.isArray(right) ? right : [right]),
+        ]),
+      ];
+
+/**
+ * Merge `LogFilter`s into the smallest possible set of "eth_getLogs" requests.
+ *
+ * @dev Two filters are merged into a single request when:
+ *   1. their required intervals overlap by at least 80% (of the smaller
+ *      interval's length), and
+ *   2. at most one of `address`, `topic0`, `topic1`, `topic2`, or `topic3`
+ *      differs between them.
+ * The one differing dimension (if any) is unioned into an array.
+ *
+ * @dev Factory addresses are resolved into concrete child addresses (or
+ * `undefined`, above `factoryAddressCountThreshold`) before merging, so
+ * requests originating from different factories can still be merged.
+ */
+export const mergeLogFiltersToRequests = (
+  filters: IntervalWithFilter[],
+  childAddresses: ChildAddresses,
+  factoryAddressCountThreshold: number,
+): (Extract<RequestParameters, { method: "eth_getLogs" }> & {
+  filters: LogFilter[];
+})[] => {
+  const requests: LogRequestParams[] = [];
+
+  for (const { filter, interval } of filters) {
+    if (filter.type !== "log") continue;
+
+    let address: Hex | Hex[] | undefined;
+    if (isAddressFactory(filter.address)) {
+      const addresses = childAddresses.get(filter.address.id)!;
+      if (addresses.size === 0) continue;
+
+      address =
+        addresses.size >= factoryAddressCountThreshold
+          ? undefined
+          : Array.from(addresses.keys());
+    } else {
+      address = filter.address;
+    }
+
+    const candidate = {
+      address,
+      topic0: filter.topic0,
+      topic1: filter.topic1 ?? undefined,
+      topic2: filter.topic2 ?? undefined,
+      topic3: filter.topic3 ?? undefined,
+    };
+
+    let isMerged = false;
+
+    for (const request of requests) {
+      if (
+        hasSufficientLogIntervalOverlap(
+          [request.fromBlock, request.toBlock],
+          interval,
+        ) === false
+      ) {
+        continue;
+      }
+
+      const numberOfDifferences = logRequestKeys.filter(
+        (key) =>
+          JSON.stringify(request[key]) !== JSON.stringify(candidate[key]),
+      ).length;
+      if (numberOfDifferences > 1) continue;
+
+      for (const key of logRequestKeys) {
+        if (JSON.stringify(request[key]) === JSON.stringify(candidate[key])) {
+          continue;
+        }
+        request[key] = mergeLogFilterValue(request[key], candidate[key]);
+      }
+
+      request.fromBlock = Math.min(request.fromBlock, interval[0]);
+      request.toBlock = Math.max(request.toBlock, interval[1]);
+      request.filters.push(filter);
+      isMerged = true;
+      break;
+    }
+
+    if (isMerged === false) {
+      requests.push({
+        fromBlock: interval[0],
+        toBlock: interval[1],
+        ...candidate,
+        filters: [filter],
+      });
+    }
+  }
+
+  return requests.map(({ fromBlock, toBlock, filters, ...filter }) => ({
+    method: "eth_getLogs" as const,
+    params: [
+      {
+        address: filter.address as Address | Address[] | undefined,
+        topics: sanitizeLogTopics([
+          filter.topic0 ?? null,
+          filter.topic1 ?? null,
+          filter.topic2 ?? null,
+          filter.topic3 ?? null,
+        ]),
+        fromBlock: numberToHex(fromBlock),
+        toBlock: numberToHex(toBlock),
+      },
+    ],
+    filters,
+  }));
+};
+
 export type HistoricalSync = {
   /**
    * Sync block data that can be queried for a range of blocks (logs).
@@ -79,6 +240,7 @@ export type HistoricalSync = {
   }): Promise<SyncLog[]>;
   /**
    * Sync block data that must be queried for a single block (block, transactions, receipts, traces).
+   * @returns Closest-to-tip synced block.
    */
   syncBlockData(params: {
     interval: Interval;
@@ -120,48 +282,37 @@ export const createHistoricalSync = (
   // Helper functions for sync tasks
   ////////
 
-  type EthGetLogsParams = {
-    address: Address | Address[] | undefined;
-    topic0?: LogTopic;
-    topic1?: LogTopic;
-    topic2?: LogTopic;
-    topic3?: LogTopic;
-    interval: Interval;
-  };
-
   /**
    * Split "eth_getLogs" requests into ranges inferred from errors
    * and batch requests.
    */
   const syncLogsDynamic = async (
-    { address, topic0, topic1, topic2, topic3, interval }: EthGetLogsParams,
+    params: Extract<RequestParameters, { method: "eth_getLogs" }>["params"][0],
     context?: Parameters<Rpc["request"]>[1],
   ): Promise<SyncLog[]> => {
+    const { address, topics } = params;
+
     const intervals = getChunks({
-      interval,
+      interval: [
+        hexToNumber(params.fromBlock as Hex),
+        hexToNumber(params.toBlock as Hex),
+      ],
       maxChunkSize:
         args.chain.ethGetLogsBlockRange ??
         logsRequestMetadata.confirmedRange ??
         logsRequestMetadata.estimatedRange,
     });
 
-    const topics = sanitizeLogTopics([
-      topic0 ?? null,
-      topic1 ?? null,
-      topic2 ?? null,
-      topic3 ?? null,
-    ])!;
-
     const logs = await Promise.all(
-      intervals.map((interval) =>
+      intervals.map(([fromBlock, toBlock]) =>
         eth_getLogs(
           args.rpc,
           [
             {
               address,
               topics,
-              fromBlock: numberToHex(interval[0]),
-              toBlock: numberToHex(interval[1]),
+              fromBlock: numberToHex(fromBlock),
+              toBlock: numberToHex(toBlock),
             },
           ],
           context,
@@ -177,8 +328,8 @@ export const createHistoricalSync = (
               {
                 address,
                 topics,
-                fromBlock: toHex(interval[0]),
-                toBlock: toHex(interval[1]),
+                fromBlock: toHex(fromBlock),
+                toBlock: toHex(toBlock),
               },
             ],
             error: error as RpcError,
@@ -205,7 +356,12 @@ export const createHistoricalSync = (
           };
 
           return syncLogsDynamic(
-            { address, topic0, topic1, topic2, topic3, interval },
+            {
+              address,
+              topics,
+              fromBlock: numberToHex(fromBlock),
+              toBlock: numberToHex(toBlock),
+            },
             context,
           );
         }),
@@ -318,14 +474,15 @@ export const createHistoricalSync = (
     const logs = await syncLogsDynamic(
       {
         address: factory.address,
-        topic0: factory.eventSelector,
-        interval,
+        topics: [factory.eventSelector],
+        fromBlock: numberToHex(interval[0]),
+        toBlock: numberToHex(interval[1]),
       },
       context,
     );
 
     const childAddresses = new Map<Address, number>();
-    const childAddressesRecord = args.childAddresses.get(factory.id)!;
+    const factoryChildAddresses = args.childAddresses.get(factory.id)!;
 
     const childAddressDecodeFailureIds = new Set<string>();
     let childAddressDecodeFailureCount = 0;
@@ -358,7 +515,7 @@ export const createHistoricalSync = (
             throw error;
           }
         }
-        const existingBlockNumber = childAddressesRecord.get(address);
+        const existingBlockNumber = factoryChildAddresses.get(address);
         const newBlockNumber = hexToNumber(log.blockNumber);
 
         if (
@@ -366,7 +523,7 @@ export const createHistoricalSync = (
           existingBlockNumber > newBlockNumber
         ) {
           childAddresses.set(address, newBlockNumber);
-          childAddressesRecord.set(address, newBlockNumber);
+          factoryChildAddresses.set(address, newBlockNumber);
         }
       }
     }
@@ -428,132 +585,17 @@ export const createHistoricalSync = (
         }),
       );
 
-      const mergedEthGetLogsParams: Map<string, EthGetLogsParams> = new Map();
-      const singleEthGetLogsParams: EthGetLogsParams[] = [];
-
-      for (const { filter, interval } of requiredIntervals) {
-        if (filter.type !== "log") continue;
-
-        const hasAddress = filter.address !== undefined;
-        const hasTopic1 = filter.topic1 !== undefined && filter.topic1 !== null;
-        const hasTopic2 = filter.topic2 !== undefined && filter.topic2 !== null;
-        const hasTopic3 = filter.topic3 !== undefined && filter.topic3 !== null;
-
-        if (hasAddress === false || hasTopic1 || hasTopic2 || hasTopic3) {
-          if (isAddressFactory(filter.address)) {
-            const childAddresses = args.childAddresses.get(filter.address.id)!;
-
-            if (childAddresses.size === 0) {
-              continue;
-            }
-
-            singleEthGetLogsParams.push({
-              address:
-                childAddresses.size >=
-                args.common.options.factoryAddressCountThreshold
-                  ? undefined
-                  : Array.from(childAddresses.keys()),
-              topic0: filter.topic0,
-              topic1: filter.topic1,
-              topic2: filter.topic2,
-              topic3: filter.topic3,
-              interval,
-            });
-          } else {
-            singleEthGetLogsParams.push({
-              address: filter.address,
-              topic0: filter.topic0,
-              topic1: filter.topic1,
-              topic2: filter.topic2,
-              topic3: filter.topic3,
-              interval,
-            });
-          }
-
-          continue;
-        }
-
-        let addressKey: string;
-        if (isAddressFactory(filter.address)) {
-          addressKey = filter.address.id;
-        } else if (Array.isArray(filter.address)) {
-          addressKey = filter.address.join("_");
-        } else {
-          addressKey = filter.address as Address;
-        }
-
-        if (mergedEthGetLogsParams.has(addressKey) === false) {
-          if (isAddressFactory(filter.address)) {
-            const childAddresses = args.childAddresses.get(filter.address.id)!;
-
-            if (childAddresses.size === 0) {
-              continue;
-            }
-
-            mergedEthGetLogsParams.set(addressKey, {
-              address:
-                childAddresses.size >=
-                args.common.options.factoryAddressCountThreshold
-                  ? undefined
-                  : Array.from(childAddresses.keys()),
-              topic0: filter.topic0,
-              topic1: filter.topic1,
-              topic2: filter.topic2,
-              topic3: filter.topic3,
-              interval,
-            });
-          } else {
-            mergedEthGetLogsParams.set(addressKey, {
-              address: filter.address,
-              topic0: filter.topic0,
-              topic1: filter.topic1,
-              topic2: filter.topic2,
-              topic3: filter.topic3,
-              interval,
-            });
-          }
-        } else {
-          const existingInterval =
-            mergedEthGetLogsParams.get(addressKey)!.interval;
-          const existingTopic0 = mergedEthGetLogsParams.get(addressKey)!
-            .topic0 as Hex | Hex[];
-
-          if (Array.isArray(existingTopic0)) {
-            if (existingTopic0.includes(filter.topic0) === false) {
-              mergedEthGetLogsParams.get(addressKey)!.topic0 = [
-                ...existingTopic0,
-                filter.topic0,
-              ];
-            }
-          } else {
-            if (existingTopic0 !== filter.topic0) {
-              mergedEthGetLogsParams.get(addressKey)!.topic0 = [
-                existingTopic0,
-                filter.topic0,
-              ];
-            }
-          }
-
-          mergedEthGetLogsParams.get(addressKey)!.interval = intervalBounds([
-            existingInterval,
-            interval,
-          ]);
-        }
-      }
-
-      const ethGetLogsParams = dedupe(
-        [
-          ...singleEthGetLogsParams,
-          ...Array.from(mergedEthGetLogsParams.values()),
-        ],
-        (params) => JSON.stringify(params),
+      const ethGetLogsRequests = mergeLogFiltersToRequests(
+        requiredIntervals,
+        args.childAddresses,
+        args.common.options.factoryAddressCountThreshold,
       );
 
       let logs: SyncLog[] = [];
 
       await Promise.all(
-        ethGetLogsParams.map(async (params) => {
-          const _logs = await syncLogsDynamic(params, context);
+        ethGetLogsRequests.map(async (request) => {
+          const _logs = await syncLogsDynamic(request.params[0], context);
           for (const log of _logs) {
             logs.push(log);
           }

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -36,11 +36,7 @@ import {
   validateTracesAndBlock,
   validateTransactionsAndBlock,
 } from "@/rpc/actions.js";
-import {
-  type RequestParameters,
-  type Rpc,
-  sanitizeLogTopics,
-} from "@/rpc/index.js";
+import type { RequestParameters, Rpc } from "@/rpc/index.js";
 import {
   getChildAddress,
   isAddressFactory,
@@ -52,6 +48,7 @@ import {
   isTraceFilterMatched,
   isTransactionFilterMatched,
   isTransferFilterMatched,
+  mergeLogFiltersToRequests,
 } from "@/runtime/filter.js";
 import type {
   ChildAddresses,
@@ -69,164 +66,6 @@ import {
 import { promiseAllSettledWithThrow } from "@/utils/promiseAllSettledWithThrow.js";
 import { createQueue } from "@/utils/queue.js";
 import { startClock } from "@/utils/timer.js";
-
-type LogRequestParams = {
-  fromBlock: number;
-  toBlock: number;
-  address: Hex | Hex[] | undefined;
-  topic0: Hex | Hex[] | undefined;
-  topic1: Hex | Hex[] | undefined;
-  topic2: Hex | Hex[] | undefined;
-  topic3: Hex | Hex[] | undefined;
-  filters: LogFilter[];
-};
-
-const logRequestKeys = [
-  "address",
-  "topic0",
-  "topic1",
-  "topic2",
-  "topic3",
-] as const;
-
-/** Returns `true` if `left` and `right` overlap by at least 80% of the smaller interval's length. */
-const hasSufficientLogIntervalOverlap = (
-  left: Interval,
-  right: Interval,
-): boolean => {
-  const overlapStart = Math.max(left[0], right[0]);
-  const overlapEnd = Math.min(left[1], right[1]);
-  if (overlapStart > overlapEnd) return false;
-
-  const overlapLength = overlapEnd - overlapStart + 1;
-  const smallerIntervalLength = Math.min(
-    left[1] - left[0] + 1,
-    right[1] - right[0] + 1,
-  );
-
-  return overlapLength / smallerIntervalLength >= 0.8;
-};
-
-const mergeLogFilterValue = <value extends Hex>(
-  left: value | value[] | undefined,
-  right: value | value[] | undefined,
-): value[] | undefined =>
-  left === undefined || right === undefined
-    ? undefined
-    : [
-        ...new Set([
-          ...(Array.isArray(left) ? left : [left]),
-          ...(Array.isArray(right) ? right : [right]),
-        ]),
-      ];
-
-/**
- * Merge `LogFilter`s into the smallest possible set of "eth_getLogs" requests.
- *
- * @dev Two filters are merged into a single request when:
- *   1. their required intervals overlap by at least 80% (of the smaller
- *      interval's length), and
- *   2. at most one of `address`, `topic0`, `topic1`, `topic2`, or `topic3`
- *      differs between them.
- * The one differing dimension (if any) is unioned into an array.
- *
- * @dev Factory addresses are resolved into concrete child addresses (or
- * `undefined`, above `factoryAddressCountThreshold`) before merging, so
- * requests originating from different factories can still be merged.
- */
-export const mergeLogFiltersToRequests = (
-  filters: IntervalWithFilter[],
-  childAddresses: ChildAddresses,
-  factoryAddressCountThreshold: number,
-): (Extract<RequestParameters, { method: "eth_getLogs" }> & {
-  filters: LogFilter[];
-})[] => {
-  const requests: LogRequestParams[] = [];
-
-  for (const { filter, interval } of filters) {
-    if (filter.type !== "log") continue;
-
-    let address: Hex | Hex[] | undefined;
-    if (isAddressFactory(filter.address)) {
-      const addresses = childAddresses.get(filter.address.id)!;
-      if (addresses.size === 0) continue;
-
-      address =
-        addresses.size >= factoryAddressCountThreshold
-          ? undefined
-          : Array.from(addresses.keys());
-    } else {
-      address = filter.address;
-    }
-
-    const candidate = {
-      address,
-      topic0: filter.topic0,
-      topic1: filter.topic1 ?? undefined,
-      topic2: filter.topic2 ?? undefined,
-      topic3: filter.topic3 ?? undefined,
-    };
-
-    let isMerged = false;
-
-    for (const request of requests) {
-      if (
-        hasSufficientLogIntervalOverlap(
-          [request.fromBlock, request.toBlock],
-          interval,
-        ) === false
-      ) {
-        continue;
-      }
-
-      const numberOfDifferences = logRequestKeys.filter(
-        (key) =>
-          JSON.stringify(request[key]) !== JSON.stringify(candidate[key]),
-      ).length;
-      if (numberOfDifferences > 1) continue;
-
-      for (const key of logRequestKeys) {
-        if (JSON.stringify(request[key]) === JSON.stringify(candidate[key])) {
-          continue;
-        }
-        request[key] = mergeLogFilterValue(request[key], candidate[key]);
-      }
-
-      request.fromBlock = Math.min(request.fromBlock, interval[0]);
-      request.toBlock = Math.max(request.toBlock, interval[1]);
-      request.filters.push(filter);
-      isMerged = true;
-      break;
-    }
-
-    if (isMerged === false) {
-      requests.push({
-        fromBlock: interval[0],
-        toBlock: interval[1],
-        ...candidate,
-        filters: [filter],
-      });
-    }
-  }
-
-  return requests.map(({ fromBlock, toBlock, filters, ...filter }) => ({
-    method: "eth_getLogs" as const,
-    params: [
-      {
-        address: filter.address as Address | Address[] | undefined,
-        topics: sanitizeLogTopics([
-          filter.topic0 ?? null,
-          filter.topic1 ?? null,
-          filter.topic2 ?? null,
-          filter.topic3 ?? null,
-        ]),
-        fromBlock: numberToHex(fromBlock),
-        toBlock: numberToHex(toBlock),
-      },
-    ],
-    filters,
-  }));
-};
 
 export type HistoricalSync = {
   /**


### PR DESCRIPTION
## Summary

Replaces the address-keyed `eth_getLogs` request merging algorithm in `syncBlockRangeData` with a general one, derived from the request-merging algorithm used by `mergeFiltersToQueryRequests` in `sync-historical/query.ts`.

Two log filters are now merged into a single `eth_getLogs` request when:
1. their required intervals overlap by at least 80% (of the smaller interval's length), and
2. at most one of `address`, `topic0`, `topic1`, `topic2`, or `topic3` differs between them (the differing dimension is unioned into an array).

This merges cases the old algorithm could not handle, for example:
- Filters with different addresses but identical topics.
- Filters with different indexed topic values (`topic1`/`topic2`/`topic3`).
- Filters where one has a factory-address and another doesn't (or where they reference different factories), once child addresses are resolved.