### PR TITLE
feat: opt-in HyperSync fast path for historical sync

### DIFF
--- a/.changeset/hypersync-historical-source.md
+++ b/.changeset/hypersync-historical-source.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Added an opt-in HyperSync fast path for historical sync. With `PONDER_HYPERSYNC=true` and an API token in `ENVIO_API_TOKEN`, bounded-range `eth_getLogs` requests are served by a single HyperSync query whose join also returns the blocks and transactions those logs touch, and the per-eventful-block `eth_getBlockByNumber` requests are answered from that data. Requests near the chain tip, cache misses, and realtime sync use the RPC unchanged. The client library is an optional peer dependency, imported lazily — installs that never enable the path carry no native module, and if it is absent every request falls back to the RPC.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,10 +47,14 @@
   "peerDependencies": {
     "hono": ">=4.5",
     "typescript": ">=5.4.0",
-    "viem": ">=2.35"
+    "viem": ">=2.35",
+    "@envio-dev/hypersync-client": ">=0.6.5"
   },
   "peerDependenciesMeta": {
     "typescript": {
+      "optional": true
+    },
+    "@envio-dev/hypersync-client": {
       "optional": true
     }
   },
@@ -109,7 +113,8 @@
     "mitata": "^1.0.34",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.2",
-    "vitest": "1.6.1"
+    "vitest": "1.6.1",
+    "@envio-dev/hypersync-client": "^0.6.5"
   },
   "engines": {
     "node": ">=22"

--- a/packages/core/src/rpc/actions.ts
+++ b/packages/core/src/rpc/actions.ts
@@ -18,6 +18,11 @@ import type {
   SyncTransaction,
   SyncTransactionReceipt,
 } from "@/internal/types.js";
+import {
+  hypersyncEnabled,
+  hypersyncGetLogs,
+  takeHypersyncBlock,
+} from "@/rpc/hypersync.js";
 import type { RequestParameters, Rpc } from "@/rpc/index.js";
 import { zeroLogsBloom } from "@/sync-realtime/bloom.js";
 import { chunk } from "@/utils/chunk.js";
@@ -37,8 +42,19 @@ export const eth_getBlockByNumber = <
   rpc: Rpc,
   params: params,
   context?: Parameters<Rpc["request"]>[1],
-): Promise<params[1] extends true ? SyncBlock : LightBlock> =>
-  rpc
+): Promise<params[1] extends true ? SyncBlock : LightBlock> => {
+  if (hypersyncEnabled() && params[1] === true && isHex(params[0])) {
+    const cached = takeHypersyncBlock(hexToNumber(params[0]));
+    if (cached !== undefined) {
+      return Promise.resolve(
+        standardizeBlock(cached, {
+          method: "eth_getBlockByNumber",
+          params,
+        }) as params[1] extends true ? SyncBlock : LightBlock,
+      );
+    }
+  }
+  return rpc
     .request({ method: "eth_getBlockByNumber", params }, context)
     .then((_block) => {
       if (!_block) {
@@ -58,6 +74,7 @@ export const eth_getBlockByNumber = <
         params,
       });
     });
