### PR TITLE
fix(core): support large log indices

### DIFF
--- a/.changeset/tidy-cows-index.md
+++ b/.changeset/tidy-cows-index.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a crash caused by RPC logs with a `logIndex` larger than a Postgres integer.

--- a/packages/core/src/rpc/actions.test.ts
+++ b/packages/core/src/rpc/actions.test.ts
@@ -83,3 +83,22 @@ test("eth_getLogs skips empty address arrays", async () => {
   await expect(eth_getLogs(rpc, params)).resolves.toStrictEqual([]);
   expect(rpcRequest).not.toHaveBeenCalled();
 });
+
+test("eth_getLogs accepts log indices larger than a Postgres integer", async () => {
+  const log = createLog({ logIndex: "0xfffffffc" });
+  const rpc = {
+    request: vi.fn(async () => [log]),
+  } as unknown as Rpc;
+
+  await expect(eth_getLogs(rpc, [{}])).resolves.toStrictEqual([log]);
+});
+
+test("eth_getLogs rejects log indices larger than a safe integer", async () => {
+  const rpc = {
+    request: vi.fn(async () => [createLog({ logIndex: "0x20000000000000" })]),
+  } as unknown as Rpc;
+
+  await expect(eth_getLogs(rpc, [{}])).rejects.toThrow(
+    "'log.logIndex' (9007199254740992) is larger than the maximum allowed value (9007199254740991)",
+  );
+});

--- a/packages/core/src/rpc/actions.ts
+++ b/packages/core/src/rpc/actions.ts
@@ -1087,9 +1087,9 @@ export const standardizeLogs = (
       error.stack = undefined;
       throw error;
     }
-    if (hexToBigInt(log.logIndex) > BigInt(PG_INTEGER_MAX)) {
+    if (hexToBigInt(log.logIndex) > BigInt(Number.MAX_SAFE_INTEGER)) {
       const error = new RpcProviderError(
-        `Invalid RPC response: 'log.logIndex' (${hexToBigInt(log.logIndex)}) is larger than the maximum allowed value (${PG_INTEGER_MAX}).`,
+        `Invalid RPC response: 'log.logIndex' (${hexToBigInt(log.logIndex)}) is larger than the maximum allowed value (${Number.MAX_SAFE_INTEGER}).`,
       );
       error.meta = [
         "Please report this error to the RPC operator.",

--- a/packages/core/src/sync-store/migrations.ts
+++ b/packages/core/src/sync-store/migrations.ts
@@ -1798,4 +1798,12 @@ GROUP BY fragment_id, chain_id
       });
     },
   },
+  "2026_08_18_0_log_index_bigint": {
+    async up(db) {
+      await db.schema
+        .alterTable("logs")
+        .alterColumn("log_index", (col) => col.setDataType("bigint"))
+        .execute();
+    },
+  },
 };

--- a/packages/core/src/sync-store/schema.ts
+++ b/packages/core/src/sync-store/schema.ts
@@ -132,7 +132,7 @@ export const logs = PONDER_SYNC.table(
   (t) => ({
     chainId: t.bigint({ mode: "bigint" }).notNull(),
     blockNumber: t.bigint({ mode: "bigint" }).notNull(),
-    logIndex: t.integer().notNull(),
+    logIndex: t.bigint({ mode: "number" }).notNull(),
     transactionIndex: t.integer().notNull(),
     blockHash: t.varchar({ length: 66 }).notNull().$type<Hash>(),
     transactionHash: t.varchar({ length: 66 }).notNull().$type<Hash>(),


### PR DESCRIPTION
## Summary

- Store `ponder_sync.logs.log_index` as a Postgres `bigint`.
- Accept `logIndex` values through `Number.MAX_SAFE_INTEGER`.
- Keep the validation for values that JavaScript cannot represent safely.

## Why

Some RPC providers return synthetic logs with `logIndex` values near the unsigned 32-bit limit. Examples include `0xffffffe2` in #2103 and similar values in #2181.

The Ethereum execution API defines `logIndex` as a hex-encoded unsigned integer. It does not define a signed 32-bit limit. The current limit stops the backfill when these logs occur.

We also received `0xfffffffc` from a Gnosis RPC. This change preserves that log instead of dropping it or stopping the indexer.

## Migration

The sync migration changes the existing `logs.log_index` column from `integer` to `bigint`. Existing values do not change.

## Tests

- Added a regression test for `0xfffffffc`.
- Added a test for values above `Number.MAX_SAFE_INTEGER`.
- Ran the Ponder build successfully.
