### PR TITLE
Fix SQL relation cache identity

### DIFF
--- a/.changeset/fair-relations-cache.md
+++ b/.changeset/fair-relations-cache.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug that caused SQL-over-HTTP cache invalidation and live updates to use the wrong table dependencies.

--- a/packages/core/src/utils/sql-parse.test.ts
+++ b/packages/core/src/utils/sql-parse.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { createClient } from "@ponder/client";
 import { expect, test } from "vitest";
 import { eq, onchainTable, relations } from "@/index.js";
@@ -36,6 +37,23 @@ test("getSQLQueryRelations", async () => {
       "table",
     }
   `);
+});
+
+test("getSQLQueryRelations() cache identity", async () => {
+  const first = "SELECT 1 /*Ap0yb*/";
+  const second = "SELECT * FROM _ponder_checkpoint /*Bd6bu*/";
+  const firstHash = createHash("sha256").update(first).digest("hex");
+  const secondHash = createHash("sha256").update(second).digest("hex");
+
+  expect(firstHash.slice(0, 10)).toBe(secondHash.slice(0, 10));
+  expect(firstHash).not.toBe(secondHash);
+
+  const firstRelations = await getSQLQueryRelations(first);
+  const secondRelations = await getSQLQueryRelations(second);
+
+  expect(firstRelations).toEqual(new Set());
+  expect(secondRelations).toEqual(new Set(["_ponder_checkpoint"]));
+  expect(firstRelations).not.toEqual(secondRelations);
 });
 
 test("validateAllowableSQLQuery()", async () => {

--- a/packages/core/src/utils/sql-parse.ts
+++ b/packages/core/src/utils/sql-parse.ts
@@ -152,17 +152,12 @@ export const isReadonlySQLQuery = async (sql: string): Promise<boolean> => {
 export const getSQLQueryRelations = async (
   sql: string,
 ): Promise<Set<string>> => {
-  const crypto = await import(/* webpackIgnore: true */ "node:crypto");
-
   if (sql.length > 5_000) {
     throw new Error("Invalid query");
   }
 
-  const hash = crypto
-    .createHash("sha256")
-    .update(sql)
-    .digest("hex")
-    .slice(0, 10);
+  const crypto = await import(/* webpackIgnore: true */ "node:crypto");
+  const hash = crypto.createHash("sha256").update(sql).digest("hex");
 
   if (RELATIONS_CACHE.has(hash)) {
     const result = RELATIONS_CACHE.get(hash)!;


### PR DESCRIPTION
## Summary

- The relation cache now uses the full SHA-256 digest instead of a truncated prefix.
- The regression covers two valid queries with equal old prefixes but different relations.

## Tests

- CI=1 pnpm --filter ponder test src/utils/sql-parse.test.ts
- pnpm --filter ponder typecheck
- pnpm lint (Biome)

Note: Vitest emitted the existing close-timeout warning after the focused test completed successfully.