### PR TITLE
Use seconds for unfinalized window

### DIFF
--- a/.changeset/poor-friends-rest.md
+++ b/.changeset/poor-friends-rest.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Added `reorgWindow` to chain configuration in `ponder.config.ts` to control how long Ponder retains the data required to recover from reorgs. The window is measured in seconds and defaults to `180`.

--- a/.changeset/poor-friends-rest.md
+++ b/.changeset/poor-friends-rest.md
@@ -1,5 +1,5 @@
 ---
-"ponder": patch
+"ponder": minor
 ---
 
 Added `reorgWindow` to chain configuration in `ponder.config.ts` to control how long Ponder retains the data required to recover from reorgs. The window is measured in seconds and defaults to `180`.

--- a/docs/pages/docs/api-reference/ponder/config.mdx
+++ b/docs/pages/docs/api-reference/ponder/config.mdx
@@ -156,6 +156,7 @@ export default createConfig({
 | **rpc**                   |  `string \| string[] \| Transport` | **Required**. One or more RPC endpoints or a Viem [Transport](https://viem.sh/docs/clients/transports/http) e.g. `http` or `fallback`.                                          |
 | **ws**                    |  `string`                          | **Default: `undefined`**. A webSocket endpoint for realtime indexing on this chain.                                                                                             |
 | **pollingInterval**       |  `number`                          | **Default: `1_000`**. Frequency (in ms) used when polling for new events on this chain.                                                                                         |
+| **reorgWindow**           |  `number`                          | **Default: `180`**. Duration, in seconds between block timestamps, for which Ponder retains the data required to recover from reorgs. Must be an integer between `0` and `600`. |
 | **disableCache**          |  `boolean`                         | **Default: `false`**. Disables the RPC request cache. Use when indexing a [local node](/docs/guides/foundry) like Anvil.                                                        |
 | **ethGetLogsBlockRange** |  `number`                          | **Default: `undefined`**. Maximum block range for `eth_getLogs` requests. If undefined, Ponder will attempt to determine the block range automatically based on error messages. |
 

--- a/docs/pages/docs/config/chains.mdx
+++ b/docs/pages/docs/config/chains.mdx
@@ -177,6 +177,28 @@ export default createConfig({
 });
 ```
 
+## Reorg window
+
+The `reorgWindow` option controls how long Ponder retains the data required to automatically recover from a chain reorganization. The value is measured in seconds and defaults to `180` (3 minutes).
+
+Increasing `reorgWindow` lets Ponder recover from older reorgs, but increases memory and database usage. Decreasing it reduces resource usage, but increases the chance that Ponder encounters an unrecoverable reorg and errors.
+
+The value must be an integer between `0` and `600` (10 minutes). Setting `reorgWindow` to `0` disables automatic reorg recovery by treating each block as finalized immediately. Ponder will still detect reorgs and stop rather than continue with inconsistent data.
+
+```ts [ponder.config.ts]
+import { createConfig } from "ponder";
+
+export default createConfig({
+  chains: {
+    mainnet: {
+      id: 1,
+      rpc: process.env.PONDER_RPC_URL_1,
+      reorgWindow: 300, // 5 minutes [!code focus]
+    },
+  },
+});
+```
+
 ## Disable caching
 
 Use the `disableCache` option to disable caching for RPC responses. The default is `false`.

--- a/docs/pages/docs/config/chains.mdx
+++ b/docs/pages/docs/config/chains.mdx
@@ -181,9 +181,9 @@ export default createConfig({
 
 The `reorgWindow` option controls how long Ponder retains the data required to automatically recover from a chain reorganization. The value is measured in seconds and defaults to `180` (3 minutes).
 
-Increasing `reorgWindow` lets Ponder recover from older reorgs, but increases memory and database usage. Decreasing it reduces resource usage, but increases the chance that Ponder encounters an unrecoverable reorg and errors.
+Increasing `reorgWindow` lets Ponder recover from older reorgs, but increases memory and database usage. Decreasing it reduces resource usage, but increases the chance that Ponder encounters an unrecoverable reorg and crashes with a fatal error.
 
-The value must be an integer between `0` and `600` (10 minutes). Setting `reorgWindow` to `0` disables automatic reorg recovery by treating each block as finalized immediately. Ponder will still detect reorgs and stop rather than continue with inconsistent data.
+The value must be an integer between `0` and `600` (10 minutes). Setting `reorgWindow` to `0` disables automatic reorg recovery by treating each block as finalized immediately. Ponder will still detect reorgs and crash with a fatal error rather than continue with inconsistent data.
 
 ```ts [ponder.config.ts]
 import { createConfig } from "ponder";

--- a/docs/pages/docs/indexing/overview.mdx
+++ b/docs/pages/docs/indexing/overview.mdx
@@ -36,7 +36,7 @@ For each chain, the indexing engine calls indexing functions according to EVM ex
 
 ### Reorgs
 
-The indexing engine handles reorgs automatically. You do not need to adjust your indexing function logic to handle them. Here's how it works.
+The indexing engine automatically handles reorgs within each chain's configured [`reorgWindow`](/docs/config/chains#reorg-window). You do not need to adjust your indexing function logic to handle them. Here's how it works.
 
 - The indexing engine records all changes (insert, update, delete) to each table defined in `ponder.schema.ts` using a trigger-based [transaction log](https://en.wikipedia.org/wiki/Transaction_log).
 - When the indexing engine detects a reorg, it follows these steps to reconcile the database state with the new canonical chain.
@@ -44,15 +44,15 @@ The indexing engine handles reorgs automatically. You do not need to adjust your
   2. Roll back the database to the common ancestor block height using the transaction log.
   3. Fetch the new canonical data from the RPC / remote chain.
   4. Run indexing functions to process the new canonical data.
-- The indexing engine periodically drops finalized data from the transaction log to avoid database bloat.
+- Ponder treats a block as finalized once it is outside the `reorgWindow`, then removes its rollback records to limit database growth.
+- If a reorg crosses this finalized boundary, Ponder errors rather than continue with inconsistent data.
 
 ### Crash recovery
 
-If the process crashes and starts back up again using the same exact configuration, the indexing engine attempts a crash recovery. This process is similar to reorg reconciliation, except all unfinalized changes (the entire transaction log) are rolled back. Then, indexing resumes from the finalized block.
+If the process crashes and starts back up again using the same exact configuration, the indexing engine attempts a crash recovery. This process is similar to reorg reconciliation, except all changes within the `reorgWindow` are rolled back. Then, indexing resumes from the most recent block that Ponder treated as finalized.
 
 ### Backfill vs. live indexing
 
 Internally, the indexing engine has two distinct modes – **backfill** and **live** indexing – which use different approaches for fetching data from the RPC.
 
 However, indexing function logic works the same way in both modes. As long as the logic is compatible with the expected onchain activity, indexing will work fine in both modes.
-

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -661,14 +661,14 @@ export const getSimulatedEvent = ({
   return events[0]!;
 };
 
-export const getChain = (params?: { finalityBlockCount?: number }) => {
+export const getChain = (params?: { maxReorgSeconds?: number }) => {
   return {
     name: "mainnet",
     id: 1,
     rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}`,
     ws: undefined,
     pollingInterval: 1_000,
-    finalityBlockCount: params?.finalityBlockCount ?? 1,
+    maxReorgSeconds: params?.maxReorgSeconds ?? 1,
     disableCache: false,
     ethGetLogsBlockRange: undefined,
     viemChain: anvil,

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -661,14 +661,14 @@ export const getSimulatedEvent = ({
   return events[0]!;
 };
 
-export const getChain = (params?: { maxReorgSeconds?: number }) => {
+export const getChain = (params?: { reorgWindow?: number }) => {
   return {
     name: "mainnet",
     id: 1,
     rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}`,
     ws: undefined,
     pollingInterval: 1_000,
-    maxReorgSeconds: params?.maxReorgSeconds ?? 1,
+    reorgWindow: params?.reorgWindow ?? 1,
     disableCache: false,
     ethGetLogsBlockRange: undefined,
     viemChain: anvil,

--- a/packages/core/src/build/config.test.ts
+++ b/packages/core/src/build/config.test.ts
@@ -1087,6 +1087,23 @@ test("buildIndexingFunctions() returns chain, rpc, and finalized block", async (
   expect(finalizedBlocks[0]!.number).toBe("0x0");
 });
 
+test("buildConfig() uses the configured max reorg window", () => {
+  const config = createConfig({
+    chains: {
+      mainnet: {
+        id: 1,
+        rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}`,
+        maxReorgSeconds: 120,
+      },
+    },
+    blocks: { b: { chain: "mainnet" } },
+  });
+
+  const { chains } = buildConfig({ common: context.common, config });
+
+  expect(chains[0]!.maxReorgSeconds).toBe(120);
+});
+
 test("buildIndexingFunctions() hyperliquid evm", async () => {
   const config = createConfig({
     chains: {

--- a/packages/core/src/build/config.test.ts
+++ b/packages/core/src/build/config.test.ts
@@ -1087,13 +1087,13 @@ test("buildIndexingFunctions() returns chain, rpc, and finalized block", async (
   expect(finalizedBlocks[0]!.number).toBe("0x0");
 });
 
-test("buildConfig() uses the configured max reorg window", () => {
+test("buildConfig() uses the configured reorg window", () => {
   const config = createConfig({
     chains: {
       mainnet: {
         id: 1,
         rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}`,
-        maxReorgSeconds: 120,
+        reorgWindow: 120,
       },
     },
     blocks: { b: { chain: "mainnet" } },
@@ -1101,8 +1101,64 @@ test("buildConfig() uses the configured max reorg window", () => {
 
   const { chains } = buildConfig({ common: context.common, config });
 
-  expect(chains[0]!.maxReorgSeconds).toBe(120);
+  expect(chains[0]!.reorgWindow).toBe(120);
 });
+
+test("buildConfig() defaults the reorg window to 180 seconds", () => {
+  const config = createConfig({
+    chains: {
+      mainnet: {
+        id: 1,
+        rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}`,
+      },
+    },
+    blocks: { b: { chain: "mainnet" } },
+  });
+
+  const { chains } = buildConfig({ common: context.common, config });
+
+  expect(chains[0]!.reorgWindow).toBe(180);
+});
+
+test.each([0, 600])(
+  "buildConfig() accepts a reorg window of %s seconds",
+  (reorgWindow) => {
+    const config = createConfig({
+      chains: {
+        mainnet: {
+          id: 1,
+          rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}`,
+          reorgWindow,
+        },
+      },
+      blocks: { b: { chain: "mainnet" } },
+    });
+
+    const { chains } = buildConfig({ common: context.common, config });
+
+    expect(chains[0]!.reorgWindow).toBe(reorgWindow);
+  },
+);
+
+test.each([-1, 1.5, 601, Number.NaN])(
+  "buildConfig() rejects an invalid reorg window of %s",
+  (reorgWindow) => {
+    const config = createConfig({
+      chains: {
+        mainnet: {
+          id: 1,
+          rpc: `http://127.0.0.1:8545/${TEST_POOL_ID}`,
+          reorgWindow,
+        },
+      },
+      blocks: { b: { chain: "mainnet" } },
+    });
+
+    expect(() => buildConfig({ common: context.common, config })).toThrow(
+      `Invalid 'reorgWindow' for chain 'mainnet'. Expected an integer between 0 and 600 seconds, got ${reorgWindow}.`,
+    );
+  },
+);
 
 test("buildIndexingFunctions() hyperliquid evm", async () => {
   const config = createConfig({

--- a/packages/core/src/build/config.ts
+++ b/packages/core/src/build/config.ts
@@ -7,7 +7,6 @@ import {
   type Hex,
   hexToNumber,
   type LogTopic,
-  numberToHex,
   toEventSelector,
   toFunctionSelector,
 } from "viem";
@@ -44,7 +43,10 @@ import {
 import { buildTopics, toSafeName } from "@/utils/abi.js";
 import { hyperliquidEvm, chains as viemChains } from "@/utils/chains.js";
 import { dedupe } from "@/utils/dedupe.js";
-import { getFinalityBlockCount } from "@/utils/finality.js";
+import {
+  DEFAULT_MAX_REORG_SECONDS,
+  getFinalizedBlock,
+} from "@/utils/finality.js";
 import { toLowerCase } from "@/utils/lowercase.js";
 import { buildLogFactory } from "./factory.js";
 
@@ -188,30 +190,26 @@ export async function buildIndexingFunctions({
   const finalizedBlocks = await Promise.all(
     chains.map((chain) => {
       const rpc = rpcs[chains.findIndex((c) => c.name === chain.name)]!;
-      const blockPromise = eth_getBlockByNumber(rpc, ["latest", false], {
+      const latestBlockPromise = eth_getBlockByNumber(rpc, ["latest", false], {
         ...context,
         retryNullBlockRequest: true,
-      })
-        .then((block) => hexToNumber((block as SyncBlock).number))
-        .catch((e) => {
-          throw new Error(
-            `Unable to fetch "latest" block for chain '${chain.name}':\n${e.message}`,
-          );
-        });
+      }).catch((e) => {
+        throw new Error(
+          `Unable to fetch "latest" block for chain '${chain.name}':\n${e.message}`,
+        );
+      });
+      const blockPromise = latestBlockPromise.then((block) =>
+        hexToNumber((block as SyncBlock).number),
+      );
 
       perChainLatestBlockNumber.set(chain.name, blockPromise);
 
-      return blockPromise.then((latest) =>
-        eth_getBlockByNumber(
+      return latestBlockPromise.then((latestBlock) =>
+        getFinalizedBlock({
+          chain,
           rpc,
-          [numberToHex(Math.max(latest - chain.finalityBlockCount, 0)), false],
-          { ...context, retryNullBlockRequest: true },
-        ).then((block) => ({
-          hash: block.hash,
-          parentHash: block.parentHash,
-          number: block.number,
-          timestamp: block.timestamp,
-        })),
+          latestBlock,
+        }),
       );
     }),
   );
@@ -1076,7 +1074,7 @@ export function buildConfig({
         rpc: chain.rpc,
         ws: chain.ws,
         pollingInterval: chain.pollingInterval ?? 1_000,
-        finalityBlockCount: getFinalityBlockCount({ chain: matchedChain }),
+        maxReorgSeconds: chain.maxReorgSeconds ?? DEFAULT_MAX_REORG_SECONDS,
         disableCache: chain.disableCache ?? false,
         ethGetLogsBlockRange: chain.ethGetLogsBlockRange,
         viemChain: matchedChain,

--- a/packages/core/src/build/config.ts
+++ b/packages/core/src/build/config.ts
@@ -195,11 +195,11 @@ export async function buildIndexingFunctions({
           `Unable to fetch "latest" block for chain '${chain.name}':\n${e.message}`,
         );
       });
-      const blockPromise = latestBlockPromise.then((block) =>
+      const blockNumberPromise = latestBlockPromise.then((block) =>
         hexToNumber((block as SyncBlock).number),
       );
 
-      perChainLatestBlockNumber.set(chain.name, blockPromise);
+      perChainLatestBlockNumber.set(chain.name, blockNumberPromise);
 
       return latestBlockPromise.then((latestBlock) =>
         getFinalizedBlock({

--- a/packages/core/src/build/config.ts
+++ b/packages/core/src/build/config.ts
@@ -43,10 +43,7 @@ import {
 import { buildTopics, toSafeName } from "@/utils/abi.js";
 import { hyperliquidEvm, chains as viemChains } from "@/utils/chains.js";
 import { dedupe } from "@/utils/dedupe.js";
-import {
-  DEFAULT_MAX_REORG_SECONDS,
-  getFinalizedBlock,
-} from "@/utils/finality.js";
+import { DEFAULT_REORG_WINDOW, getFinalizedBlock } from "@/utils/finality.js";
 import { toLowerCase } from "@/utils/lowercase.js";
 import { buildLogFactory } from "./factory.js";
 
@@ -1068,13 +1065,24 @@ export function buildConfig({
         );
       }
 
+      if (
+        chain.reorgWindow !== undefined &&
+        (!Number.isInteger(chain.reorgWindow) ||
+          chain.reorgWindow < 0 ||
+          chain.reorgWindow > 600)
+      ) {
+        throw new Error(
+          `Invalid 'reorgWindow' for chain '${chainName}'. Expected an integer between 0 and 600 seconds, got ${chain.reorgWindow}.`,
+        );
+      }
+
       return {
         id: chain.id,
         name: chainName,
         rpc: chain.rpc,
         ws: chain.ws,
         pollingInterval: chain.pollingInterval ?? 1_000,
-        maxReorgSeconds: chain.maxReorgSeconds ?? DEFAULT_MAX_REORG_SECONDS,
+        reorgWindow: chain.reorgWindow ?? DEFAULT_REORG_WINDOW,
         disableCache: chain.disableCache ?? false,
         ethGetLogsBlockRange: chain.ethGetLogsBlockRange,
         viemChain: matchedChain,

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -97,6 +97,9 @@ type ChainConfig<chain> = {
   ws?: string;
   /** Polling interval (in ms). Default: `1_000`. */
   pollingInterval?: number;
+  /** Maximum age of blocks that can be reverted during a reorg (in seconds). Default: `60`. */
+  // TODO(kyle) Possible names: `unfinalizedWindow`, `reorgWindow`, `finalityWindow`.
+  maxReorgSeconds?: number;
   /**
    * Maximum number of RPC requests per second.
    * @deprecated Handled automatically instead.

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -97,9 +97,12 @@ type ChainConfig<chain> = {
   ws?: string;
   /** Polling interval (in ms). Default: `1_000`. */
   pollingInterval?: number;
-  /** Maximum age of blocks that can be reverted during a reorg (in seconds). Default: `60`. */
-  // TODO(kyle) Possible names: `unfinalizedWindow`, `reorgWindow`, `finalityWindow`.
-  maxReorgSeconds?: number;
+  /**
+   * The duration, in seconds, for which Ponder retains
+   * the data required to recover from a chain reorganization. Default: `180`.
+   * Maximum: `600`.
+   */
+  reorgWindow?: number;
   /**
    * Maximum number of RPC requests per second.
    * @deprecated Handled automatically instead.

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -302,7 +302,7 @@ export type Chain = {
   rpc: string | string[] | Transport;
   ws: string | undefined;
   pollingInterval: number;
-  maxReorgSeconds: number;
+  reorgWindow: number;
   disableCache: boolean;
   ethGetLogsBlockRange: number | undefined;
   viemChain: ViemChain | undefined;

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -302,7 +302,7 @@ export type Chain = {
   rpc: string | string[] | Transport;
   ws: string | undefined;
   pollingInterval: number;
-  finalityBlockCount: number;
+  maxReorgSeconds: number;
   disableCache: boolean;
   ethGetLogsBlockRange: number | undefined;
   viemChain: ViemChain | undefined;

--- a/packages/core/src/runtime/historical.test.ts
+++ b/packages/core/src/runtime/historical.test.ts
@@ -307,7 +307,7 @@ test("getLocalSyncGenerator() with full cache", async () => {
   await testClient.mine({ blocks: 1 });
 
   // finalized block: 1
-  chain.finalityBlockCount = 0;
+  chain.maxReorgSeconds = 0;
 
   let cachedIntervals = await getCachedIntervals({
     chain,

--- a/packages/core/src/runtime/historical.test.ts
+++ b/packages/core/src/runtime/historical.test.ts
@@ -307,7 +307,7 @@ test("getLocalSyncGenerator() with full cache", async () => {
   await testClient.mine({ blocks: 1 });
 
   // finalized block: 1
-  chain.maxReorgSeconds = 0;
+  chain.reorgWindow = 0;
 
   let cachedIntervals = await getCachedIntervals({
     chain,

--- a/packages/core/src/runtime/historical.ts
+++ b/packages/core/src/runtime/historical.ts
@@ -317,7 +317,7 @@ export async function* getHistoricalEventsOmnichain(params: {
       params.indexingBuild.chains.every(
         (chain) =>
           Date.now() - lastUnfinalizedRefetch <
-          Math.max(chain.maxReorgSeconds * 1_000, 30_000),
+          Math.max(chain.reorgWindow * 1_000, 30_000),
       )
     ) {
       break;
@@ -565,7 +565,7 @@ export async function* getHistoricalEventsMultichain(params: {
       params.indexingBuild.chains.every(
         (chain) =>
           Date.now() - lastUnfinalizedRefetch <
-          Math.max(chain.maxReorgSeconds * 1_000, 30_000),
+          Math.max(chain.reorgWindow * 1_000, 30_000),
       )
     ) {
       break;
@@ -775,7 +775,7 @@ export async function* getHistoricalEventsIsolated(params: {
       params.indexingBuild.chains.every(
         (chain) =>
           Date.now() - lastUnfinalizedRefetch <
-          Math.max(chain.maxReorgSeconds * 1_000, 30_000),
+          Math.max(chain.reorgWindow * 1_000, 30_000),
       )
     ) {
       break;

--- a/packages/core/src/runtime/historical.ts
+++ b/packages/core/src/runtime/historical.ts
@@ -1,4 +1,4 @@
-import { hexToNumber, numberToHex } from "viem";
+import { hexToNumber } from "viem";
 import type { Database } from "@/database/index.js";
 import type { Common } from "@/internal/common.js";
 import { ShutdownError } from "@/internal/errors.js";
@@ -24,6 +24,7 @@ import {
   ZERO_CHECKPOINT,
 } from "@/utils/checkpoint.js";
 import { estimate } from "@/utils/estimate.js";
+import { getFinalizedBlock } from "@/utils/finality.js";
 import { formatPercentage } from "@/utils/format.js";
 import {
   bufferAsyncGenerator,
@@ -70,6 +71,7 @@ export async function* getHistoricalEventsOmnichain(params: {
 > {
   let pendingEvents: Event[] = [];
   let isCatchup = false;
+  let lastUnfinalizedRefetch = Date.now();
   const perChainCursor = new Map<Chain, string>();
 
   while (true) {
@@ -311,6 +313,17 @@ export async function* getHistoricalEventsOmnichain(params: {
       yield { type: "events", result: mergeResults };
     }
 
+    if (
+      params.indexingBuild.chains.every(
+        (chain) =>
+          Date.now() - lastUnfinalizedRefetch <
+          Math.max(chain.maxReorgSeconds * 1_000, 30_000),
+      )
+    ) {
+      break;
+    }
+    lastUnfinalizedRefetch = Date.now();
+
     const context = {
       logger: params.common.logger.child({ action: "refetch_finalized_block" }),
       retryNullBlockRequest: true,
@@ -324,19 +337,13 @@ export async function* getHistoricalEventsOmnichain(params: {
 
         return eth_getBlockByNumber(rpc, ["latest", false], context)
           .then((latest) =>
-            eth_getBlockByNumber(
+            getFinalizedBlock({
+              chain,
               rpc,
-              [
-                numberToHex(
-                  Math.max(
-                    hexToNumber(latest.number) - chain.finalityBlockCount,
-                    0,
-                  ),
-                ),
-                false,
-              ],
-              context,
-            ),
+              latestBlock: latest,
+              lowerBound:
+                params.perChainSync.get(chain)!.syncProgress.finalized,
+            }),
           )
           .then((finalizedBlock) => {
             const finalizedBlockNumber = hexToNumber(finalizedBlock.number);
@@ -353,29 +360,20 @@ export async function* getHistoricalEventsOmnichain(params: {
       }),
     );
 
-    let shouldCatchup = false;
-
     for (let i = 0; i < params.indexingBuild.chains.length; i++) {
       const chain = params.indexingBuild.chains[i]!;
       const oldFinalizedBlock =
         params.perChainSync.get(chain)!.syncProgress.finalized;
-      const newFinalizedBlock = finalizedBlocks[i]!;
+      const finalizedBlock = finalizedBlocks[i]!;
 
       if (
-        hexToNumber(newFinalizedBlock.number) -
-          hexToNumber(oldFinalizedBlock.number) >
-        chain.finalityBlockCount
+        hexToNumber(finalizedBlock.number) <
+        hexToNumber(oldFinalizedBlock.number)
       ) {
-        shouldCatchup = true;
-        break;
+        throw new Error(
+          `Finalized block for chain "${chain.name}" cannot move backwards`,
+        );
       }
-    }
-
-    if (shouldCatchup === false) break;
-
-    for (let i = 0; i < params.indexingBuild.chains.length; i++) {
-      const chain = params.indexingBuild.chains[i]!;
-      const finalizedBlock = finalizedBlocks[i]!;
 
       params.perChainSync.get(chain)!.syncProgress.finalized = finalizedBlock;
     }
@@ -563,7 +561,13 @@ export async function* getHistoricalEventsMultichain(params: {
 
     yield* mergeAsyncGenerators(eventGenerators);
 
-    if (Date.now() - lastUnfinalizedRefetch < 30_000) {
+    if (
+      params.indexingBuild.chains.every(
+        (chain) =>
+          Date.now() - lastUnfinalizedRefetch <
+          Math.max(chain.maxReorgSeconds * 1_000, 30_000),
+      )
+    ) {
       break;
     }
     lastUnfinalizedRefetch = Date.now();
@@ -580,20 +584,14 @@ export async function* getHistoricalEventsMultichain(params: {
         const rpc = params.indexingBuild.rpcs[i]!;
 
         return eth_getBlockByNumber(rpc, ["latest", false], context)
-          .then((latest) =>
-            eth_getBlockByNumber(
+          .then((latestBlock) =>
+            getFinalizedBlock({
+              chain,
               rpc,
-              [
-                numberToHex(
-                  Math.max(
-                    hexToNumber(latest.number) - chain.finalityBlockCount,
-                    0,
-                  ),
-                ),
-                false,
-              ],
-              context,
-            ),
+              latestBlock,
+              lowerBound:
+                params.perChainSync.get(chain)!.syncProgress.finalized,
+            }),
           )
           .then((finalizedBlock) => {
             const finalizedBlockNumber = hexToNumber(finalizedBlock.number);
@@ -610,29 +608,18 @@ export async function* getHistoricalEventsMultichain(params: {
       }),
     );
 
-    let shouldCatchup = false;
-
-    for (let i = 0; i < params.indexingBuild.chains.length; i++) {
-      const chain = params.indexingBuild.chains[i]!;
-      const oldFinalizedBlock =
-        params.perChainSync.get(chain)!.syncProgress.finalized;
-      const newFinalizedBlock = finalizedBlocks[i]!;
-
-      if (
-        hexToNumber(newFinalizedBlock.number) -
-          hexToNumber(oldFinalizedBlock.number) >
-        chain.finalityBlockCount
-      ) {
-        shouldCatchup = true;
-        break;
-      }
-    }
-
-    if (shouldCatchup === false) break;
-
     for (let i = 0; i < params.indexingBuild.chains.length; i++) {
       const chain = params.indexingBuild.chains[i]!;
       const finalizedBlock = finalizedBlocks[i]!;
+      const oldFinalizedBlock =
+        params.perChainSync.get(chain)!.syncProgress.finalized;
+
+      if (
+        hexToNumber(finalizedBlock.number) <
+        hexToNumber(oldFinalizedBlock.number)
+      ) {
+        continue;
+      }
 
       params.perChainSync.get(chain)!.syncProgress.finalized = finalizedBlock;
     }
@@ -784,7 +771,13 @@ export async function* getHistoricalEventsIsolated(params: {
 
     cursor = to;
 
-    if (Date.now() - lastUnfinalizedRefetch < 30_000) {
+    if (
+      params.indexingBuild.chains.every(
+        (chain) =>
+          Date.now() - lastUnfinalizedRefetch <
+          Math.max(chain.maxReorgSeconds * 1_000, 30_000),
+      )
+    ) {
       break;
     }
     lastUnfinalizedRefetch = Date.now();
@@ -800,19 +793,12 @@ export async function* getHistoricalEventsIsolated(params: {
       ["latest", false],
       context,
     ).then((latest) =>
-      eth_getBlockByNumber(
+      getFinalizedBlock({
+        chain: params.chain,
         rpc,
-        [
-          numberToHex(
-            Math.max(
-              hexToNumber(latest.number) - params.chain.finalityBlockCount,
-              0,
-            ),
-          ),
-          false,
-        ],
-        context,
-      ),
+        latestBlock: latest,
+        lowerBound: params.syncProgress.finalized,
+      }),
     );
 
     const finalizedBlockNumber = hexToNumber(finalizedBlock.number);
@@ -825,9 +811,7 @@ export async function* getHistoricalEventsIsolated(params: {
     });
 
     if (
-      hexToNumber(finalizedBlock.number) -
-        hexToNumber(params.syncProgress.finalized.number) <=
-      params.chain.finalityBlockCount
+      finalizedBlockNumber < hexToNumber(params.syncProgress.finalized.number)
     ) {
       break;
     }

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -996,11 +996,7 @@ export const createHistoricalSync = (
       let receiptCount = 0;
       let traceCount = 0;
 
-      // Same memory usage as `sync-realtime`.
-      const MAX_BLOCKS_IN_MEM = Math.max(
-        args.chain.finalityBlockCount * 2,
-        100,
-      );
+      const MAX_BLOCKS_IN_MEM = 100;
 
       if (requiredIntervals.length > 0) {
         const queue = createQueue({

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -137,7 +137,7 @@ test("sync() gets missing block", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { eventCallbacks } = getBlocksIndexingBuild({
@@ -174,7 +174,7 @@ test("sync() catches error", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { eventCallbacks } = getBlocksIndexingBuild({
@@ -210,7 +210,7 @@ test("handleBlock() block event with log", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -275,7 +275,7 @@ test("sync() skips log request when bloom does not match on standard chains", as
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -307,7 +307,7 @@ test("sync() requests logs despite bloom mismatch on async-execution chains", as
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = { ...getChain({ maxReorgSeconds: 2 }), id: 143 };
+  const chain = { ...getChain({ reorgWindow: 2 }), id: 143 };
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -339,7 +339,7 @@ test("handleBlock() block event with log factory", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployFactory({ sender: ALICE });
@@ -470,7 +470,7 @@ test("handleBlock() block event with factories shared by callbacks", async () =>
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -550,7 +550,7 @@ test("handleBlock() block event with log factory and no address", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployFactory({ sender: ALICE });
@@ -685,7 +685,7 @@ test("handleBlock() block event with log factory error", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployFactory({ sender: ALICE });
@@ -781,7 +781,7 @@ test("handleBlock() block event with block", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const { eventCallbacks } = getBlocksIndexingBuild({
@@ -831,7 +831,7 @@ test("handleBlock() block event with transaction", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   await transferEth({
@@ -889,7 +889,7 @@ test("handleBlock() block event with transfer", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ common, chain });
 
   const blockData = await transferEth({
@@ -960,7 +960,7 @@ test("handleBlock() block event with trace", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({ chain, common });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -1067,7 +1067,7 @@ test("handleBlock() finalize event", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 0 });
+  const chain = getChain({ reorgWindow: 0 });
   const rpc = createRpc({
     chain,
     common,
@@ -1120,7 +1120,7 @@ test("handleReorg() finds common ancestor", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({
     chain,
     common,
@@ -1168,7 +1168,7 @@ test("handleReorg() throws error for deep reorg", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ maxReorgSeconds: 2 });
+  const chain = getChain({ reorgWindow: 2 });
   const rpc = createRpc({
     chain,
     common,

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -1120,7 +1120,7 @@ test("handleReorg() finds common ancestor", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ reorgWindow: 2 });
+  const chain = getChain({ reorgWindow: 10 });
   const rpc = createRpc({
     chain,
     common,
@@ -1168,7 +1168,7 @@ test("handleReorg() throws error for deep reorg", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ reorgWindow: 2 });
+  const chain = getChain({ reorgWindow: 10 });
   const rpc = createRpc({
     chain,
     common,

--- a/packages/core/src/sync-realtime/index.test.ts
+++ b/packages/core/src/sync-realtime/index.test.ts
@@ -137,7 +137,7 @@ test("sync() gets missing block", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { eventCallbacks } = getBlocksIndexingBuild({
@@ -174,7 +174,7 @@ test("sync() catches error", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { eventCallbacks } = getBlocksIndexingBuild({
@@ -210,7 +210,7 @@ test("handleBlock() block event with log", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -275,7 +275,7 @@ test("sync() skips log request when bloom does not match on standard chains", as
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -307,7 +307,7 @@ test("sync() requests logs despite bloom mismatch on async-execution chains", as
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = { ...getChain({ finalityBlockCount: 2 }), id: 143 };
+  const chain = { ...getChain({ maxReorgSeconds: 2 }), id: 143 };
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -339,7 +339,7 @@ test("handleBlock() block event with log factory", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployFactory({ sender: ALICE });
@@ -470,7 +470,7 @@ test("handleBlock() block event with factories shared by callbacks", async () =>
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -550,7 +550,7 @@ test("handleBlock() block event with log factory and no address", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployFactory({ sender: ALICE });
@@ -685,7 +685,7 @@ test("handleBlock() block event with log factory error", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { address } = await deployFactory({ sender: ALICE });
@@ -781,7 +781,7 @@ test("handleBlock() block event with block", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const { eventCallbacks } = getBlocksIndexingBuild({
@@ -831,7 +831,7 @@ test("handleBlock() block event with transaction", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   await transferEth({
@@ -889,7 +889,7 @@ test("handleBlock() block event with transfer", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ common, chain });
 
   const blockData = await transferEth({
@@ -960,7 +960,7 @@ test("handleBlock() block event with trace", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({ chain, common });
 
   const { address } = await deployErc20({ sender: ALICE });
@@ -1067,7 +1067,7 @@ test("handleBlock() finalize event", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 0 });
   const rpc = createRpc({
     chain,
     common,
@@ -1108,19 +1108,19 @@ test("handleBlock() finalize event", async () => {
     block: expect.any(Object),
   });
 
-  expect(realtimeSync.unfinalizedBlocks).toHaveLength(2);
+  expect(realtimeSync.unfinalizedBlocks).toHaveLength(0);
 
   expect(
     (syncResult[1] as Extract<RealtimeSyncEvent, { type: "finalize" }>).block
       .number,
-  ).toBe("0x2");
+  ).toBe("0x4");
 });
 
 test("handleReorg() finds common ancestor", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({
     chain,
     common,
@@ -1168,7 +1168,7 @@ test("handleReorg() throws error for deep reorg", async () => {
   const { common } = context;
   await setupDatabaseServices();
 
-  const chain = getChain({ finalityBlockCount: 2 });
+  const chain = getChain({ maxReorgSeconds: 2 });
   const rpc = createRpc({
     chain,
     common,

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -1152,20 +1152,24 @@ export const createRealtimeSync = (
       blockCallback,
     };
 
-    // Determine if a new range has become finalized by evaluating if the
-    // latest block number is 2 * finalityBlockCount >= finalized block number.
-    // Essentially, there is a range the width of finalityBlockCount that is entirely
-    // finalized.
-
+    // Finalize the oldest contiguous blocks that are outside the timestamp
+    // based reorg window.
     const blockMovesFinality =
-      hexToNumber(block.number) >=
-      hexToNumber(finalizedBlock.number) + 2 * args.chain.finalityBlockCount;
+      hexToNumber(block.timestamp) -
+        hexToNumber(unfinalizedBlocks[0]!.timestamp) >=
+      args.chain.maxReorgSeconds;
     if (blockMovesFinality) {
-      const pendingFinalizedBlock = unfinalizedBlocks.find(
-        (lb) =>
-          hexToNumber(lb.number) ===
-          hexToNumber(block.number) - args.chain.finalityBlockCount,
-      )!;
+      let pendingFinalizedBlock = unfinalizedBlocks[0]!;
+      for (const candidate of unfinalizedBlocks) {
+        if (
+          hexToNumber(block.timestamp) - hexToNumber(candidate.timestamp) >=
+          args.chain.maxReorgSeconds
+        ) {
+          pendingFinalizedBlock = candidate;
+        } else {
+          break;
+        }
+      }
 
       args.common.logger.debug({
         msg: "Removed finalized blocks from local chain",

--- a/packages/core/src/sync-realtime/index.ts
+++ b/packages/core/src/sync-realtime/index.ts
@@ -1157,13 +1157,13 @@ export const createRealtimeSync = (
     const blockMovesFinality =
       hexToNumber(block.timestamp) -
         hexToNumber(unfinalizedBlocks[0]!.timestamp) >=
-      args.chain.maxReorgSeconds;
+      args.chain.reorgWindow;
     if (blockMovesFinality) {
       let pendingFinalizedBlock = unfinalizedBlocks[0]!;
       for (const candidate of unfinalizedBlocks) {
         if (
           hexToNumber(block.timestamp) - hexToNumber(candidate.timestamp) >=
-          args.chain.maxReorgSeconds
+          args.chain.reorgWindow
         ) {
           pendingFinalizedBlock = candidate;
         } else {

--- a/packages/core/src/utils/finality.test.ts
+++ b/packages/core/src/utils/finality.test.ts
@@ -31,9 +31,9 @@ const getRpc = (blocks: Map<number, ReturnType<typeof getBlock>>) => {
   } as unknown as Rpc & { request: typeof request };
 };
 
-const getChain = (maxReorgSeconds: number, blockTime?: number) =>
+const getChain = (reorgWindow: number, blockTime?: number) =>
   ({
-    maxReorgSeconds,
+    reorgWindow,
     viemChain: blockTime === undefined ? undefined : { blockTime },
   }) as Chain;
 
@@ -63,7 +63,7 @@ test("getFinalizedBlock() uses blockTime for its initial guess", async () => {
     latestBlock: getBlock(100, 100),
   });
 
-  expect(Number(result.number)).toBe(78);
+  expect(Number(result.number)).toBe(80);
   expect(Number(rpc.request.mock.calls[0]![0].params[0])).toBe(90);
 });
 
@@ -79,4 +79,35 @@ test("getFinalizedBlock() assumes one-second blocks without blockTime", async ()
   });
 
   expect(Number(rpc.request.mock.calls[0]![0].params[0])).toBe(80);
+});
+
+test("getFinalizedBlock() returns genesis when the chain is younger than the reorg window", async () => {
+  const genesis = getBlock(0, 100);
+  const blocks = new Map<number, ReturnType<typeof getBlock>>([
+    [0, genesis],
+    [1, getBlock(1, 110)],
+  ]);
+  const rpc = getRpc(blocks);
+
+  const result = await getFinalizedBlock({
+    chain: getChain(180),
+    rpc,
+    latestBlock: getBlock(1, 110),
+  });
+
+  expect(result).toEqual(genesis);
+});
+
+test("getFinalizedBlock() returns the newest block at the exact cutoff", async () => {
+  const blocks = new Map<number, ReturnType<typeof getBlock>>();
+  for (let i = 0; i <= 100; i++) blocks.set(i, getBlock(i, i));
+  const rpc = getRpc(blocks);
+
+  const result = await getFinalizedBlock({
+    chain: getChain(20),
+    rpc,
+    latestBlock: getBlock(100, 100),
+  });
+
+  expect(Number(result.number)).toBe(80);
 });

--- a/packages/core/src/utils/finality.test.ts
+++ b/packages/core/src/utils/finality.test.ts
@@ -1,8 +1,82 @@
-import { expect, test } from "vitest";
-import { isAsyncExecutionChain } from "./finality.js";
+import { expect, test, vi } from "vitest";
+import type { Chain } from "@/internal/types.js";
+import type { Rpc } from "@/rpc/index.js";
+import { getFinalizedBlock, isAsyncExecutionChain } from "./finality.js";
 
 test("isAsyncExecutionChain()", () => {
   expect(isAsyncExecutionChain(143)).toBe(true);
   expect(isAsyncExecutionChain(10143)).toBe(true);
   expect(isAsyncExecutionChain(1)).toBe(false);
+});
+
+const getBlock = (number: number, timestamp: number) =>
+  ({
+    hash: `0x${number.toString(16)}`,
+    parentHash: `0x${Math.max(number - 1, 0).toString(16)}`,
+    number: `0x${number.toString(16)}`,
+    timestamp: `0x${timestamp.toString(16)}`,
+    logsBloom: "0x",
+  }) as any;
+
+const getRpc = (blocks: Map<number, ReturnType<typeof getBlock>>) => {
+  const request = vi.fn(async (request: any) =>
+    blocks.get(Number(request.params[0])),
+  );
+
+  return {
+    request,
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    hostnames: [],
+  } as unknown as Rpc & { request: typeof request };
+};
+
+const getChain = (maxReorgSeconds: number, blockTime?: number) =>
+  ({
+    maxReorgSeconds,
+    viemChain: blockTime === undefined ? undefined : { blockTime },
+  }) as Chain;
+
+test("getFinalizedBlock() skips the search when finality has not advanced", async () => {
+  const lowerBound = getBlock(80, 80);
+  const rpc = getRpc(new Map());
+
+  const result = await getFinalizedBlock({
+    chain: getChain(30),
+    rpc,
+    lowerBound,
+    latestBlock: getBlock(100, 100),
+  });
+
+  expect(result).toBe(lowerBound);
+  expect(rpc.request).not.toHaveBeenCalled();
+});
+
+test("getFinalizedBlock() uses blockTime for its initial guess", async () => {
+  const blocks = new Map<number, ReturnType<typeof getBlock>>();
+  for (let i = 0; i <= 100; i++) blocks.set(i, getBlock(i, i));
+  const rpc = getRpc(blocks);
+
+  const result = await getFinalizedBlock({
+    chain: getChain(20, 2_000),
+    rpc,
+    latestBlock: getBlock(100, 100),
+  });
+
+  expect(Number(result.number)).toBe(78);
+  expect(Number(rpc.request.mock.calls[0]![0].params[0])).toBe(90);
+});
+
+test("getFinalizedBlock() assumes one-second blocks without blockTime", async () => {
+  const blocks = new Map<number, ReturnType<typeof getBlock>>();
+  for (let i = 0; i <= 100; i++) blocks.set(i, getBlock(i, i));
+  const rpc = getRpc(blocks);
+
+  await getFinalizedBlock({
+    chain: getChain(20),
+    rpc,
+    latestBlock: getBlock(100, 100),
+  });
+
+  expect(Number(rpc.request.mock.calls[0]![0].params[0])).toBe(80);
 });

--- a/packages/core/src/utils/finality.ts
+++ b/packages/core/src/utils/finality.ts
@@ -1,43 +1,75 @@
-import type { Chain } from "viem";
+import { hexToNumber, numberToHex } from "viem";
+import type { Chain, LightBlock } from "@/internal/types.js";
+import { eth_getBlockByNumber } from "@/rpc/actions.js";
+import type { Rpc } from "@/rpc/index.js";
+
+export const DEFAULT_MAX_REORG_SECONDS = 60;
 
 export const isAsyncExecutionChain = (chainId: number) =>
   chainId === 143 || chainId === 10143;
 
 /**
- * Returns the number of blocks that must pass before a block is considered final.
- * Note that a value of `0` indicates that blocks are considered final immediately.
- *
- * @param chain The chain to get the finality block count for.
- * @returns The finality block count.
+ * Finds a block whose timestamp is outside the reorg window.
+ * Block timestamps are monotonic, so a binary search avoids retaining or
+ * fetching one block per second on fast chains. The returned block can be up
+ * to 20% older than the target timestamp, which is safe and avoids extra RPC
+ * requests when the block time estimate is slightly inaccurate.
  */
-export function getFinalityBlockCount({ chain }: { chain: Chain | undefined }) {
-  let finalityBlockCount: number;
-  switch (chain?.id) {
-    // Mainnet and mainnet testnets.
-    case 1:
-    case 3:
-    case 4:
-    case 5:
-    case 42:
-    case 11155111:
-      finalityBlockCount = 65;
-      break;
-    // Polygon.
-    case 137:
-    case 80001:
-      finalityBlockCount = 200;
-      break;
-    // Arbitrum.
-    case 42161:
-    case 42170:
-    case 421611:
-    case 421613:
-      finalityBlockCount = 240;
-      break;
-    default:
-      // Assume a 2-second block time, e.g. OP stack chains.
-      finalityBlockCount = 30;
+export async function getFinalizedBlock({
+  chain,
+  rpc,
+  latestBlock,
+  lowerBound,
+}: {
+  chain: Chain;
+  rpc: Rpc;
+  latestBlock: LightBlock;
+  lowerBound?: LightBlock;
+}): Promise<LightBlock> {
+  const { maxReorgSeconds } = chain;
+  if (maxReorgSeconds === 0) return latestBlock;
+
+  const targetTimestamp = hexToNumber(latestBlock.timestamp) - maxReorgSeconds;
+
+  let low = lowerBound ? hexToNumber(lowerBound.number) : 0;
+  let high = hexToNumber(latestBlock.number);
+  let finalizedBlock: LightBlock | undefined;
+
+  const blockTimeSeconds =
+    chain.viemChain?.blockTime === undefined || chain.viemChain.blockTime <= 0
+      ? 1
+      : chain.viemChain.blockTime / 1_000;
+  const estimatedBlockCount = Math.ceil(maxReorgSeconds / blockTimeSeconds);
+  const estimatedBlockNumber = high - estimatedBlockCount;
+  let blockNumber = Math.max(low, Math.min(estimatedBlockNumber, high));
+  const timestampTolerance = maxReorgSeconds / 5;
+
+  while (low <= high) {
+    const block = await eth_getBlockByNumber(
+      rpc,
+      [numberToHex(blockNumber), false],
+      { retryNullBlockRequest: true },
+    );
+
+    if (hexToNumber(block.timestamp) <= targetTimestamp) {
+      finalizedBlock = block;
+
+      if (targetTimestamp - hexToNumber(block.timestamp) < timestampTolerance) {
+        return block;
+      }
+
+      low = blockNumber + 1;
+    } else {
+      high = blockNumber - 1;
+    }
+
+    if (low > high) break;
+    blockNumber = Math.floor((low + high) / 2);
   }
 
-  return finalityBlockCount;
+  if (finalizedBlock === undefined) {
+    throw new Error("Unable to find a finalized block");
+  }
+
+  return finalizedBlock;
 }

--- a/packages/core/src/utils/finality.ts
+++ b/packages/core/src/utils/finality.ts
@@ -3,7 +3,7 @@ import type { Chain, LightBlock } from "@/internal/types.js";
 import { eth_getBlockByNumber } from "@/rpc/actions.js";
 import type { Rpc } from "@/rpc/index.js";
 
-export const DEFAULT_MAX_REORG_SECONDS = 60;
+export const DEFAULT_REORG_WINDOW = 180;
 
 export const isAsyncExecutionChain = (chainId: number) =>
   chainId === 143 || chainId === 10143;
@@ -11,9 +11,7 @@ export const isAsyncExecutionChain = (chainId: number) =>
 /**
  * Finds a block whose timestamp is outside the reorg window.
  * Block timestamps are monotonic, so a binary search avoids retaining or
- * fetching one block per second on fast chains. The returned block can be up
- * to 20% older than the target timestamp, which is safe and avoids extra RPC
- * requests when the block time estimate is slightly inaccurate.
+ * fetching one block per second on fast chains.
  */
 export async function getFinalizedBlock({
   chain,
@@ -26,23 +24,29 @@ export async function getFinalizedBlock({
   latestBlock: LightBlock;
   lowerBound?: LightBlock;
 }): Promise<LightBlock> {
-  const { maxReorgSeconds } = chain;
-  if (maxReorgSeconds === 0) return latestBlock;
+  const { reorgWindow } = chain;
+  if (reorgWindow === 0) return latestBlock;
 
-  const targetTimestamp = hexToNumber(latestBlock.timestamp) - maxReorgSeconds;
+  const targetTimestamp = hexToNumber(latestBlock.timestamp) - reorgWindow;
 
-  let low = lowerBound ? hexToNumber(lowerBound.number) : 0;
+  if (
+    lowerBound !== undefined &&
+    hexToNumber(lowerBound.timestamp) > targetTimestamp
+  ) {
+    return lowerBound;
+  }
+
+  let low = lowerBound ? hexToNumber(lowerBound.number) + 1 : 0;
   let high = hexToNumber(latestBlock.number);
-  let finalizedBlock: LightBlock | undefined;
+  let finalizedBlock = lowerBound;
 
   const blockTimeSeconds =
     chain.viemChain?.blockTime === undefined || chain.viemChain.blockTime <= 0
       ? 1
       : chain.viemChain.blockTime / 1_000;
-  const estimatedBlockCount = Math.ceil(maxReorgSeconds / blockTimeSeconds);
+  const estimatedBlockCount = Math.ceil(reorgWindow / blockTimeSeconds);
   const estimatedBlockNumber = high - estimatedBlockCount;
   let blockNumber = Math.max(low, Math.min(estimatedBlockNumber, high));
-  const timestampTolerance = maxReorgSeconds / 5;
 
   while (low <= high) {
     const block = await eth_getBlockByNumber(
@@ -53,11 +57,6 @@ export async function getFinalizedBlock({
 
     if (hexToNumber(block.timestamp) <= targetTimestamp) {
       finalizedBlock = block;
-
-      if (targetTimestamp - hexToNumber(block.timestamp) < timestampTolerance) {
-        return block;
-      }
-
       low = blockNumber + 1;
     } else {
       high = blockNumber - 1;
@@ -68,7 +67,9 @@ export async function getFinalizedBlock({
   }
 
   if (finalizedBlock === undefined) {
-    throw new Error("Unable to find a finalized block");
+    return eth_getBlockByNumber(rpc, ["0x0", false], {
+      retryNullBlockRequest: true,
+    });
   }
 
   return finalizedBlock;

--- a/simulation-test/src/rpc-sim.ts
+++ b/simulation-test/src/rpc-sim.ts
@@ -88,13 +88,23 @@ export const sim =
         const index = APP.indexingBuild.chains.findIndex(
           (_chain) => _chain.id === chain.id,
         );
-        const number = hexToNumber(
-          APP.indexingBuild.finalizedBlocks[index]!.number,
-        );
+        const finalizedBlock = APP.indexingBuild.finalizedBlocks[index]!;
+        const chainConfig = APP.indexingBuild.chains[index]!;
+        const targetTimestamp =
+          hexToNumber(finalizedBlock.timestamp) +
+          chainConfig.maxReorgSeconds;
+        let number = hexToNumber(finalizedBlock.number);
 
-        body.params[0] = toHex(
-          number + APP.indexingBuild.chains[index].finalityBlockCount,
-        );
+        while (true) {
+          const block = await _request({
+            method: "eth_getBlockByNumber",
+            params: [toHex(number + 1), false],
+          });
+          if (hexToNumber(block.timestamp) >= targetTimestamp) break;
+          number += 1;
+        }
+
+        body.params[0] = toHex(number);
       }
 
       // block tag validation

--- a/simulation-test/src/rpc-sim.ts
+++ b/simulation-test/src/rpc-sim.ts
@@ -91,8 +91,7 @@ export const sim =
         const finalizedBlock = APP.indexingBuild.finalizedBlocks[index]!;
         const chainConfig = APP.indexingBuild.chains[index]!;
         const targetTimestamp =
-          hexToNumber(finalizedBlock.timestamp) +
-          chainConfig.maxReorgSeconds;
+          hexToNumber(finalizedBlock.timestamp) + chainConfig.reorgWindow;
         let number = hexToNumber(finalizedBlock.number);
 
         while (true) {
@@ -100,8 +99,8 @@ export const sim =
             method: "eth_getBlockByNumber",
             params: [toHex(number + 1), false],
           });
-          if (hexToNumber(block.timestamp) >= targetTimestamp) break;
           number += 1;
+          if (hexToNumber(block.timestamp) >= targetTimestamp) break;
         }
 
         body.params[0] = toHex(number);


### PR DESCRIPTION
## Motivation

Ponder currently defines the recoverable reorg window as a chain-specific number of blocks. That assumption breaks down on fast chains: Robinhood Chain produces blocks roughly every 100 ms, so the 30-block fallback retains only about 3 seconds of rollback data. Adding more per-chain block counts would continue coupling reorg safety to incomplete and potentially stale block-time assumptions.

This PR defines the window in elapsed chain time instead. A duration has consistent semantics across chains and gives apps an explicit resource-versus-safety control.

## User-facing behavior

- Adds `reorgWindow` to each chain in `ponder.config.ts`. It is an integer number of seconds from `0` through `600` and defaults to `180`.

Closes #2359.