+};
 
 /**
  * Helper function for "eth_getBlockByHash" request.
@@ -95,6 +112,15 @@ export const eth_getLogs = async (
     method: "eth_getLogs",
     params,
   };
+
+  // One HyperSync query serves the whole request — address lists of any size,
+  // no chunking — and fills the block cache consumed by eth_getBlockByNumber.
+  if (hypersyncEnabled()) {
+    const logs = await hypersyncGetLogs(
+      params as Parameters<typeof hypersyncGetLogs>[0],
+    );
+    if (logs !== null) return standardizeLogs(logs, request);
+  }
 
   const requests: Extract<RequestParameters, { method: "eth_getLogs" }>[] =
     Array.isArray(params[0].address)

--- a/packages/core/src/rpc/hypersync.ts
+++ b/packages/core/src/rpc/hypersync.ts
@@ -1,0 +1,343 @@
+// HyperSync-backed fast path for the two hot historical-sync requests.
+//
+// Enabled with PONDER_HYPERSYNC=true and an API token in ENVIO_API_TOKEN or
+// HYPERSYNC_API_TOKEN (https://envio.dev/app/api-tokens). When enabled,
+// bounded-range eth_getLogs requests are served by a HyperSync query whose
+// join also returns the blocks and transactions those logs touch; the blocks
+// (with their matched transactions) are cached, and the per-eventful-block
+// eth_getBlockByNumber requests that follow are served from that cache. Every
+// other request — near-tip ranges, cache misses, realtime — falls through to
+// the RPC unchanged.
+import type {
+  Block as HsBlock,
+  Log as HsLog,
+  Transaction as HsTransaction,
+  HypersyncClient,
+  Query,
+} from "@envio-dev/hypersync-client";
+import { type Hex, hexToNumber, isHex, numberToHex } from "viem";
+import type { SyncBlock, SyncLog, SyncTransaction } from "@/internal/types.js";
+
+const resolveToken = (): string | undefined => {
+  const token = process.env.ENVIO_API_TOKEN ?? process.env.HYPERSYNC_API_TOKEN;
+  return token === undefined || token.trim() === "" ? undefined : token;
+};
+
+export const hypersyncEnabled = (): boolean =>
+  process.env.PONDER_HYPERSYNC === "true" && resolveToken() !== undefined;
+
+// The client is an optional peer dependency, imported lazily so a Ponder
+// install that never enables this path carries no native module. An absent or
+// failing import permanently resolves to null and every request falls back to
+// the RPC.
+type HypersyncModule = typeof import("@envio-dev/hypersync-client");
+let modulePromise: Promise<HypersyncModule | null> | undefined;
+const getModule = (): Promise<HypersyncModule | null> => {
+  modulePromise ??= import("@envio-dev/hypersync-client").then(
+    (mod) => mod,
+    () => null,
+  );
+  return modulePromise;
+};
+
+let client: HypersyncClient | undefined;
+const getClient = async (): Promise<HypersyncClient | null> => {
+  if (client === undefined) {
+    const mod = await getModule();
+    if (mod === null) return null;
+    client = mod.HypersyncClient.new({
+      url: process.env.PONDER_HYPERSYNC_URL ?? "https://1.hypersync.xyz",
+      bearerToken: resolveToken(),
+    });
+  }
+  return client;
+};
+
+// Archive height, cached like a monotonic clock: a height at or past the
+// requested block is always trusted, otherwise it is refreshed at most every
+// two seconds. Requests past the archive fall back to the RPC, which is
+// authoritative for the head.
+let heightCache: { fetchedAt: number; height: number } | undefined;
+const coversBlock = async (toBlock: number): Promise<boolean> => {
+  if (heightCache !== undefined) {
+    if (heightCache.height >= toBlock) return true;
+    if (Date.now() - heightCache.fetchedAt < 2_000) return false;
+  }
+  try {
+    const hypersync = await getClient();
+    if (hypersync === null) return false;
+    const height = await hypersync.getHeight();
+    heightCache = { fetchedAt: Date.now(), height };
+    return height >= toBlock;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Blocks touched by recent log queries, keyed by number and consumed
+ * (deleted) on read. Transactions are kept as a map by index and merged
+ * across queries: with several log filters over one range, each filter's
+ * query joins only its own logs' transactions, and the block must end up
+ * holding the union before its one reader validates every matched log
+ * against it. The cap only guards against a consumer that never comes.
+ */
+type CacheEntry = {
+  block: HsBlock;
+  transactions: Map<number, SyncTransaction>;
+};
+const blockCache = new Map<number, CacheEntry>();
+const BLOCK_CACHE_CAP = 50_000;
+
+const hex = (value: string): Hex => value.toLowerCase() as Hex;
+const quantity = (value: number | bigint): Hex => numberToHex(value);
+
+const toSyncLog = (log: HsLog): SyncLog => ({
+  address: hex(log.address!),
+  blockHash: hex(log.blockHash!),
+  blockNumber: quantity(log.blockNumber!),
+  data: hex(log.data ?? "0x"),
+  logIndex: quantity(log.logIndex!),
+  removed: log.removed ?? false,
+  topics: log.topics.filter(
+    (topic): topic is string => topic !== undefined && topic !== null,
+  ) as SyncLog["topics"],
+  transactionHash: hex(log.transactionHash!),
+  transactionIndex: quantity(log.transactionIndex!),
+});
+
+const toSyncTransaction = (tx: HsTransaction): SyncTransaction =>
+  ({
+    blockHash: hex(tx.blockHash!),
+    blockNumber: quantity(tx.blockNumber!),
+    from: hex(tx.from!),
+    gas: quantity(tx.gas ?? 0n),
+    gasPrice: tx.gasPrice !== undefined ? quantity(tx.gasPrice) : undefined,
+    maxFeePerGas:
+      tx.maxFeePerGas !== undefined ? quantity(tx.maxFeePerGas) : undefined,
+    maxPriorityFeePerGas:
+      tx.maxPriorityFeePerGas !== undefined
+        ? quantity(tx.maxPriorityFeePerGas)
+        : undefined,
+    hash: hex(tx.hash!),
+    input: hex(tx.input ?? "0x"),
+    nonce: quantity(tx.nonce ?? 0n),
+    to: tx.to === undefined || tx.to === null ? null : hex(tx.to),
+    transactionIndex: quantity(tx.transactionIndex!),
+    value: quantity(tx.value ?? 0n),
+    type: tx.kind !== undefined ? numberToHex(tx.kind) : "0x0",
+    v: tx.v !== undefined ? tx.v : (tx.yParity ?? "0x0"),
+    r: tx.r ?? "0x0",
+    s: tx.s ?? "0x0",
+    accessList: tx.accessList as SyncTransaction["accessList"],
+    chainId: tx.chainId !== undefined ? numberToHex(tx.chainId) : undefined,
+  }) as unknown as SyncTransaction;
+
+const toSyncBlock = (
+  block: HsBlock,
+  transactions: SyncTransaction[],
+): SyncBlock =>
+  ({
+    baseFeePerGas:
+      block.baseFeePerGas !== undefined ? quantity(block.baseFeePerGas) : null,
+    difficulty: quantity(block.difficulty ?? 0n),
+    extraData: hex(block.extraData ?? "0x"),
+    gasLimit: quantity(block.gasLimit ?? 0n),
+    gasUsed: quantity(block.gasUsed ?? 0n),
+    hash: hex(block.hash!),
+    logsBloom: hex(block.logsBloom!),
+    miner: hex(block.miner!),
+    mixHash: block.mixHash !== undefined ? hex(block.mixHash) : null,
+    nonce:
+      block.nonce !== undefined ? numberToHex(block.nonce, { size: 8 }) : null,
+    number: quantity(block.number!),
+    parentHash: hex(block.parentHash!),
+    receiptsRoot: hex(block.receiptsRoot!),
+    sha3Uncles: block.sha3Uncles !== undefined ? hex(block.sha3Uncles) : null,
+    size: quantity(block.size ?? 0n),
+    stateRoot: hex(block.stateRoot!),
+    timestamp: quantity(block.timestamp!),
+    totalDifficulty:
+      block.totalDifficulty !== undefined
+        ? quantity(block.totalDifficulty)
+        : null,
+    transactionsRoot: hex(block.transactionsRoot!),
+    transactions,
+    uncles: (block.uncles ?? []) as Hex[],
+  }) as unknown as SyncBlock;
+
+type GetLogsParams = [
+  {
+    address?: Hex | Hex[];
+    topics?: (Hex | Hex[] | null)[];
+    fromBlock?: Hex | string;
+    toBlock?: Hex | string;
+    blockHash?: Hex;
+  },
+];
+
+/**
+ * Serve a bounded-range eth_getLogs from HyperSync, filling the block cache
+ * with the blocks (and their matched transactions) as a side effect. Returns
+ * null when the request is not one this path serves — the caller then uses
+ * the RPC exactly as before.
+ */
+export const hypersyncGetLogs = async (
+  params: GetLogsParams,
+): Promise<SyncLog[] | null> => {
+  const filter = params[0];
+  if (
+    filter === undefined ||
+    filter.blockHash !== undefined ||
+    !isHex(filter.fromBlock) ||
+    !isHex(filter.toBlock)
+  ) {
+    return null;
+  }
+
+  const fromBlock = hexToNumber(filter.fromBlock as Hex);
+  const toBlock = hexToNumber(filter.toBlock as Hex);
+  if (toBlock < fromBlock) return [];
+  const mod = await getModule();
+  const hypersync = await getClient();
+  if (mod === null || hypersync === null) return null;
+  if ((await coversBlock(toBlock)) === false) return null;
+  const { BlockField, JoinMode, LogField, TransactionField } = mod;
+
+  const address =
+    filter.address === undefined
+      ? undefined
+      : (Array.isArray(filter.address) ? filter.address : [filter.address]).map(
+          (a) => a.toLowerCase(),
+        );
+  const topics = (filter.topics ?? []).map((topic) =>
+    topic === null || topic === undefined
+      ? []
+      : Array.isArray(topic)
+        ? topic
+        : [topic],
+  );
+
+  const query: Query = {
+    fromBlock,
+    toBlock: toBlock + 1, // hypersync's toBlock is exclusive
+    logs: [{ address, topics }],
+    fieldSelection: {
+      log: [
+        LogField.Removed,
+        LogField.LogIndex,
+        LogField.TransactionIndex,
+        LogField.TransactionHash,
+        LogField.BlockHash,
+        LogField.BlockNumber,
+        LogField.Address,
+        LogField.Data,
+        LogField.Topic0,
+        LogField.Topic1,
+        LogField.Topic2,
+        LogField.Topic3,
+      ],
+      block: [
+        BlockField.Number,
+        BlockField.Hash,
+        BlockField.ParentHash,
+        BlockField.Nonce,
+        BlockField.Sha3Uncles,
+        BlockField.LogsBloom,
+        BlockField.TransactionsRoot,
+        BlockField.StateRoot,
+        BlockField.ReceiptsRoot,
+        BlockField.Miner,
+        BlockField.Difficulty,
+        BlockField.TotalDifficulty,
+        BlockField.ExtraData,
+        BlockField.Size,
+        BlockField.GasLimit,
+        BlockField.GasUsed,
+        BlockField.Timestamp,
+        BlockField.MixHash,
+        BlockField.BaseFeePerGas,
+      ],
+      transaction: [
+        TransactionField.BlockHash,
+        TransactionField.BlockNumber,
+        TransactionField.From,
+        TransactionField.Gas,
+        TransactionField.GasPrice,
+        TransactionField.Hash,
+        TransactionField.Input,
+        TransactionField.Nonce,
+        TransactionField.To,
+        TransactionField.TransactionIndex,
+        TransactionField.Value,
+        TransactionField.V,
+        TransactionField.R,
+        TransactionField.S,
+        TransactionField.YParity,
+        TransactionField.MaxPriorityFeePerGas,
+        TransactionField.MaxFeePerGas,
+        TransactionField.ChainId,
+        TransactionField.Kind,
+      ],
+    },
+    joinMode: JoinMode.Default,
+  };
+
+  const logs: SyncLog[] = [];
+  const blocks = new Map<number, HsBlock>();
+  const transactionsByBlock = new Map<number, SyncTransaction[]>();
+
+  let next = fromBlock;
+  while (next <= toBlock) {
+    const response = await hypersync.get({ ...query, fromBlock: next });
+    for (const log of response.data.logs) logs.push(toSyncLog(log));
+    for (const block of response.data.blocks) blocks.set(block.number!, block);
+    for (const tx of response.data.transactions) {
+      const list = transactionsByBlock.get(tx.blockNumber!) ?? [];
+      list.push(toSyncTransaction(tx));
+      transactionsByBlock.set(tx.blockNumber!, list);
+    }
+    if (response.nextBlock <= next) {
+      // No forward progress would loop forever; let the RPC handle it.
+      return null;
+    }
+    next = response.nextBlock;
+  }
+
+  for (const [number, block] of blocks) {
+    const entry = blockCache.get(number) ?? {
+      block,
+      transactions: new Map<number, SyncTransaction>(),
+    };
+    for (const transaction of transactionsByBlock.get(number) ?? []) {
+      entry.transactions.set(
+        hexToNumber(transaction.transactionIndex),
+        transaction,
+      );
+    }
+    if (blockCache.has(number) || blockCache.size < BLOCK_CACHE_CAP) {
+      blockCache.set(number, entry);
+    }
+  }
+
+  logs.sort((a, b) =>
+    a.blockNumber === b.blockNumber
+      ? hexToNumber(a.logIndex) - hexToNumber(b.logIndex)
+      : hexToNumber(a.blockNumber) - hexToNumber(b.blockNumber),
+  );
+
+  return logs;
+};
+
+/** A cached block is consumed by its one expected reader. */
+export const takeHypersyncBlock = (
+  blockNumber: number,
+): SyncBlock | undefined => {
+  const entry = blockCache.get(blockNumber);
+  if (entry === undefined) return undefined;
+  blockCache.delete(blockNumber);
+  const transactions = [...entry.transactions.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, transaction]) => transaction);
+  return toSyncBlock(entry.block, transactions);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 4.1.6
       vocs:
         specifier: ^1.0.11
