### PR TITLE
Scope empty schema finalization by chain

### DIFF
--- a/.changeset/quiet-chains-finalize.md
+++ b/.changeset/quiet-chains-finalize.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed a bug that caused crash recovery to fail with `Finalized block for chain "<id>" cannot move backwards` in `ordering: "multichain"` apps with empty schemas.

--- a/packages/core/src/database/actions.test.ts
+++ b/packages/core/src/database/actions.test.ts
@@ -536,6 +536,71 @@ test("empty schema", async () => {
   });
 });
 
+test("finalizeMultichain() with empty schema only updates matching chain", async () => {
+  const { database } = await setupDatabaseServices({
+    schemaBuild: { schema: {} },
+  });
+  const checkpointTable = getPonderCheckpointTable();
+  const mainnetCheckpoint = createCheckpoint({
+    chainId: 1n,
+    blockNumber: 1n,
+  });
+  const optimismCheckpoint = createCheckpoint({
+    chainId: 10n,
+    blockNumber: 1n,
+  });
+  const finalizedCheckpoint = createCheckpoint({
+    chainId: 1n,
+    blockNumber: 10n,
+  });
+
+  await database.userQB.wrap((db) =>
+    db.insert(checkpointTable).values([
+      {
+        chainName: "mainnet",
+        chainId: 1,
+        safeCheckpoint: mainnetCheckpoint,
+        finalizedCheckpoint: mainnetCheckpoint,
+        latestCheckpoint: mainnetCheckpoint,
+      },
+      {
+        chainName: "optimism",
+        chainId: 10,
+        safeCheckpoint: optimismCheckpoint,
+        finalizedCheckpoint: optimismCheckpoint,
+        latestCheckpoint: optimismCheckpoint,
+      },
+    ]),
+  );
+
+  await finalizeMultichain(database.userQB, {
+    tables: [],
+    checkpoint: finalizedCheckpoint,
+    namespaceBuild: { schema: "public", viewsSchema: undefined },
+  });
+
+  const checkpoints = await database.userQB.wrap((db) =>
+    db.select().from(checkpointTable).orderBy(checkpointTable.chainId),
+  );
+
+  expect(checkpoints).toStrictEqual([
+    {
+      chainName: "mainnet",
+      chainId: 1,
+      safeCheckpoint: finalizedCheckpoint,
+      latestCheckpoint: mainnetCheckpoint,
+      finalizedCheckpoint,
+    },
+    {
+      chainName: "optimism",
+      chainId: 10,
+      safeCheckpoint: optimismCheckpoint,
+      latestCheckpoint: optimismCheckpoint,
+      finalizedCheckpoint: optimismCheckpoint,
+    },
+  ]);
+});
+
 async function getUserIndexNames(
   database: Database,
   namespace: string,

--- a/packages/core/src/database/actions.ts
+++ b/packages/core/src/database/actions.ts
@@ -599,14 +599,15 @@ export const finalizeMultichain = async (
   context?: { logger?: Logger },
 ) => {
   const PONDER_CHECKPOINT = getPonderCheckpointTable(namespaceBuild.schema);
+  const chainId = Number(decodeCheckpoint(checkpoint).chainId);
 
-  // TODO(kyle) is this breaking an invariant?
   if (tables.length === 0) {
     await qb.wrap(
       (db) =>
         db
           .update(PONDER_CHECKPOINT)
-          .set({ finalizedCheckpoint: checkpoint, safeCheckpoint: checkpoint }),
+          .set({ finalizedCheckpoint: checkpoint, safeCheckpoint: checkpoint })
+          .where(eq(PONDER_CHECKPOINT.chainId, chainId)),
       context,
     );
     return;
@@ -621,12 +622,7 @@ export const finalizeMultichain = async (
         tx
           .update(PONDER_CHECKPOINT)
           .set({ finalizedCheckpoint: checkpoint })
-          .where(
-            eq(
-              PONDER_CHECKPOINT.chainId,
-              Number(decodeCheckpoint(checkpoint).chainId),
-            ),
-          ),
+          .where(eq(PONDER_CHECKPOINT.chainId, chainId)),
       );
 
       const minOperationId = await tx


### PR DESCRIPTION
## Summary

- Updated empty-schema finalization to update only the checkpoint row for the triggering chain.
- Prevented unrelated chains from inheriting the triggering chain's safe and finalized checkpoint during multichain crash recovery.

## Tests

- `CI=1 pnpm --filter ponder test src/database/actions.test.ts -t 'empty schema only updates matching chain'`
- `pnpm --filter ponder typecheck`
- `pnpm lint` (Biome)

The focused Vitest run passed (1 passed, 10 skipped). After successful completion, Vitest emitted the existing close-timeout warning: `Tests closed successfully but something prevents Vite server from exiting`.