### PR TITLE
Decouple the sync engine from the database layer, and expose it as `ponder/sync`

### DIFF
--- a/.changeset/tidy-sync-entrypoint.md
+++ b/.changeset/tidy-sync-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"ponder": minor
+---
+
+Added a `ponder/sync` entrypoint that exposes the sync engine on its own. It exports `createHistoricalSync`, `createRealtimeSync`, `createRpc`, and the `SyncStore` type the engine reads and writes through, so an application can run Ponder's backfill, reorg handling, factory child-address discovery, and rpc cache against its own tables by implementing `SyncStore` and handling `RealtimeSyncEvent` directly. Importing `ponder/sync` does not load Drizzle, `pg`, PGlite, Hono, or the CLI.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js"
     },
+    "./sync": {
+      "types": "./dist/types/sync.d.ts",
+      "import": "./dist/esm/sync.js"
+    },
     "./virtual": {
       "types": "./src/types.d.ts"
     }

--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -3,17 +3,16 @@ import pg from "pg";
 import { afterAll } from "vitest";
 import { buildSchema } from "@/build/schema.js";
 import { createDatabase, type Database } from "@/database/index.js";
+import type { DatabaseConfig, SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import { createLogger } from "@/internal/logger.js";
 import { MetricsService } from "@/internal/metrics.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import type {
-  DatabaseConfig,
   EventCallback,
   IndexingBuild,
   NamespaceBuild,
-  SchemaBuild,
 } from "@/internal/types.js";
 import { getFilterFactories, isAddressFactory } from "@/runtime/filter.js";
 import { getFactoryFragments, getFragments } from "@/runtime/fragments.js";

--- a/packages/core/src/bin/commands/codegen.ts
+++ b/packages/core/src/bin/commands/codegen.ts
@@ -1,9 +1,9 @@
 import { runCodegen } from "@/bin/utils/codegen.js";
 import { createLogger } from "@/internal/logger.js";
 import { MetricsService } from "@/internal/metrics.js";
