### PR TITLE
fix: handle singleton final batch in getIntervals()

### DIFF
--- a/.changeset/tidy-interval-batches.md
+++ b/.changeset/tidy-interval-batches.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed the error `TypeError: Cannot read properties of undefined (reading 'getSelectedFields')` that occurred during startup.

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -85,16 +85,7 @@ test("getIntervals() empty", async () => {
 });
 
 test("getIntervals() supports every batch remainder", async () => {
-  const { database, syncStore } = await setupDatabaseServices();
-
-  // Avoid retrying the malformed query so the test exposes the original error.
-  vi.spyOn(database.syncQB, "wrap").mockImplementation(
-    async (...args: any[]) => {
-      const query = typeof args[0] === "function" ? args[0] : args[1];
-      await query(database.syncQB);
-      return [];
-    },
-  );
+  const { syncStore } = await setupDatabaseServices();
 
   for (const queryCount of [1, 2, 199, 200, 201, 400, 401]) {
     const filters = Array.from({ length: queryCount }, (_, index) => ({

--- a/packages/core/src/sync-store/index.test.ts
+++ b/packages/core/src/sync-store/index.test.ts
@@ -84,6 +84,30 @@ test("getIntervals() empty", async () => {
   `);
 });
 
+test("getIntervals() supports every batch remainder", async () => {
+  const { database, syncStore } = await setupDatabaseServices();
+
+  // Avoid retrying the malformed query so the test exposes the original error.
+  vi.spyOn(database.syncQB, "wrap").mockImplementation(
+    async (...args: any[]) => {
+      const query = typeof args[0] === "function" ? args[0] : args[1];
+      await query(database.syncQB);
+      return [];
+    },
+  );
+
+  for (const queryCount of [1, 2, 199, 200, 201, 400, 401]) {
+    const filters = Array.from({ length: queryCount }, (_, index) => ({
+      ...EMPTY_BLOCK_FILTER,
+      sourceId: `test-${queryCount}-${index}`,
+    }));
+
+    const intervals = await syncStore.getIntervals({ filters });
+
+    expect(intervals).toHaveLength(queryCount);
+  }
+});
+
 test("getIntervals() returns intervals", async () => {
   const { syncStore } = await setupDatabaseServices();
 

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -351,11 +351,15 @@ export const createSyncStore = ({
         const batchSize = 200;
 
         for (let i = 0; i < queries.length; i += batchSize) {
+          const batch = queries.slice(i, i + batchSize);
           const _rows = await qb.wrap(
             { label: "select_intervals" },
-            () =>
+            () => {
+              if (batch.length === 1) return batch[0]!.execute();
+
               // @ts-expect-error
-              unionAll(...queries.slice(i, i + batchSize)),
+              return unionAll(...batch);
+            },
             context,
           );
 


### PR DESCRIPTION
Closes #2368

When `getIntervals()` generated a query count congruent to 1 modulo 200, the final batch contained a single query. Passing that singleton to Drizzle's `unionAll` failed.

This change executes singleton batches directly via `query.execute()`, while larger batches continue to use `unionAll()` to avoid the Drizzle maximum-call-stack issue.