### PR TITLE
fix: clean up live query listeners

### DIFF
--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -194,7 +194,7 @@ export const client = ({
     );
     driver.instance.query(`LISTEN "${channel}"`);
 
-    driver.instance.onNotification((_, payload) => {
+    const unsubscribe = driver.instance.onNotification((_, payload) => {
       const tables = JSON.parse(payload!) as string[];
       tables.push("_ponder_checkpoint");
       let invalidQueryCount = 0;
@@ -232,6 +232,8 @@ export const client = ({
         });
       }
     });
+
+    globalThis.PONDER_COMMON.apiShutdown.add(unsubscribe);
   } else {
     (async () => {
       let client: pg.PoolClient | undefined;
@@ -246,6 +248,7 @@ export const client = ({
 
             if (hasRegisteredShutdown === false) {
               globalThis.PONDER_COMMON.apiShutdown.add(() => {
+                client?.removeAllListeners("notification");
                 client?.release();
                 client = undefined;
               });

--- a/packages/core/src/database/actions.test.ts
+++ b/packages/core/src/database/actions.test.ts
@@ -204,6 +204,7 @@ test("live query notify trigger batches large payloads", async () => {
 
   const channel = getLiveQueryChannelName("public");
   const notifications: string[] = [];
+  let unsubscribe: (() => void) | undefined;
   let resolve!: () => void;
   const done = new Promise<void>((_resolve) => {
     resolve = _resolve;
@@ -216,7 +217,7 @@ test("live query notify trigger batches large payloads", async () => {
 
   if (database.driver.dialect === "pglite") {
     await database.driver.instance.query(`LISTEN "${channel}"`);
-    database.driver.instance.onNotification((_, payload) =>
+    unsubscribe = database.driver.instance.onNotification((_, payload) =>
       onNotification(payload),
     );
   }
@@ -284,6 +285,7 @@ test("live query notify trigger batches large payloads", async () => {
     await done;
   } finally {
     if (database.driver.dialect === "pglite") {
+      unsubscribe?.();
       await database.driver.instance.query(`UNLISTEN "${channel}"`);
     } else if (client) {
       await client.query(`UNLISTEN "${channel}"`);


### PR DESCRIPTION
## Summary
- unsubscribe PGlite live-query notification handlers during API shutdown
- remove Postgres notification handlers before releasing the dedicated LISTEN client
- clean up the batching test's PGlite notification callback

Bun runs test files in one process, so leaked listeners from `client/index.test.ts` received synthetic table notifications from `database/actions.test.ts` and caused `perTableResolver.get(table)` to be undefined.