+import type { CliOptions } from "@/internal/options.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
-import type { CliOptions } from "../ponder.js";
 import { createExit } from "../utils/exit.js";
 
 export async function codegen({ cliOptions }: { cliOptions: CliOptions }) {

--- a/packages/core/src/bin/commands/createViews.ts
+++ b/packages/core/src/bin/commands/createViews.ts
@@ -23,10 +23,10 @@ import {
 import { sql } from "@/index.js";
 import { createLogger } from "@/internal/logger.js";
 import { MetricsService } from "@/internal/metrics.js";
+import type { CliOptions } from "@/internal/options.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import { startClock } from "@/utils/timer.js";
-import type { CliOptions } from "../ponder.js";
 import { createExit } from "../utils/exit.js";
 
 const emptySchemaBuild = {

--- a/packages/core/src/bin/commands/dev.ts
+++ b/packages/core/src/bin/commands/dev.ts
@@ -2,16 +2,18 @@ import fs from "node:fs";
 import path from "node:path";
 import { createBuild } from "@/build/index.js";
 import { createDatabase, type Database } from "@/database/index.js";
+import { getSchemaTableNames } from "@/drizzle/index.js";
+import type { PreBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import { NonRetryableUserError, ShutdownError } from "@/internal/errors.js";
 import { createLogger } from "@/internal/logger.js";
 import { MetricsService } from "@/internal/metrics.js";
+import type { CliOptions } from "@/internal/options.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import type {
   CrashRecoveryCheckpoint,
   IndexingBuild,
-  PreBuild,
 } from "@/internal/types.js";
 import { runMultichain } from "@/runtime/multichain.js";
 import { runOmnichain } from "@/runtime/omnichain.js";
@@ -20,7 +22,6 @@ import { createUi } from "@/ui/index.js";
 import { createQueue } from "@/utils/queue.js";
 import type { Result } from "@/utils/result.js";
 import { isolatedController } from "../isolatedController.js";
-import type { CliOptions } from "../ponder.js";
 import { runCodegen } from "../utils/codegen.js";
 import { createExit } from "../utils/exit.js";
 
@@ -330,8 +331,10 @@ export async function dev({ cliOptions }: { cliOptions: CliOptions }) {
         createServer({ common, database, apiBuild: apiBuildResult.result });
 
         metrics.initializeIndexingMetrics({
-          indexingBuild: indexingBuildResult.result,
-          schemaBuild: compileSchemaResult.result,
+          eventNames: indexingBuildResult.result.indexingFunctions.map(
+            ({ name }) => name,
+          ),
+          tableNames: getSchemaTableNames(compileSchemaResult.result.schema),
         });
 
         switch (preCompileResult.result.ordering) {

--- a/packages/core/src/bin/commands/list.ts
+++ b/packages/core/src/bin/commands/list.ts
@@ -17,11 +17,11 @@ import {
 } from "@/database/index.js";
 import { createLogger } from "@/internal/logger.js";
 import { MetricsService } from "@/internal/metrics.js";
+import type { CliOptions } from "@/internal/options.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import { buildTable } from "@/ui/app.js";
 import { formatEta } from "@/utils/format.js";
-import type { CliOptions } from "../ponder.js";
 import { createExit } from "../utils/exit.js";
 
 const emptySchemaBuild = {

--- a/packages/core/src/bin/commands/prune.ts
+++ b/packages/core/src/bin/commands/prune.ts
@@ -25,10 +25,10 @@ import {
 } from "@/drizzle/onchain.js";
 import { createLogger } from "@/internal/logger.js";
 import { MetricsService } from "@/internal/metrics.js";
+import type { CliOptions } from "@/internal/options.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import { startClock } from "@/utils/timer.js";
-import type { CliOptions } from "../ponder.js";
 import { createExit } from "../utils/exit.js";
 
 const emptySchemaBuild = {

--- a/packages/core/src/bin/commands/serve.ts
+++ b/packages/core/src/bin/commands/serve.ts
@@ -3,10 +3,10 @@ import { createBuild } from "@/build/index.js";
 import { createDatabase, SCHEMATA } from "@/database/index.js";
 import { createLogger } from "@/internal/logger.js";
 import { MetricsService } from "@/internal/metrics.js";
+import type { CliOptions } from "@/internal/options.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import { createServer } from "@/server/index.js";
-import type { CliOptions } from "../ponder.js";
 import { createExit } from "../utils/exit.js";
 
 export async function serve({ cliOptions }: { cliOptions: CliOptions }) {

--- a/packages/core/src/bin/commands/start.ts
+++ b/packages/core/src/bin/commands/start.ts
@@ -1,24 +1,23 @@
 import { runCodegen } from "@/bin/utils/codegen.js";
 import { createBuild } from "@/build/index.js";
 import { createDatabase, type Database } from "@/database/index.js";
+import { getSchemaTableNames } from "@/drizzle/index.js";
+import type { ApiBuild, PreBuild, SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import { createLogger } from "@/internal/logger.js";
 import { MetricsService } from "@/internal/metrics.js";
+import type { CliOptions } from "@/internal/options.js";
 import { buildOptions } from "@/internal/options.js";
 import { createShutdown } from "@/internal/shutdown.js";
 import type {
-  ApiBuild,
   CrashRecoveryCheckpoint,
   IndexingBuild,
   NamespaceBuild,
-  PreBuild,
-  SchemaBuild,
 } from "@/internal/types.js";
 import { runMultichain } from "@/runtime/multichain.js";
 import { runOmnichain } from "@/runtime/omnichain.js";
 import { createServer } from "@/server/index.js";
 import { isolatedController } from "../isolatedController.js";
-import type { CliOptions } from "../ponder.js";
 import { createExit } from "../utils/exit.js";
 
 export type PonderApp = {
@@ -281,7 +280,10 @@ export async function start({
     app = await onBuild(app);
   }
 
-  metrics.initializeIndexingMetrics(app);
+  metrics.initializeIndexingMetrics({
+    eventNames: app.indexingBuild.indexingFunctions.map(({ name }) => name),
+    tableNames: getSchemaTableNames(app.schemaBuild.schema),
+  });
 
   switch (preCompileResult.result.ordering) {
     case "omnichain":

--- a/packages/core/src/bin/isolatedController.ts
+++ b/packages/core/src/bin/isolatedController.ts
@@ -5,6 +5,7 @@ import { Worker } from "node:worker_threads";
 import { isTable, isView, sql } from "drizzle-orm";
 import { createIndexes, createViews } from "@/database/actions.js";
 import { type Database, getPonderMetaTable } from "@/database/index.js";
+import type { PreBuild, SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import {
   NonRetryableUserError,
@@ -15,8 +16,6 @@ import type {
   CrashRecoveryCheckpoint,
   IndexingBuild,
   NamespaceBuild,
-  PreBuild,
-  SchemaBuild,
 } from "@/internal/types.js";
 import { runIsolated } from "@/runtime/isolated.js";
 import { chunk } from "@/utils/chunk.js";

--- a/packages/core/src/bin/isolatedWorker.ts
+++ b/packages/core/src/bin/isolatedWorker.ts
@@ -1,6 +1,7 @@
 import { isMainThread, parentPort, workerData } from "node:worker_threads";
 import { createBuild } from "@/build/index.js";
 import { createDatabase } from "@/database/index.js";
+import { getSchemaTableNames } from "@/drizzle/index.js";
 import type { Common } from "@/internal/common.js";
 import { createLogger } from "@/internal/logger.js";
 import { IsolatedMetricsService } from "@/internal/metrics.js";
@@ -163,8 +164,8 @@ export async function isolatedWorker({
       };
 
       common.metrics.initializeIndexingMetrics({
-        indexingBuild,
-        schemaBuild: schemaBuildResult.result,
+        eventNames: indexingBuild.indexingFunctions.map(({ name }) => name),
+        tableNames: getSchemaTableNames(schemaBuildResult.result.schema),
       });
 
       await runIsolated({

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -4,7 +4,6 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command } from "@commander-js/extra-typings";
 import dotenv from "dotenv";
-import type { Prettify } from "@/types/utils.js";
 import { codegen } from "./commands/codegen.js";
 import { createViews } from "./commands/createViews.js";
 import { dev } from "./commands/dev.js";
@@ -194,15 +193,17 @@ ponder.addCommand(serveCommand);
 ponder.addCommand(dbCommand);
 ponder.addCommand(codegenCommand);
 
-export type CliOptions = Prettify<
-  GlobalOptions &
-    Partial<
-      ReturnType<typeof devCommand.opts> &
-        ReturnType<typeof startCommand.opts> &
-        ReturnType<typeof serveCommand.opts> &
-        ReturnType<typeof dbCommand.opts> &
-        ReturnType<typeof codegenCommand.opts>
-    >
->;
+/**
+ * `CliOptions` -- the shape every command receives -- is declared in
+ * `@/internal/options.ts`, next to the `buildOptions` that consumes it, rather
+ * than derived from the commands above.
+ *
+ * That keeps the dependency pointing one way. This module runs a command as a
+ * side effect of being imported, so nothing outside `bin/` should have to
+ * import it merely to describe its own input, and now nothing does. Each
+ * `.action` handler below passes its parsed options straight into a command
+ * that declares `CliOptions`, so a flag that stops matching the contract is
+ * still a compile error -- at the call site instead of in a type alias.
+ */
 
 await ponder.parseAsync();

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -13,25 +13,23 @@ import { ViteNodeServer } from "vite-node/server";
 import { installSourcemapsSupport } from "vite-node/source-map";
 import { normalizeModuleId, toFilePath } from "vite-node/utils";
 import viteTsconfigPathsPlugin from "vite-tsconfig-paths";
-import type { CliOptions } from "@/bin/ponder.js";
 import type { Config } from "@/config/index.js";
 import type { Database } from "@/database/index.js";
 import { createQB } from "@/database/queryBuilder.js";
 import { MAX_DATABASE_OBJECT_NAME_LENGTH } from "@/drizzle/onchain.js";
+import type { ApiBuild, PreBuild, SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import {
   BuildError,
   NonRetryableUserError,
   RetryableError,
 } from "@/internal/errors.js";
+import type { CliOptions } from "@/internal/options.js";
 import type {
-  ApiBuild,
   IndexingBuild,
   IndexingFunctions,
   NamespaceBuild,
-  PreBuild,
   Schema,
-  SchemaBuild,
 } from "@/internal/types.js";
 import { createPool, getDatabaseName } from "@/utils/pg.js";
 import { createPglite } from "@/utils/pglite.js";

--- a/packages/core/src/build/pre.ts
+++ b/packages/core/src/build/pre.ts
@@ -1,9 +1,9 @@
 import path from "node:path";
 import type { Config } from "@/config/index.js";
+import type { DatabaseConfig } from "@/internal/build.js";
 import { BuildError } from "@/internal/errors.js";
 import type { Logger } from "@/internal/logger.js";
 import type { Options } from "@/internal/options.js";
-import type { DatabaseConfig } from "@/internal/types.js";
 
 export function buildPre({
   config,

--- a/packages/core/src/build/schema.ts
+++ b/packages/core/src/build/schema.ts
@@ -24,8 +24,9 @@ import {
 import { getPrimaryKeyColumns } from "@/drizzle/index.js";
 import { getSql } from "@/drizzle/kit/index.js";
 import { MAX_DATABASE_OBJECT_NAME_LENGTH } from "@/drizzle/onchain.js";
+import type { PreBuild } from "@/internal/build.js";
 import { BuildError } from "@/internal/errors.js";
-import type { PreBuild, Schema } from "@/internal/types.js";
+import type { Schema } from "@/internal/types.js";
 
 export const buildSchema = ({
   schema,

--- a/packages/core/src/database/actions.ts
+++ b/packages/core/src/database/actions.ts
@@ -27,12 +27,9 @@ import {
   getReorgTriggerName,
   getViewsLiveQueryNotifyTriggerName,
 } from "@/drizzle/onchain.js";
+import type { PreBuild, SchemaBuild } from "@/internal/build.js";
 import type { Logger } from "@/internal/logger.js";
-import type {
-  NamespaceBuild,
-  PreBuild,
-  SchemaBuild,
-} from "@/internal/types.js";
+import type { NamespaceBuild } from "@/internal/types.js";
 import { decodeCheckpoint, MAX_CHECKPOINT_STRING } from "@/utils/checkpoint.js";
 import {
   getPonderCheckpointTable,

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -21,6 +21,7 @@ import {
   getReorgSequenceName,
   getReorgTableName,
 } from "@/drizzle/onchain.js";
+import type { PreBuild, SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import {
   MigrationError,
@@ -31,8 +32,6 @@ import type {
   CrashRecoveryCheckpoint,
   IndexingBuild,
   NamespaceBuild,
-  PreBuild,
-  SchemaBuild,
 } from "@/internal/types.js";
 import { buildMigrationProvider } from "@/sync-store/migrations.js";
 import * as PONDER_SYNC from "@/sync-store/schema.js";

--- a/packages/core/src/drizzle/index.ts
+++ b/packages/core/src/drizzle/index.ts
@@ -1,10 +1,20 @@
-import { getTableColumns } from "drizzle-orm";
+import { getTableColumns, getTableName, isTable } from "drizzle-orm";
 import {
   getTableConfig,
   type PgColumn,
   type PgTable,
 } from "drizzle-orm/pg-core";
 import { getColumnCasing } from "./kit/index.js";
+
+/**
+ * The names of the tables in a user schema, for metric labels.
+ *
+ * Here rather than in `internal/metrics.ts` so that knowing what a Drizzle
+ * table is stays in the schema layer.
+ */
+export const getSchemaTableNames = (schema: {
+  [name: string]: unknown;
+}): string[] => Object.values(schema).filter(isTable).map(getTableName);
 
 export const getPrimaryKeyColumns = (
   table: PgTable,

--- a/packages/core/src/indexing-store/cache.ts
+++ b/packages/core/src/indexing-store/cache.ts
@@ -13,17 +13,14 @@ import { getPrimaryKeyColumns } from "@/drizzle/index.js";
 import { getColumnCasing } from "@/drizzle/kit/index.js";
 import { getPartitionName } from "@/drizzle/onchain.js";
 import { addErrorMeta, toErrorMeta } from "@/indexing/index.js";
+import type { SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import {
   CopyFlushError,
   DelayedInsertError,
   ShutdownError,
 } from "@/internal/errors.js";
-import type {
-  CrashRecoveryCheckpoint,
-  Event,
-  SchemaBuild,
-} from "@/internal/types.js";
+import type { CrashRecoveryCheckpoint, Event } from "@/internal/types.js";
 import { dedupe } from "@/utils/dedupe.js";
 import { prettyPrint } from "@/utils/print.js";
 import { promiseAllSettledWithThrow } from "@/utils/promiseAllSettledWithThrow.js";

--- a/packages/core/src/indexing-store/index.ts
+++ b/packages/core/src/indexing-store/index.ts
@@ -12,6 +12,7 @@ import { getTableConfig } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/pg-proxy";
 import type { QB } from "@/database/queryBuilder.js";
 import { onchain } from "@/drizzle/onchain.js";
+import type { SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import {
   DbConnectionError,
@@ -24,11 +25,7 @@ import {
   UndefinedTableError,
   UniqueConstraintError,
 } from "@/internal/errors.js";
-import type {
-  IndexingErrorHandler,
-  Schema,
-  SchemaBuild,
-} from "@/internal/types.js";
+import type { IndexingErrorHandler, Schema } from "@/internal/types.js";
 import type { Db } from "@/types/db.js";
 import { copy, copyOnWrite } from "@/utils/copy.js";
 import { createLock } from "@/utils/mutex.js";

--- a/packages/core/src/internal/build.ts
+++ b/packages/core/src/internal/build.ts
@@ -1,0 +1,45 @@
+import type { PGlite } from "@electric-sql/pglite";
+import type { Hono } from "hono";
+import type { PoolConfig } from "pg";
+import type { SqlStatements } from "@/drizzle/kit/index.js";
+import type { PGliteOptions } from "@/utils/pglite.js";
+import type { Ordering, Schema } from "./types.js";
+
+/**
+ * Build artefacts that name a database, an HTTP server, or generated SQL.
+ *
+ * These live apart from `./types.ts` because that module describes the
+ * blockchain data model -- blocks, logs, filters, fragments -- which the sync
+ * engine is built on. Keeping the two apart is what lets the engine be
+ * compiled without Drizzle, PGlite, `pg`, or Hono in scope.
+ */
+
+import type { Prettify } from "@/types/utils.js";
+
+export type DatabaseConfig =
+  | { kind: "pglite"; options: PGliteOptions }
+  | { kind: "pglite_test"; instance: PGlite }
+  | { kind: "postgres"; poolConfig: Prettify<PoolConfig & { max: number }> };
+
+/** Consolidated CLI, env vars, and config. */
+export type PreBuild = {
+  /** Database type and configuration */
+  databaseConfig: DatabaseConfig;
+  /** Ordering of events */
+  ordering: Ordering;
+};
+
+export type SchemaBuild = {
+  schema: Schema;
+  /** SQL statements to create the schema */
+  statements: SqlStatements;
+};
+
+export type ApiBuild = {
+  /** Hostname for server */
+  hostname?: string;
+  /** Port number for server */
+  port: number;
+  /** Hono app exported from `ponder/api/index.ts`. */
+  app: Hono;
+};

--- a/packages/core/src/internal/layering.test.ts
+++ b/packages/core/src/internal/layering.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * The modules the sync engine is entered through.
+ *
+ * Anything reachable from here is part of the engine, and is what a standalone
+ * consumer would have to install.
+ */
+const ENTRYPOINTS = [
+  "sync-historical/index.ts",
+  "sync-realtime/index.ts",
+  "rpc/index.ts",
+];
+
+/**
+ * Layers the sync engine must not reach.
+ *
+ * The engine talks to storage through the `SyncStore` type in
+ * `sync-store/store.ts` and nothing else, so an application can supply its own
+ * implementation over its own tables. Reaching any of these would put a
+ * database driver, an HTTP server, or the CLI back in its import graph -- and
+ * `bin/ponder.ts` in particular runs a command when it is imported.
+ */
+const FORBIDDEN = [
+  "bin/",
+  "build/",
+  "client/",
+  "database/",
+  "drizzle/",
+  "graphql/",
+  "indexing/",
+  "indexing-store/",
+  "server/",
+  "sync-store/index.ts",
+];
+
+/** Packages that would come with a database or a web server. */
+const FORBIDDEN_PACKAGES = [
+  "drizzle-orm",
+  "drizzle-kit",
+  "pg",
+  "pg-connection-string",
+  "@electric-sql/pglite",
+  "hono",
+  "@hono/node-server",
+  "@commander-js/extra-typings",
+  "graphql",
+];
+
+const SPECIFIER = /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s+"([^"]+)"/g;
+
+function specifiers(file: string): string[] {
+  const source = readFileSync(join(SRC, file), "utf8");
+  return [...source.matchAll(SPECIFIER)].map((m) => m[1]!);
+}
+
+function resolveSpecifier(from: string, specifier: string): string | undefined {
+  if (specifier.startsWith("@/")) {
+    return `${specifier.slice(2).replace(/\.js$/, ".ts")}`;
+  }
+  if (specifier.startsWith(".")) {
+    const abs = resolve(dirname(join(SRC, from)), specifier);
+    return relative(SRC, abs).replace(/\.js$/, ".ts");
+  }
+  return undefined;
+}
+
+/** Every source file reachable from the sync engine's entrypoints. */
+function closure(): { files: Set<string>; packages: Map<string, string[]> } {
+  const files = new Set<string>();
+  const packages = new Map<string, string[]>();
+  const stack = [...ENTRYPOINTS];
+
+  while (stack.length > 0) {
+    const file = stack.pop()!;
+    if (files.has(file)) continue;
+    let found: string[];
+    try {
+      found = specifiers(file);
+    } catch {
+      continue; // not a file in this package
+    }
+    files.add(file);
+
+    for (const specifier of found) {
+      const resolved = resolveSpecifier(file, specifier);
+      if (resolved === undefined) {
+        const pkg = specifier.startsWith("@")
+          ? specifier.split("/").slice(0, 2).join("/")
+          : specifier.split("/")[0]!;
+        packages.set(pkg, [...(packages.get(pkg) ?? []), file]);
+        continue;
+      }
+      stack.push(resolved);
+    }
+  }
+
+  return { files, packages };
+}
+
+test("the sync engine does not import the database, server, or CLI layers", () => {
+  const { files } = closure();
+
+  const violations = [...files]
+    .filter((file) => FORBIDDEN.some((layer) => file.startsWith(layer)))
+    .sort();
+
+  expect(violations).toStrictEqual([]);
+});
+
+test("the sync engine does not depend on a database driver or web server", () => {
+  const { packages } = closure();
+
+  const violations = FORBIDDEN_PACKAGES.filter((pkg) => packages.has(pkg))
+    .map((pkg) => `${pkg} (via ${packages.get(pkg)!.join(", ")})`)
+    .sort();
+
+  expect(violations).toStrictEqual([]);
+});
+
+test("the sync engine reaches storage only through the SyncStore contract", () => {
+  const { files } = closure();
+
+  // The contract is in the closure; the Drizzle implementation beside it is not.
+  expect(files.has("sync-store/store.ts")).toBe(true);
+  expect(files.has("sync-store/index.ts")).toBe(false);
+});

--- a/packages/core/src/internal/layering.test.ts
+++ b/packages/core/src/internal/layering.test.ts
@@ -12,6 +12,7 @@ const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "..");
  * consumer would have to install.
  */
 const ENTRYPOINTS = [
+  "sync.ts",
   "sync-historical/index.ts",
   "sync-realtime/index.ts",
   "rpc/index.ts",

--- a/packages/core/src/internal/metrics.ts
+++ b/packages/core/src/internal/metrics.ts
@@ -1,12 +1,11 @@
 import { parentPort, type Worker } from "node:worker_threads";
-import { getTableName, isTable } from "drizzle-orm";
 import prometheus from "prom-client";
 import {
   type PromiseWithResolvers,
   promiseWithResolvers,
 } from "@/utils/promiseWithResolvers.js";
 import { truncate } from "@/utils/truncate.js";
-import type { IndexingBuild, PreBuild, SchemaBuild } from "./types.js";
+import type { Ordering } from "./types.js";
 
 const sometimesIODurationMs = [
   0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 50, 100, 500, 1_000, 5_000,
@@ -529,32 +528,32 @@ export class MetricsService {
     this.indexingStoreQueries.clear();
   }
 
+  /**
+   * Registers the zero-valued indexing series, so a table or event that never
+   * fires still appears.
+   *
+   * Takes names rather than a schema: resolving a Drizzle table to its name is
+   * the schema layer's job, and doing it here would put Drizzle in the import
+   * graph of every module that holds a `Common`, the sync engine included.
+   */
   initializeIndexingMetrics({
-    indexingBuild,
-    schemaBuild,
+    eventNames,
+    tableNames,
   }: {
-    indexingBuild: Pick<IndexingBuild, "indexingFunctions">;
-    schemaBuild: SchemaBuild;
+    eventNames: string[];
+    tableNames: string[];
   }) {
-    const tables = Object.values(schemaBuild.schema).filter(isTable);
-
-    for (const { name: eventName } of indexingBuild.indexingFunctions) {
+    for (const eventName of eventNames) {
       this.ponder_indexing_completed_events.inc({ event: eventName }, 0);
     }
 
-    for (const table of tables) {
+    for (const table of tableNames) {
       for (const type of ["complete", "hit", "miss", "prefetch"]) {
-        this.ponder_indexing_cache_requests_total.inc(
-          { table: getTableName(table), type },
-          0,
-        );
+        this.ponder_indexing_cache_requests_total.inc({ table, type }, 0);
       }
 
       for (const method of ["find", "insert", "update", "delete"]) {
-        this.ponder_indexing_store_queries_total.inc(
-          { table: getTableName(table), method },
-          0,
-        );
+        this.ponder_indexing_store_queries_total.inc({ table, method }, 0);
       }
     }
   }
@@ -912,8 +911,8 @@ export async function getAppProgress(metrics: MetricsService): Promise<{
   const settingsMetric = await registry
     .getSingleMetric("ponder_settings_info")!
     .get();
-  const ordering: PreBuild["ordering"] | undefined = settingsMetric?.values[0]
-    ?.labels.ordering as any;
+  const ordering: Ordering | undefined = settingsMetric?.values[0]?.labels
+    .ordering as any;
 
   switch (ordering) {
     case undefined:

--- a/packages/core/src/internal/options.ts
+++ b/packages/core/src/internal/options.ts
@@ -2,7 +2,31 @@ import path from "node:path";
 import v8 from "node:v8";
 import type { LevelWithSilent } from "pino";
 import { parse, type SemVer } from "semver";
-import type { CliOptions } from "@/bin/ponder.js";
+
+/**
+ * The command-line inputs `buildOptions` reads.
+ *
+ * Declared here rather than imported from the CLI so that `Options` -- which
+ * most of the codebase depends on -- does not pull in `bin/ponder.ts`, a
+ * module whose last statement parses `process.argv` and runs a command. The
+ * CLI's own commander-derived option type is checked against this one, so the
+ * two cannot drift.
+ */
+export type CliOptions = {
+  command: Options["command"];
+  version: string;
+  config: string;
+  root?: string;
+  schema?: string;
+  viewsSchema?: string;
+  port?: number;
+  hostname?: string;
+  logLevel?: string;
+  logFormat?: string;
+  debug?: boolean;
+  trace?: boolean;
+  disableUi?: boolean;
+};
 
 export type Options = {
   command: "dev" | "start" | "serve" | "codegen" | "list" | "prune";

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -1,6 +1,3 @@
-import type { PGlite } from "@electric-sql/pglite";
-import type { Hono } from "hono";
-import type { PoolConfig } from "pg";
 import type {
   Abi,
   AbiEvent,
@@ -16,7 +13,6 @@ import type {
   Chain as ViemChain,
   Log as ViemLog,
 } from "viem";
-import type { SqlStatements } from "@/drizzle/kit/index.js";
 import type { Rpc } from "@/rpc/index.js";
 import type {
   Block,
@@ -28,15 +24,7 @@ import type {
 } from "@/types/eth.js";
 import type { PartialExcept, Prettify } from "@/types/utils.js";
 import type { Trace as DebugTrace } from "@/utils/debug.js";
-import type { PGliteOptions } from "@/utils/pglite.js";
 import type { RetryableError } from "./errors.js";
-
-// Database
-
-export type DatabaseConfig =
-  | { kind: "pglite"; options: PGliteOptions }
-  | { kind: "pglite_test"; instance: PGlite }
-  | { kind: "postgres"; poolConfig: Prettify<PoolConfig & { max: number }> };
 
 // Indexing
 
@@ -313,26 +301,15 @@ export type Chain = {
 /** User-defined tables, enums, and indexes. */
 export type Schema = { [name: string]: unknown };
 
+/** How events from different chains are interleaved. */
+export type Ordering = "omnichain" | "multichain" | "experimental_isolated";
+
 // Build artifacts
 
 /** Database schema name. */
 export type NamespaceBuild = {
   schema: string;
   viewsSchema: string | undefined;
-};
-
-/** Consolidated CLI, env vars, and config. */
-export type PreBuild = {
-  /** Database type and configuration */
-  databaseConfig: DatabaseConfig;
-  /** Ordering of events */
-  ordering: "omnichain" | "multichain" | "experimental_isolated";
-};
-
-export type SchemaBuild = {
-  schema: Schema;
-  /** SQL statements to create the schema */
-  statements: SqlStatements;
 };
 
 export type IndexingBuild = {
@@ -354,15 +331,6 @@ export type IndexingBuild = {
   contracts: {
     [name: string]: Contract;
   }[];
-};
-
-export type ApiBuild = {
-  /** Hostname for server */
-  hostname?: string;
-  /** Port number for server */
-  port: number;
-  /** Hono app exported from `ponder/api/index.ts`. */
-  app: Hono;
 };
 
 // Crash recovery

--- a/packages/core/src/rpc/actions.ts
+++ b/packages/core/src/rpc/actions.ts
@@ -21,7 +21,7 @@ import type {
 import type { RequestParameters, Rpc } from "@/rpc/index.js";
 import { zeroLogsBloom } from "@/sync-realtime/bloom.js";
 import { chunk } from "@/utils/chunk.js";
-import { PG_BIGINT_MAX, PG_INTEGER_MAX } from "@/utils/pg.js";
+import { PG_BIGINT_MAX, PG_INTEGER_MAX } from "@/utils/pgLimits.js";
 
 const ADDRESS_CHUNK_SIZE = 50;
 

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -22,7 +22,7 @@ import {
   getFragments,
   recoverFilter,
 } from "@/runtime/fragments.js";
-import type { SyncStore } from "@/sync-store/index.js";
+import type { SyncStore } from "@/sync-store/store.js";
 import {
   blockToCheckpoint,
   encodeCheckpoint,

--- a/packages/core/src/runtime/isolated.ts
+++ b/packages/core/src/runtime/isolated.ts
@@ -18,6 +18,7 @@ import {
 } from "@/indexing/index.js";
 import { createIndexingCache } from "@/indexing-store/cache.js";
 import { createIndexingStore } from "@/indexing-store/index.js";
+import type { PreBuild, SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import {
   InvalidEventAccessError,
@@ -29,8 +30,6 @@ import type {
   IndexingBuild,
   IndexingErrorHandler,
   NamespaceBuild,
-  PreBuild,
-  SchemaBuild,
   Seconds,
 } from "@/internal/types.js";
 import { splitEvents } from "@/runtime/events.js";

--- a/packages/core/src/runtime/multichain.ts
+++ b/packages/core/src/runtime/multichain.ts
@@ -24,6 +24,7 @@ import {
 } from "@/indexing/index.js";
 import { createIndexingCache } from "@/indexing-store/cache.js";
 import { createIndexingStore } from "@/indexing-store/index.js";
+import type { PreBuild, SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import {
   InvalidEventAccessError,
@@ -37,8 +38,6 @@ import type {
   IndexingBuild,
   IndexingErrorHandler,
   NamespaceBuild,
-  PreBuild,
-  SchemaBuild,
   Seconds,
 } from "@/internal/types.js";
 import { splitEvents } from "@/runtime/events.js";

--- a/packages/core/src/runtime/omnichain.ts
+++ b/packages/core/src/runtime/omnichain.ts
@@ -24,6 +24,7 @@ import {
 } from "@/indexing/index.js";
 import { createIndexingCache } from "@/indexing-store/cache.js";
 import { createIndexingStore } from "@/indexing-store/index.js";
+import type { PreBuild, SchemaBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
 import {
   InvalidEventAccessError,
@@ -38,8 +39,6 @@ import type {
   IndexingBuild,
   IndexingErrorHandler,
   NamespaceBuild,
-  PreBuild,
-  SchemaBuild,
   Seconds,
 } from "@/internal/types.js";
 import { splitEvents } from "@/runtime/events.js";

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -9,8 +9,9 @@ import {
   getPonderCheckpointTable,
   getPonderMetaTable,
 } from "@/database/index.js";
+import type { ApiBuild } from "@/internal/build.js";
 import type { Common } from "@/internal/common.js";
-import type { ApiBuild, Status } from "@/internal/types.js";
+import type { Status } from "@/internal/types.js";
 import { decodeCheckpoint } from "@/utils/checkpoint.js";
 import { startClock } from "@/utils/timer.js";
 import { onError } from "./error.js";

--- a/packages/core/src/sync-historical/index.ts
+++ b/packages/core/src/sync-historical/index.ts
@@ -55,7 +55,7 @@ import type {
   IntervalWithFactory,
   IntervalWithFilter,
 } from "@/runtime/index.js";
-import type { SyncStore } from "@/sync-store/index.js";
+import type { SyncStore } from "@/sync-store/store.js";
 import { dedupe } from "@/utils/dedupe.js";
 import {
   getChunks,

--- a/packages/core/src/sync-store/index.ts
+++ b/packages/core/src/sync-store/index.ts
@@ -22,7 +22,6 @@ import { type Address, hexToNumber, isHex } from "viem";
 import type { QB } from "@/database/queryBuilder.js";
 import { extractBlockNumberParam } from "@/indexing/client.js";
 import type { Common } from "@/internal/common.js";
-import type { Logger } from "@/internal/logger.js";
 import type {
   BlockFilter,
   Factory,
@@ -34,23 +33,15 @@ import type {
   InternalTrace,
   InternalTransaction,
   InternalTransactionReceipt,
-  LightBlock,
   LogFilter,
   RequiredInternalBlockColumns,
   RequiredInternalTraceColumns,
   RequiredInternalTransactionColumns,
   RequiredInternalTransactionReceiptColumns,
-  SyncBlock,
-  SyncBlockHeader,
-  SyncLog,
-  SyncTrace,
-  SyncTransaction,
-  SyncTransactionReceipt,
   TraceFilter,
   TransactionFilter,
   TransferFilter,
 } from "@/internal/types.js";
-import type { RequestParameters } from "@/rpc/index.js";
 import {
   getFilterFactories,
   isAddressFactory,
@@ -64,10 +55,6 @@ import {
   getFactoryFragments,
   getFragments,
 } from "@/runtime/fragments.js";
-import type {
-  IntervalWithFactory,
-  IntervalWithFilter,
-} from "@/runtime/index.js";
 import type { Interval } from "@/utils/interval.js";
 import { toLowerCase } from "@/utils/lowercase.js";
 import { orderObject } from "@/utils/order.js";
@@ -80,124 +67,9 @@ import {
   encodeTransactionReceipt,
 } from "./encode.js";
 import * as PONDER_SYNC from "./schema.js";
+import type { SyncStore } from "./store.js";
 
-export type SyncStore = {
-  insertIntervals(
-    args: {
-      intervals: IntervalWithFilter[];
-      factoryIntervals: IntervalWithFactory[];
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  getIntervals(
-    args: { filters: Filter[] },
-    context?: { logger?: Logger },
-  ): Promise<
-    Map<Filter | Factory, { fragment: Fragment; intervals: Interval[] }[]>
-  >;
-  insertChildAddresses(
-    args: {
-      factory: Factory;
-      childAddresses: Map<Address, number>;
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  getChildAddresses(
-    args: { factory: Factory },
-    context?: { logger?: Logger },
-  ): Promise<Map<Address, number>>;
-  getSafeCrashRecoveryBlock(
-    args: {
-      chainId: number;
-      timestamp: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<{ number: bigint; timestamp: bigint } | undefined>;
-  insertLogs(
-    args: { logs: SyncLog[]; chainId: number },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  insertBlocks(
-    args: {
-      blocks: (SyncBlock | SyncBlockHeader)[];
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  insertTransactions(
-    args: {
-      transactions: SyncTransaction[];
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  insertTransactionReceipts(
-    args: {
-      transactionReceipts: SyncTransactionReceipt[];
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  insertTraces(
-    args: {
-      traces: {
-        trace: SyncTrace;
-        block: SyncBlock;
-        transaction: SyncTransaction;
-      }[];
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  getEventData(
-    args: {
-      filters: Filter[];
-      fromBlock: number;
-      toBlock: number;
-      chainId: number;
-      limit: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<{
-    blocks: InternalBlock[];
-    logs: InternalLog[];
-    transactions: InternalTransaction[];
-    transactionReceipts: InternalTransactionReceipt[];
-    traces: InternalTrace[];
-    cursor: number;
-  }>;
-  insertRpcRequestResults(
-    args: {
-      requests: {
-        request: RequestParameters;
-        blockNumber: number | undefined;
-        result: string;
-      }[];
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  getRpcRequestResults(
-    args: {
-      requests: RequestParameters[];
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<(string | undefined)[]>;
-  pruneRpcRequestResults(
-    args: {
-      blocks: Pick<LightBlock, "number">[];
-      chainId: number;
-    },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-  pruneByChain(
-    args: { chainId: number },
-    context?: { logger?: Logger },
-  ): Promise<void>;
-};
+export type { SyncStore } from "./store.js";
 
 export const createSyncStore = ({
   common,

--- a/packages/core/src/sync-store/store.ts
+++ b/packages/core/src/sync-store/store.ts
@@ -1,0 +1,156 @@
+import type { Address } from "viem";
+import type { Logger } from "@/internal/logger.js";
+import type {
+  Factory,
+  Filter,
+  Fragment,
+  InternalBlock,
+  InternalLog,
+  InternalTrace,
+  InternalTransaction,
+  InternalTransactionReceipt,
+  LightBlock,
+  SyncBlock,
+  SyncBlockHeader,
+  SyncLog,
+  SyncTrace,
+  SyncTransaction,
+  SyncTransactionReceipt,
+} from "@/internal/types.js";
+import type { RequestParameters } from "@/rpc/index.js";
+import type {
+  IntervalWithFactory,
+  IntervalWithFilter,
+} from "@/runtime/index.js";
+import type { Interval } from "@/utils/interval.js";
+
+/**
+ * Everything the sync engine needs from durable storage.
+ *
+ * This is the seam between the engine and the database. The engine is written
+ * against this type alone, so an application that wants Ponder's backfill,
+ * reorg handling, factory child-address discovery and rpc cache while owning
+ * its own tables implements this and supplies it. `createSyncStore` in
+ * `./index.ts` is the implementation Ponder itself runs, over Postgres and
+ * PGlite via Drizzle.
+ *
+ * It is declared apart from that implementation so that depending on the
+ * contract does not mean depending on Drizzle.
+ */
+export type SyncStore = {
+  insertIntervals(
+    args: {
+      intervals: IntervalWithFilter[];
+      factoryIntervals: IntervalWithFactory[];
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  getIntervals(
+    args: { filters: Filter[] },
+    context?: { logger?: Logger },
+  ): Promise<
+    Map<Filter | Factory, { fragment: Fragment; intervals: Interval[] }[]>
+  >;
+  insertChildAddresses(
+    args: {
+      factory: Factory;
+      childAddresses: Map<Address, number>;
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  getChildAddresses(
+    args: { factory: Factory },
+    context?: { logger?: Logger },
+  ): Promise<Map<Address, number>>;
+  getSafeCrashRecoveryBlock(
+    args: {
+      chainId: number;
+      timestamp: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<{ number: bigint; timestamp: bigint } | undefined>;
+  insertLogs(
+    args: { logs: SyncLog[]; chainId: number },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  insertBlocks(
+    args: {
+      blocks: (SyncBlock | SyncBlockHeader)[];
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  insertTransactions(
+    args: {
+      transactions: SyncTransaction[];
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  insertTransactionReceipts(
+    args: {
+      transactionReceipts: SyncTransactionReceipt[];
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  insertTraces(
+    args: {
+      traces: {
+        trace: SyncTrace;
+        block: SyncBlock;
+        transaction: SyncTransaction;
+      }[];
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  getEventData(
+    args: {
+      filters: Filter[];
+      fromBlock: number;
+      toBlock: number;
+      chainId: number;
+      limit: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<{
+    blocks: InternalBlock[];
+    logs: InternalLog[];
+    transactions: InternalTransaction[];
+    transactionReceipts: InternalTransactionReceipt[];
+    traces: InternalTrace[];
+    cursor: number;
+  }>;
+  insertRpcRequestResults(
+    args: {
+      requests: {
+        request: RequestParameters;
+        blockNumber: number | undefined;
+        result: string;
+      }[];
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  getRpcRequestResults(
+    args: {
+      requests: RequestParameters[];
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<(string | undefined)[]>;
+  pruneRpcRequestResults(
+    args: {
+      blocks: Pick<LightBlock, "number">[];
+      chainId: number;
+    },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+  pruneByChain(
+    args: { chainId: number },
+    context?: { logger?: Logger },
+  ): Promise<void>;
+};

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -1,0 +1,123 @@
+/**
+ * The sync engine, on its own.
+ *
+ * Ponder's backfill and realtime sync are written against the {@link SyncStore}
+ * type and nothing else, so an application that already has its own database
+ * can drive them directly: implement `SyncStore` over your own tables, hand it
+ * to {@link createHistoricalSync}, and handle {@link RealtimeSyncEvent} rather
+ * than writing indexing functions.
+ *
+ * What that gets you is the part that is tedious to get right: `eth_getLogs`
+ * range estimation and error recovery, interval bookkeeping so a restart does
+ * not refetch, factory child-address discovery, block-hash reorg detection with
+ * finality tracking, and the rpc request cache.
+ *
+ * Nothing reachable from this module imports Drizzle, `pg`, PGlite, Hono, or
+ * the CLI -- `internal/layering.test.ts` fails if that changes.
+ */
+
+// A `Common` is the engine's ambient services. Build one with these.
+export type { Common } from "@/internal/common.js";
+export {
+  createLogger,
+  createNoopLogger,
+  type Logger,
+} from "@/internal/logger.js";
+export { MetricsService } from "@/internal/metrics.js";
+export {
+  buildOptions,
+  type CliOptions,
+  type Options,
+} from "@/internal/options.js";
+export { createShutdown, type Shutdown } from "@/internal/shutdown.js";
+// The data model the engine is written in terms of.
+export type {
+  BlockFilter,
+  Chain,
+  EventCallback,
+  Factory,
+  Filter,
+  FilterAddress,
+  Fragment,
+  FragmentId,
+  LightBlock,
+  LogFactory,
+  LogFilter,
+  SyncBlock,
+  SyncBlockHeader,
+  SyncLog,
+  SyncTrace,
+  SyncTransaction,
+  SyncTransactionReceipt,
+  TraceFilter,
+  TransactionFilter,
+  TransferFilter,
+} from "@/internal/types.js";
+export {
+  createRpc,
+  type RequestParameters,
+  type RequestReturnType,
+  type Rpc,
+} from "@/rpc/index.js";
+// Deciding whether a filter matches, and how filters map onto cache fragments.
+export {
+  getFilterFactories,
+  getFilterFromBlock,
+  getFilterToBlock,
+  isAddressFactory,
+  isBlockFilterMatched,
+  isBlockInFilter,
+  isLogFactoryMatched,
+  isLogFilterMatched,
+  isTraceFilterMatched,
+  isTransactionFilterMatched,
+  isTransferFilterMatched,
+} from "@/runtime/filter.js";
+export {
+  decodeFragment,
+  encodeFragment,
+  getFactoryFragments,
+  getFragments,
+  recoverFilter,
+} from "@/runtime/fragments.js";
+// Progress and interval bookkeeping, for driving the engine over a range.
+export {
+  type CachedIntervals,
+  type ChildAddresses,
+  getCachedBlock,
+  getCachedIntervals,
+  getChildAddresses,
+  getLocalSyncProgress,
+  getRequiredIntervals,
+  type IntervalWithFactory,
+  type IntervalWithFilter,
+  type SyncProgress,
+} from "@/runtime/index.js";
+export {
+  createHistoricalSync,
+  type HistoricalSync,
+} from "@/sync-historical/index.js";
+export {
+  type BlockWithEventData,
+  createRealtimeSync,
+  type RealtimeSync,
+  type RealtimeSyncEvent,
+} from "@/sync-realtime/index.js";
+// The storage contract. `createSyncStore` in `@/sync-store/index.js` is
+// Ponder's own implementation of it, over Postgres and PGlite; it is
+// deliberately not exported here, because depending on it would mean
+// depending on Drizzle.
+export type { SyncStore } from "@/sync-store/store.js";
+
+export {
+  getChunks,
+  type Interval,
+  intervalBounds,
+  intervalDifference,
+  intervalIntersection,
+  intervalIntersectionMany,
+  intervalRange,
+  intervalSum,
+  intervalUnion,
+  sortIntervals,
+} from "@/utils/interval.js";

--- a/packages/core/src/utils/pg.ts
+++ b/packages/core/src/utils/pg.ts
@@ -8,8 +8,7 @@ import type { Logger } from "@/internal/logger.js";
 const bigIntArrayParser = pg.types.getTypeParser(1016);
 pg.types.setTypeParser(1231, bigIntArrayParser);
 
-export const PG_BIGINT_MAX = 9223372036854775807n;
-export const PG_INTEGER_MAX = 2147483647;
+export { PG_BIGINT_MAX, PG_INTEGER_MAX } from "./pgLimits.js";
 
 export function getDatabaseName(conf: PoolConfig) {
   const config = parseBaseConfig(conf);

--- a/packages/core/src/utils/pgLimits.ts
+++ b/packages/core/src/utils/pgLimits.ts
@@ -1,0 +1,10 @@
+/**
+ * Postgres column limits.
+ *
+ * Kept apart from `./pg.ts` because these are the only things the rpc layer
+ * needs from it, and `./pg.ts` imports the `pg` driver: depending on two
+ * numbers should not mean depending on a database client.
+ */
+
+export const PG_BIGINT_MAX = 9223372036854775807n;
+export const PG_INTEGER_MAX = 2147483647;


### PR DESCRIPTION
Opened as a draft — this touches layering across `packages/core`, and the second commit adds public API, so it's a proposal rather than a finished call. Happy to cut it down, split it, or drop the second commit entirely.

## The problem

`sync-historical` and `sync-realtime` are already written against the `SyncStore` type and never touch Drizzle themselves. But following imports from those two modules and `rpc/index.ts` reaches **114 files and 41,975 lines** — the CLI, the server, GraphQL, the indexing store, the Drizzle schema builder. The engine is decoupled in spirit and coupled in the import graph.

Four edges caused all of it, and each pointed the wrong way:

| edge | why it matters |
|---|---|
| `internal/options.ts` → `bin/ponder.ts` for `type CliOptions` | every holder of an `Options` reached the CLI — and `bin/ponder.ts` runs a command as a side effect of being imported |
| `sync-historical` / `runtime` → `sync-store/index.ts` for `type SyncStore` | depending on the contract meant depending on its Drizzle implementation |
| `internal/types.ts` → `drizzle/kit` for `SqlStatements` | the blockchain data model and the build artefacts shared a module, so the model named `SqlStatements`, `PGlite`, `PoolConfig` and `Hono` |
| `internal/metrics.ts` → `drizzle-orm` for `isTable` | filtering a user schema to label a metric put Drizzle in the graph of everything holding a `Common` |

## Commit 1 — stop the sync engine importing the database, server, and CLI layers

Each edge is turned around rather than removed:

- `CliOptions` moves to `internal/options.ts`, beside the `buildOptions` that reads it. `bin/ponder.ts` keeps its commander definitions; each `.action` handler already passes its parsed options into a command declaring `CliOptions`, so a flag that stops matching is still a compile error, now at the call site.
- The `SyncStore` type moves to `sync-store/store.ts`. `sync-store/index.ts` re-exports it, so nothing else changes.
- `DatabaseConfig`, `PreBuild`, `SchemaBuild` and `ApiBuild` move to `internal/build.ts`.
- `initializeIndexingMetrics` takes table names instead of a schema; resolving a Drizzle table to its name becomes `getSchemaTableNames` in the schema layer. `rpc/actions.ts` reached the `pg` driver for two integer constants, which move to `utils/pgLimits.ts`.

The closure is now **36 files and 10,707 lines**, with no file from those layers and no import of `drizzle-orm`, `pg`, `@electric-sql/pglite` or `hono`.

`internal/layering.test.ts` walks the import graph and fails if that changes. Reverting any one of the four edges fails it, naming the offending file and the package it drags in — I checked each.

This commit stands on its own. Even setting packaging aside, a leaf config module importing a script that calls `process.argv` parsing at import time is worth turning around.

## Commit 2 — a `ponder/sync` entrypoint

Being decoupled is not the same as being reachable: `ponder` exports only `.` and `./virtual`. `src/sync.ts` exports the engine factories, `createRpc`, the `SyncStore` type, the interval/progress helpers, the filter and fragment predicates, the blockchain types, and the four services a `Common` is made of.

`createSyncStore` is deliberately **not** exported — that would put Drizzle back in the entrypoint's graph, and the point of the contract is that an application brings its own.

The parameters turn out to be constructible from outside, which is what makes this worth doing at all: `createHistoricalSync` takes `{ common, chain, rpc, childAddresses }`, `createRealtimeSync` adds `eventCallbacks` and a finalized block, and neither needs a build artefact. `syncStore` is an argument to `syncBlockRangeData` rather than a constructor dependency. Realtime reports `block` / `finalize` / `reorg` for the caller to handle.

So an application with its own database can implement `SyncStore` over its own tables and get the parts that are tedious to get right — `eth_getLogs` range estimation and error recovery, interval bookkeeping so a restart doesn't refetch, factory child-address discovery, block-hash reorg detection with finality tracking, and the rpc cache — without adopting the indexing model or the schema.

That is our interest here, for the record: we maintain a multi-chain indexer with its own Postgres schema and would rather use this engine than keep our own.

## Verification

- `pnpm --filter ponder build`, `pnpm --filter ponder typecheck`, `pnpm lint` — all clean.
- **The built output, not just the type graph**: walking `dist/esm/sync.js` reaches 31 emitted modules and, outside Node builtins, only `@ponder/utils`, `picocolors`, `pino`, `prom-client`, `semver`, `viem`, `ws`.
- `internal`, `runtime`, `utils`, `rpc` — 271 tests pass.
- `sync-historical`, `sync-realtime`, `sync-store` — 76 pass, 1 fails: `handleReorg() throws error for deep reorg` times out at 15s. **It fails identically on `4a2c771` without these changes**, which I verified by checking out the upstream sources in the same tree; I have not looked into it further.

No behaviour changes are intended anywhere. The only runtime change is `initializeIndexingMetrics`, which is internal and whose three callers are updated.

## What this is not

It is not the separate package that would let the engine be installed without the framework. I started there and backed off: the closure contains `internal/common|logger|metrics|options|errors` and 17 `utils/` files, which are framework-wide — `internal/types.ts` alone has 53 importers outside the closure. A `@ponder/sync` owning the logger and metrics for the whole framework would be the wrong package. Doing it properly is a three-way split (`@ponder/common` → `@ponder/sync` → `ponder`), moving 36 files and repointing 63 source and 39 test files, and the naming, versioning and release surface are yours to decide, not mine to presume. This PR is the prerequisite either way, and I'd be glad to do that follow-up if you want it.

Related: #4, from 2022, proposed separating packages so they could be plugged into the core.

The changeset is a minor. Per `AGENTS.md` this is the pre-1.0 case where changesets produces `1.0.0` by mistake — it should be `0.18.0` in the release PR.

https://claude.ai/code/session_018fCeEYi1BdAhcaKZmDwAKb