-        version: 1.0.11(@types/node@22.20.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(acorn@8.14.1)(jiti@2.4.2)(lightningcss@1.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(tsx@4.19.2)(typescript@5.9.3)
+        version: 1.0.11(@types/node@22.20.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(acorn@8.14.1)(jiti@2.4.2)(lightningcss@1.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(tsx@4.19.2)(typescript@5.4.5)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -519,7 +519,7 @@ importers:
     devDependencies:
       '@wagmi/cli':
         specifier: ^1.5.2
-        version: 1.5.2(typescript@5.9.3)
+        version: 1.5.2(typescript@5.4.5)
 
   examples/with-foundry/foundry:
     dependencies:
@@ -769,13 +769,13 @@ importers:
         version: 2.4.0
       '@hono/node-server':
         specifier: 1.19.5
-        version: 1.19.5(hono@4.7.9)
+        version: 1.19.5(hono@4.5.0)
       '@ponder/utils':
         specifier: workspace:*
         version: link:../utils
       abitype:
         specifier: ^0.10.2
-        version: 0.10.3(typescript@5.9.3)(zod@3.23.8)
+        version: 0.10.3(typescript@5.4.5)(zod@3.23.8)
       ansi-escapes:
         specifier: ^7.0.0
         version: 7.0.0
@@ -853,11 +853,14 @@ importers:
         version: 1.0.2(@types/node@22.20.1)(lightningcss@1.30.0)
       vite-tsconfig-paths:
         specifier: 4.3.1
-        version: 4.3.1(typescript@5.9.3)(vite@5.4.21(@types/node@22.20.1)(lightningcss@1.30.0))
+        version: 4.3.1(typescript@5.4.5)(vite@5.4.21(@types/node@22.20.1)(lightningcss@1.30.0))
       ws:
         specifier: ^8.18.3
         version: 8.18.3
     devDependencies:
+      '@envio-dev/hypersync-client':
+        specifier: ^0.6.5
+        version: 0.6.7
       '@pgsql/types':
         specifier: 16.0.0
         version: 16.0.0
@@ -890,7 +893,7 @@ importers:
         version: 0.0.6
       '@wagmi/cli':
         specifier: ^1.5.2
-        version: 1.5.2(typescript@5.9.3)
+        version: 1.5.2(typescript@5.4.5)
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1386,6 +1389,49 @@ packages:
   '@envelop/types@5.2.1':
     resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
     engines: {node: '>=18.0.0'}
+
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.7':
+    resolution: {integrity: sha512-cEMcdzorkuYn/c+bopKAdnrxAcRAwSYwkLfYg+V9/vEyNvMR86vCMnV5D2zxpMg/Urv9z80V/Pfg6buT/iPDkA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@envio-dev/hypersync-client-darwin-x64@0.6.7':
+    resolution: {integrity: sha512-aw0gpWIMGgSTWorPnt9Jk4S24h1mH0srSIGlMphs70It1raiSE9aFowLFxNXDR/mepfnzQrZMccnEGlLpgTC7g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.7':
+    resolution: {integrity: sha512-Kt2r9qrlab9JEK44GR70VaLOTLVojGY7wt7DdnzvgniYt+nrS42bmgq3GDhas/Sn/mM3Tl7T6AcpFLzdZxrAXQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.7':
+    resolution: {integrity: sha512-TDfJZq3Aag+c4xROZOwNvPNKZdbaFq52yQhAj6ZvG13bMQzEM9Lj1UAiNcDRxCDqSDMANhKFWTlFd0JW7jG3hA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.7':
+    resolution: {integrity: sha512-OX3+OGSwWzjHwSnt/M31CdJXNjAAH5IthyffvtDnsKUGbg4y2FGdR1sVJir2L3CD1Kyv/VJmpZFygBDmQW1EZg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.7':
+    resolution: {integrity: sha512-3eTaz/yEOx5h8oBFgp4fVNyb/ptaH4Iav7chhsYRBmrlx8BwoI669Xd5u+Qw5O/mr3jCDMKPiIG4cGH9MJsRNw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@envio-dev/hypersync-client@0.6.7':
+    resolution: {integrity: sha512-KONNp/inLNWC80hw4FZckkXI7pigxnugxnfNBWOjAF0DZJDpFn4wgdGRlSb/dtsUc5Gk8JCI5oXWGSXmSOqW/A==}
+    engines: {node: '>= 10'}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -8296,6 +8342,33 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.7':
+    optional: true
+
+  '@envio-dev/hypersync-client-darwin-x64@0.6.7':
+    optional: true
+
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.7':
+    optional: true
+
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.7':
+    optional: true
+
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.7':
+    optional: true
+
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.7':
+    optional: true
+
+  '@envio-dev/hypersync-client@0.6.7':
+    optionalDependencies:
+      '@envio-dev/hypersync-client-darwin-arm64': 0.6.7
+      '@envio-dev/hypersync-client-darwin-x64': 0.6.7
+      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.7
+      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.7
+      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.7
+      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.7
+
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
       esbuild: 0.18.20
@@ -8856,9 +8929,9 @@ snapshots:
     dependencies:
       hono: 4.7.9
 
-  '@hono/node-server@1.19.5(hono@4.7.9)':
+  '@hono/node-server@1.19.5(hono@4.5.0)':
     dependencies:
-      hono: 4.7.9
+      hono: 4.5.0
 
   '@hono/trpc-server@0.3.2(@trpc/server@10.45.2)(hono@4.5.0)':
     dependencies:
@@ -9977,11 +10050,11 @@ snapshots:
       '@shikijs/core': 1.29.2
       '@shikijs/types': 1.29.2
 
-  '@shikijs/twoslash@1.29.2(typescript@5.9.3)':
+  '@shikijs/twoslash@1.29.2(typescript@5.4.5)':
     dependencies:
       '@shikijs/core': 1.29.2
       '@shikijs/types': 1.29.2
-      twoslash: 0.2.12(typescript@5.9.3)
+      twoslash: 0.2.12(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10363,10 +10436,10 @@ snapshots:
     dependencies:
       '@types/node': 22.20.1
 
-  '@typescript/vfs@1.6.1(typescript@5.9.3)':
+  '@typescript/vfs@1.6.1(typescript@5.4.5)':
     dependencies:
       debug: 4.4.0
-      typescript: 5.9.3
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -10568,9 +10641,9 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@wagmi/cli@1.5.2(typescript@5.9.3)':
+  '@wagmi/cli@1.5.2(typescript@5.4.5)':
     dependencies:
-      abitype: 0.8.7(typescript@5.9.3)(zod@3.23.8)
+      abitype: 0.8.7(typescript@5.4.5)(zod@3.23.8)
       abort-controller: 3.0.0
       bundle-require: 3.1.2(esbuild@0.16.17)
       cac: 6.7.14
@@ -10590,10 +10663,10 @@ snapshots:
       pathe: 1.1.1
       picocolors: 1.1.1
       prettier: 2.8.8
-      viem: 1.21.4(typescript@5.9.3)(zod@3.23.8)
+      viem: 1.21.4(typescript@5.4.5)(zod@3.23.8)
       zod: 3.23.8
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.4.5
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10631,20 +10704,25 @@ snapshots:
 
   abbrev@3.0.1: {}
 
+  abitype@0.10.3(typescript@5.4.5)(zod@3.23.8):
+    optionalDependencies:
+      typescript: 5.4.5
+      zod: 3.23.8
+
   abitype@0.10.3(typescript@5.9.3)(zod@3.23.8):
     optionalDependencies:
       typescript: 5.9.3
       zod: 3.23.8
 
-  abitype@0.8.7(typescript@5.9.3)(zod@3.23.8):
+  abitype@0.8.7(typescript@5.4.5)(zod@3.23.8):
     dependencies:
-      typescript: 5.9.3
+      typescript: 5.4.5
     optionalDependencies:
       zod: 3.23.8
 
-  abitype@0.9.8(typescript@5.9.3)(zod@3.23.8):
+  abitype@0.9.8(typescript@5.4.5)(zod@3.23.8):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.4.5
       zod: 3.23.8
 
   abitype@1.0.5(typescript@5.9.3)(zod@3.23.8):
@@ -14594,9 +14672,9 @@ snapshots:
 
   ts-toolbelt@6.15.5: {}
 
-  tsconfck@3.0.1(typescript@5.9.3):
+  tsconfck@3.0.1(typescript@5.4.5):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.4.5
 
   tslib@2.6.2: {}
 
@@ -14634,11 +14712,11 @@ snapshots:
 
   twoslash-protocol@0.2.12: {}
 
-  twoslash@0.2.12(typescript@5.9.3):
+  twoslash@0.2.12(typescript@5.4.5):
     dependencies:
-      '@typescript/vfs': 1.6.1(typescript@5.9.3)
+      '@typescript/vfs': 1.6.1(typescript@5.4.5)
       twoslash-protocol: 0.2.12
-      typescript: 5.9.3
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14798,18 +14876,18 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  viem@1.21.4(typescript@5.9.3)(zod@3.23.8):
+  viem@1.21.4(typescript@5.4.5)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
       '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.2
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
-      abitype: 0.9.8(typescript@5.9.3)(zod@3.23.8)
+      abitype: 0.9.8(typescript@5.4.5)(zod@3.23.8)
       isows: 1.0.3(ws@8.13.0)
       ws: 8.13.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.4.5
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -14903,11 +14981,11 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.1(typescript@5.9.3)(vite@5.4.21(@types/node@22.20.1)(lightningcss@1.30.0)):
+  vite-tsconfig-paths@4.3.1(typescript@5.4.5)(vite@5.4.21(@types/node@22.20.1)(lightningcss@1.30.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.0.1(typescript@5.9.3)
+      tsconfck: 3.0.1(typescript@5.4.5)
     optionalDependencies:
       vite: 5.4.21(@types/node@22.20.1)(lightningcss@1.30.0)
     transitivePeerDependencies:
@@ -14974,7 +15052,7 @@ snapshots:
       - supports-color
       - terser
 
-  vocs@1.0.11(@types/node@22.20.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(acorn@8.14.1)(jiti@2.4.2)(lightningcss@1.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(tsx@4.19.2)(typescript@5.9.3):
+  vocs@1.0.11(@types/node@22.20.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(acorn@8.14.1)(jiti@2.4.2)(lightningcss@1.30.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(tsx@4.19.2)(typescript@5.4.5):
     dependencies:
       '@floating-ui/react': 0.27.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@hono/node-server': 1.14.1(hono@4.7.9)
@@ -14991,7 +15069,7 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@shikijs/rehype': 1.29.2
       '@shikijs/transformers': 1.29.2
-      '@shikijs/twoslash': 1.29.2(typescript@5.9.3)
+      '@shikijs/twoslash': 1.29.2(typescript@5.4.5)
       '@tailwindcss/vite': 4.0.7(vite@6.3.5(@types/node@22.20.1)(jiti@2.4.2)(lightningcss@1.30.0)(tsx@4.19.2))
       '@vanilla-extract/css': 1.17.1
       '@vanilla-extract/dynamic': 2.1.2
@@ -15039,7 +15117,7 @@ snapshots:
       serve-static: 1.16.2
       shiki: 1.29.2
       toml: 3.0.0
-      twoslash: 0.2.12(typescript@5.9.3)
+      twoslash: 0.2.12(typescript@5.4.5)
       ua-parser-js: 1.0.40
       unified: 11.0.5
       unist-util-visit: 5.0.0


### PR DESCRIPTION
## What

An opt-in fast path for historical sync backed by [Envio HyperSync](https://docs.envio.dev/docs/HyperSync/overview). With `PONDER_HYPERSYNC=true` and an API token in `ENVIO_API_TOKEN`, bounded-range `eth_getLogs` requests are served by a single HyperSync query whose join also returns the blocks and transactions the matched logs touch. The reconstructed blocks are cached, and the per-eventful-block `eth_getBlockByNumber` requests that follow — the dominant cost of a Ponder backfill — are answered from memory instead of the network. Requests near the chain tip, cache misses, and all of realtime sync use the RPC exactly as before.

Deliberately small and inert by default:

- **One new file** (`rpc/hypersync.ts`, ~340 lines) plus two short guards in `rpc/actions.ts`. No changes to the sync engine, sync-store, config schema, or types.
- **The client is an optional peer dependency, imported lazily.** A Ponder install that never enables the path carries no native module; if the module is absent, every request permanently falls back to the RPC.
- **Reconstruction is held to Ponder's own bar**: the blocks pass `validateLogsAndBlock` (faithful `logsBloom`, log↔block hash and number equality, transaction-index lookups), and results flow through `standardizeLogs`/`standardizeBlock` like any RPC response.

## Motivation — benchmarks

Measured with the [open-indexer-benchmark](https://github.com/enviodev/open-indexer-benchmark) harness (its methodology: a verified range checked row-by-row against ground truth, then best-of-two timed throughput windows). Same machine, same harness, same Ponder build — only the env var differs. Baseline runs reproduced the benchmark's published Ponder numbers within ±25% on all four cases.

| case | Ponder (RPC) | Ponder + HyperSync | data verification |
| --- | --- | --- | --- |
| Decoded Event Stream (dense USDC transfers) | 182 events/s | **4,399 events/s (24×)** | ✅ both |
| State Aggregation (rETH balances) | 66 events/s | **1,008 events/s (15×)** | ✅ both |
| External Contract Calls | DNF at 300s (57–61% missing) | **completes, verified** | ❓ → ✅ |
| Factory Registration (82k Safe proxies) | 309 events/s | **2,234 events/s (7×)** | ✅ both |

The mechanism behind the numbers: a backfill's cost is dominated by one full-transaction block fetch per eventful block. On the dense case that's ~1,000 block requests per 1,000 blocks; through this path the same range produced **zero `eth_getLogs` and five `eth_getBlockByNumber`** over RPC (measured through a counting proxy), with everything else served by the joined HyperSync responses. Factory child discovery goes through the same `eth_getLogs` seam, so it accelerates too — with no address-list chunking, since HyperSync takes arbitrary address sets.

## Scope notes / open questions

- Env-var activation keeps the change minimal for discussion. If there's appetite, the natural evolution is a per-chain config field alongside `rpc` — happy to rework in that direction.
- The fast path only ever *adds* a source for data Ponder already fetches; correctness relies on Ponder's existing validation plus the benchmark's row-level ground-truth checks above. Pointers to any additional invariants you'd want covered by tests are welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)