### PR TITLE
Fix live query quota accounting

### DIFF
--- a/.changeset/tame-live-query-quota.md
+++ b/.changeset/tame-live-query-quota.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug that caused failed `/sql/live` requests to exhaust the live query limit.

--- a/packages/core/src/client/index.test.ts
+++ b/packages/core/src/client/index.test.ts
@@ -332,3 +332,42 @@ test("client.db cache", async () => {
 
   expect(transactionSpy).toHaveBeenCalledTimes(1);
 });
+
+test("client.live releases quota when request fails before streaming", async () => {
+  globalThis.PONDER_COMMON = context.common;
+  globalThis.PONDER_PRE_BUILD = {
+    ordering: "multichain",
+    databaseConfig: context.databaseConfig,
+  };
+  globalThis.PONDER_NAMESPACE_BUILD = {
+    schema: "public",
+    viewsSchema: undefined,
+  };
+
+  const { database } = await setupDatabaseServices();
+  globalThis.PONDER_DATABASE = database;
+
+  const PONDER_META = getPonderMetaTable();
+  await database.adminQB.wrap({ label: "update_ready" }, (db) =>
+    db
+      .update(PONDER_META)
+      .set({ value: sql`jsonb_set(value, '{is_ready}', to_jsonb(1))` }),
+  );
+
+  const app = new Hono().use(
+    client({
+      db: database.readonlyQB.raw,
+      schema: {},
+    }),
+  );
+
+  await vi.waitFor(async () => {
+    const response = await app.request("/sql/live");
+    expect(response.status).toBe(400);
+  });
+
+  for (let i = 0; i < 1000; i++) {
+    const response = await app.request("/sql/live");
+    expect(response.status).toBe(400);
+  }
+});

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -439,116 +439,127 @@ export const client = ({
       }
 
       liveQueryCount++;
-
-      c.header("Content-Type", "text/event-stream");
-      c.header("Cache-Control", "no-cache");
-      c.header("Connection", "keep-alive");
-
-      const queryString = c.req.query("sql");
-      if (queryString === undefined) {
-        return c.text('Missing "sql" query parameter', 400);
-      }
-      const query = superjson.parse(queryString) as QueryWithTypings;
+      let hasLiveQuerySlot = true;
+      let isStreaming = false;
+      const releaseLiveQuerySlot = () => {
+        if (hasLiveQuerySlot === false) return;
+        hasLiveQuerySlot = false;
+        liveQueryCount--;
+      };
 
       try {
-        await validateAllowableSQLQuery(query.sql);
-      } catch (error) {
-        (error as Error).stack = undefined;
-        return c.text((error as Error).message, 500);
-      }
+        c.header("Content-Type", "text/event-stream");
+        c.header("Cache-Control", "no-cache");
+        c.header("Connection", "keep-alive");
 
-      const relations = await getSQLQueryRelations(query.sql);
-      const referencedTables = new Set<string>();
-      for (const relation of relations) {
-        if (tableNames.has(relation)) {
-          referencedTables.add(relation);
-        } else if (viewNames.has(relation)) {
-          for (const tableName of perViewTables.get(relation)!) {
-            referencedTables.add(tableName);
+        const queryString = c.req.query("sql");
+        if (queryString === undefined) {
+          return c.text('Missing "sql" query parameter', 400);
+        }
+        const query = superjson.parse(queryString) as QueryWithTypings;
+
+        try {
+          await validateAllowableSQLQuery(query.sql);
+        } catch (error) {
+          (error as Error).stack = undefined;
+          return c.text((error as Error).message, 500);
+        }
+
+        const relations = await getSQLQueryRelations(query.sql);
+        const referencedTables = new Set<string>();
+        for (const relation of relations) {
+          if (tableNames.has(relation)) {
+            referencedTables.add(relation);
+          } else if (viewNames.has(relation)) {
+            for (const tableName of perViewTables.get(relation)!) {
+              referencedTables.add(tableName);
+            }
           }
         }
-      }
 
-      let result: QueryResult;
-      if (cache.has(queryString)) {
-        const resultRef = cache.get(queryString)!.deref();
+        let result: QueryResult;
+        if (cache.has(queryString)) {
+          const resultRef = cache.get(queryString)!.deref();
 
-        if (resultRef === undefined) {
-          cache.delete(queryString);
+          if (resultRef === undefined) {
+            cache.delete(queryString);
+            const resultPromise = getQueryResult(query);
+            cache.set(queryString, new WeakRef(resultPromise));
+            perQueryReferences.set(queryString, referencedTables);
+            registry.register(resultPromise, queryString);
+            result = await resultPromise;
+          } else {
+            result = await resultRef;
+          }
+        } else {
           const resultPromise = getQueryResult(query);
           cache.set(queryString, new WeakRef(resultPromise));
           perQueryReferences.set(queryString, referencedTables);
           registry.register(resultPromise, queryString);
           result = await resultPromise;
-        } else {
-          result = await resultRef;
         }
-      } else {
-        const resultPromise = getQueryResult(query);
-        cache.set(queryString, new WeakRef(resultPromise));
-        perQueryReferences.set(queryString, referencedTables);
-        registry.register(resultPromise, queryString);
-        result = await resultPromise;
-      }
 
-      let resultHash = crypto
-        .createHash("MD5")
-        // @ts-expect-error
-        .update(JSON.stringify(result.rows))
-        .digest("hex")
-        .slice(0, 10);
+        let resultHash = crypto
+          .createHash("MD5")
+          // @ts-expect-error
+          .update(JSON.stringify(result.rows))
+          .digest("hex")
+          .slice(0, 10);
 
-      return streamSSE(c, async (stream) => {
-        stream.onAbort(() => {
-          liveQueryCount--;
-        });
+        const response = streamSSE(c, async (stream) => {
+          stream.onAbort(releaseLiveQuerySlot);
 
-        while (stream.closed === false && stream.aborted === false) {
-          await Promise.race(
-            Array.from(referencedTables).map(
-              (relation) => perTableResolver.get(relation)!.promise,
-            ),
-          );
+          while (stream.closed === false && stream.aborted === false) {
+            await Promise.race(
+              Array.from(referencedTables).map(
+                (relation) => perTableResolver.get(relation)!.promise,
+              ),
+            );
 
-          try {
-            let resultPromise: Promise<unknown>;
-            if (cache.has(queryString)) {
-              const resultRef = cache.get(queryString)!.deref();
+            try {
+              let resultPromise: Promise<unknown>;
+              if (cache.has(queryString)) {
+                const resultRef = cache.get(queryString)!.deref();
 
-              if (resultRef === undefined) {
-                cache.delete(queryString);
+                if (resultRef === undefined) {
+                  cache.delete(queryString);
+                  resultPromise = getQueryResult(query);
+                  cache.set(queryString, new WeakRef(resultPromise));
+                  perQueryReferences.set(queryString, referencedTables);
+                  registry.register(resultPromise, queryString);
+                } else {
+                  resultPromise = resultRef;
+                }
+              } else {
                 resultPromise = getQueryResult(query);
                 cache.set(queryString, new WeakRef(resultPromise));
                 perQueryReferences.set(queryString, referencedTables);
                 registry.register(resultPromise, queryString);
-              } else {
-                resultPromise = resultRef;
               }
-            } else {
-              resultPromise = getQueryResult(query);
-              cache.set(queryString, new WeakRef(resultPromise));
-              perQueryReferences.set(queryString, referencedTables);
-              registry.register(resultPromise, queryString);
+
+              const result = await resultPromise;
+
+              const _resultHash = crypto
+                .createHash("MD5")
+                // @ts-expect-error
+                .update(JSON.stringify(result.rows))
+                .digest("hex")
+                .slice(0, 10);
+
+              if (_resultHash === resultHash) continue;
+              resultHash = _resultHash;
+
+              await stream.writeSSE({ data: JSON.stringify(result) });
+            } catch {
+              stream.abort();
             }
-
-            const result = await resultPromise;
-
-            const _resultHash = crypto
-              .createHash("MD5")
-              // @ts-expect-error
-              .update(JSON.stringify(result.rows))
-              .digest("hex")
-              .slice(0, 10);
-
-            if (_resultHash === resultHash) continue;
-            resultHash = _resultHash;
-
-            await stream.writeSSE({ data: JSON.stringify(result) });
-          } catch {
-            stream.abort();
           }
-        }
-      });
+        });
+        isStreaming = true;
+        return response;
+      } finally {
+        if (isStreaming === false) releaseLiveQuerySlot();
+      }
     }
 
     return next();


### PR DESCRIPTION
## Summary

- Release reserved live query slots when requests fail before streaming.
- Make live query slot release idempotent across failure and abort paths.

## Tests

- Focused regression test for `client.live releases quota when request fails before streaming`
- Full `packages/core/src/client/index.test.ts` suite
- `pnpm --filter ponder typecheck`
- Biome (`pnpm lint`)

Vitest reported its existing close-timeout warning after both test runs completed successfully.