### PR TITLE
Fix SQL validation cache key collisions

### DIFF
--- a/.changeset/secure-sql-validator-cache.md
+++ b/.changeset/secure-sql-validator-cache.md
@@ -1,0 +1,5 @@
+---
+"ponder": patch
+---
+
+Fixed an issue in SQL-over-HTTP validation that could incorrectly reuse validation results for different queries with colliding cache keys.

--- a/packages/core/src/utils/sql-parse.test.ts
+++ b/packages/core/src/utils/sql-parse.test.ts
@@ -88,6 +88,21 @@ test("validateAllowableSQLQuery() cache", async () => {
   ).rejects.toThrow();
 });
 
+test("validateAllowableSQLQuery() cache identity", async () => {
+  const first = "SELECT 1 /*1665502*/";
+  const second = "SELECT * FROM pg_stat_activity /*536102*/";
+  const firstHash = createHash("sha256").update(first).digest("hex");
+  const secondHash = createHash("sha256").update(second).digest("hex");
+
+  expect(firstHash.slice(0, 10)).toBe(secondHash.slice(0, 10));
+  expect(firstHash).not.toBe(secondHash);
+
+  await validateAllowableSQLQuery(first);
+  await expect(validateAllowableSQLQuery(second)).rejects.toThrow(
+    "System tables not supported",
+  );
+});
+
 test("validateAllowableSQLQuery() select into", async () => {
   await expect(
     validateAllowableSQLQuery("SELECT * INTO users;"),

--- a/packages/core/src/utils/sql-parse.ts
+++ b/packages/core/src/utils/sql-parse.ts
@@ -56,11 +56,7 @@ export const parseSQLQuery = async (sql: string): Promise<Node> => {
 export const validateAllowableSQLQuery = async (sql: string) => {
   const crypto = await import(/* webpackIgnore: true */ "node:crypto");
 
-  const hash = crypto
-    .createHash("sha256")
-    .update(sql)
-    .digest("hex")
-    .slice(0, 10);
+  const hash = crypto.createHash("sha256").update(sql).digest("hex");
 
   if (ALLOW_CACHE.has(hash)) {
     const result = ALLOW_CACHE.get(hash)!;


### PR DESCRIPTION
Fixes SQL-over-HTTP validation cache keys to use the full SHA-256 digest, preventing validation results from being reused across colliding queries.