### PR TITLE
docs: redirect /docs/ to /docs/get-started

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    {
+      "source": "/docs/",
+      "destination": "/docs/get-started",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     {
       "source": "/0_6/docs/utilities/types",


### PR DESCRIPTION
Redirects `/docs/` to `/docs/get-started`, the same page linked by the Docs header item.